### PR TITLE
feat: 30분 비활성 기준으로 세션 종료를 자동으로 감지할 수 있다 (Story 2-1)

### DIFF
--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -122,12 +122,14 @@
   - Dependencies: 마지막 시청 시각 갱신 로직 완료
   - 예상 소요: 2~3h
 
-- [ ] 세션 시작/종료 시간 및 세션 ID 기록 로직 구현
+- [x] 세션 시작/종료 시간 및 세션 ID 기록 로직 구현
   - Priority: Medium / Owner: FE
   - 내용: 첫 영상 감지 시 `sessionId`(UUID 또는 타임스탬프), `startTime` 기록. 종료 시 `endTime` 기록
   - DoD: 종료된 세션 객체에 `sessionId`, `startTime`, `endTime`이 모두 포함된다.
   - Dependencies: 30분 타임아웃 감지 완료
   - 예상 소요: 1~2h
+  - 설계 결정: `endSession()`에서 `currentSession`과 `sessions`를 단일 `get` 호출로 읽은 뒤, 단일 `set` 호출로 원자적으로 기록. 이유: 두 번의 별도 read/write 사이에 alarm이 재진입하면 세션이 두 번 닫힐 수 있는 레이스 컨디션을 방지.
+  - 설계 결정: `currentSession`이 null이거나 `videos`가 빈 배열이면 세션 종료를 스킵. 이유: 영상을 하나도 보지 않은 빈 세션은 분석 대상이 아님.
 
 ---
 

--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -106,12 +106,14 @@
 
 #### Tasks
 
-- [ ] 마지막 시청 시각 갱신 로직 구현
+- [x] 마지막 시청 시각 갱신 로직 구현
   - Priority: High / Owner: FE
   - 내용: 영상 감지 시마다 `lastWatchedAt` 타임스탬프를 storage에 갱신
   - DoD: 영상 감지 시 `lastWatchedAt`이 정확히 업데이트된다.
   - Dependencies: Story 1-2 완료
   - 예상 소요: 1h
+  - 설계 결정: `lastWatchedAt`은 `currentSession` 내부가 아닌 `chrome.storage.local`의 독립 키로 저장. 이유: 세션이 null인 상태에서도 마지막 시청 시각 추적이 가능해야 하며, alarm 체크 시 `currentSession` 전체를 로드할 필요 없이 단일 키만 읽으면 됨.
+  - 설계 결정: 중복 videoId early return 전에 `lastWatchedAt` 갱신. 이유: 같은 영상을 계속 시청 중인 경우도 활성 시청이므로, 중복 여부와 무관하게 갱신하지 않으면 30분 타임아웃이 잘못 트리거될 수 있음.
 
 - [ ] 30분 타임아웃 감지 및 세션 종료 트리거 구현
   - Priority: High / Owner: FE

--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -115,12 +115,14 @@
   - 설계 결정: `lastWatchedAt`은 `currentSession` 내부가 아닌 `chrome.storage.local`의 독립 키로 저장. 이유: 세션이 null인 상태에서도 마지막 시청 시각 추적이 가능해야 하며, alarm 체크 시 `currentSession` 전체를 로드할 필요 없이 단일 키만 읽으면 됨.
   - 설계 결정: 중복 videoId early return 전에 `lastWatchedAt` 갱신. 이유: 같은 영상을 계속 시청 중인 경우도 활성 시청이므로, 중복 여부와 무관하게 갱신하지 않으면 30분 타임아웃이 잘못 트리거될 수 있음.
 
-- [ ] 30분 타임아웃 감지 및 세션 종료 트리거 구현
+- [x] 30분 타임아웃 감지 및 세션 종료 트리거 구현
   - Priority: High / Owner: FE
-  - 내용: background service worker에서 `setInterval` 또는 `chrome.alarms`로 주기적으로 `lastWatchedAt` 확인. 30분 초과 시 세션 종료 이벤트 발생
+  - 내용: background service worker에서 `chrome.alarms`로 1분마다 `lastWatchedAt` 확인. 30분 초과 시 세션 종료 이벤트 발생
   - DoD: 마지막 시청 후 30분 후 세션 종료가 자동으로 감지된다.
   - Dependencies: 마지막 시청 시각 갱신 로직 완료
   - 예상 소요: 2~3h
+  - 설계 결정: `setInterval` 대신 `chrome.alarms` 사용. 이유: service worker는 이벤트가 없으면 수십 초 내로 종료되므로 `setInterval`은 타이머 유지를 보장하지 않음. `chrome.alarms`는 OS 수준에서 스케줄링되어 service worker를 직접 깨움.
+  - 설계 결정: `chrome.alarms.create`를 service worker 최상위(top-level)에서 호출. 이유: service worker는 이벤트가 발생할 때마다 새로 깨어나므로, `onInstalled`·`onStartup`만 사용하면 중간에 alarm이 소실될 수 있음. 같은 이름의 alarm은 자동 교체되므로 중복 등록 문제 없음.
 
 - [x] 세션 시작/종료 시간 및 세션 ID 기록 로직 구현
   - Priority: Medium / Owner: FE

--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -130,7 +130,7 @@
   - DoD: 종료된 세션 객체에 `sessionId`, `startTime`, `endTime`이 모두 포함된다.
   - Dependencies: 30분 타임아웃 감지 완료
   - 예상 소요: 1~2h
-  - 설계 결정: `endSession()`에서 `currentSession`과 `sessions`를 단일 `get` 호출로 읽은 뒤, 단일 `set` 호출로 원자적으로 기록. 이유: 두 번의 별도 read/write 사이에 alarm이 재진입하면 세션이 두 번 닫힐 수 있는 레이스 컨디션을 방지.
+  - 설계 결정: `endSession()`을 `addVideo()`와 동일한 `queue`에 편입. 이유: `chrome.storage`의 get/set은 비동기이므로 단일 get+set 쌍이라도 await 지점에서 다른 함수가 끼어들 수 있음. queue로 직렬화해야만 `addVideo`와 `endSession`이 동시에 실행되는 레이스 컨디션을 방지할 수 있음. `currentSession`과 `sessions`는 단일 `get` 호출로 읽어 코드를 단순하게 유지.
   - 설계 결정: `currentSession`이 null이거나 `videos`가 빈 배열이면 세션 종료를 스킵. 이유: 영상을 하나도 보지 않은 빈 세션은 분석 대상이 아님.
 
 ---

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,4 +1,10 @@
-import { addVideo } from './storage.js';
+import { addVideo, endSession, getLastWatchedAt } from './storage.js';
+
+const ALARM_NAME = 'SESSION_TIMEOUT_CHECK';
+const TIMEOUT_MS = 30 * 60 * 1000;
+
+// service worker가 깨어날 때마다 실행 — 같은 이름의 alarm은 자동으로 교체됨
+chrome.alarms.create(ALARM_NAME, { periodInMinutes: 1 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'VIDEO_DETECTED') {
@@ -9,9 +15,25 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name !== ALARM_NAME) return;
+  checkSessionTimeout();
+});
+
 async function handleVideoDetected(message) {
   const { videoId, title } = message;
   await addVideo(videoId, title);
   console.log('[background] saved:', { videoId, title });
   return { ok: true };
+}
+
+async function checkSessionTimeout() {
+  const lastWatchedAt = await getLastWatchedAt();
+  if (!lastWatchedAt) return;
+
+  const elapsed = Date.now() - new Date(lastWatchedAt).getTime();
+  if (elapsed < TIMEOUT_MS) return;
+
+  console.log('[background] 30분 비활성 감지, 세션 종료');
+  await endSession();
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "YouTube Bias Feedback",
   "version": "0.1.0",
-  "permissions": ["storage", "activeTab"],
+  "permissions": ["storage", "activeTab", "alarms"],
   "host_permissions": ["*://*.youtube.com/*"],
   "background": {
     "service_worker": "background.js",

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -6,22 +6,22 @@ export function addVideo(videoId, title) {
 }
 
 async function _addVideo(videoId, title) {
+  const now = new Date().toISOString();
   const { currentSession } = await chrome.storage.local.get('currentSession');
 
   const session = currentSession ?? {
     sessionId: String(Date.now()),
-    startTime: new Date().toISOString(),
+    startTime: now,
     videos: [],
   };
+
+  // 중복 여부와 무관하게 먼저 갱신: 같은 영상을 계속 시청 중인 경우도 활성 시청이므로
+  await chrome.storage.local.set({ lastWatchedAt: now });
 
   const lastSaved = session.videos.at(-1);
   if (lastSaved?.videoId === videoId) return;
 
-  session.videos.push({
-    videoId,
-    title,
-    watchedAt: new Date().toISOString(),
-  });
+  session.videos.push({ videoId, title, watchedAt: now });
 
   await chrome.storage.local.set({ currentSession: session });
 }
@@ -38,4 +38,9 @@ export async function getAllSessions() {
 
 export async function clearCurrentSession() {
   await chrome.storage.local.set({ currentSession: null });
+}
+
+export async function getLastWatchedAt() {
+  const { lastWatchedAt } = await chrome.storage.local.get('lastWatchedAt');
+  return lastWatchedAt ?? null;
 }

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -40,7 +40,12 @@ export async function clearCurrentSession() {
   await chrome.storage.local.set({ currentSession: null });
 }
 
-export async function endSession() {
+export function endSession() {
+  queue = queue.then(() => _endSession());
+  return queue;
+}
+
+async function _endSession() {
   const { currentSession, sessions } = await chrome.storage.local.get([
     'currentSession',
     'sessions',

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -40,6 +40,27 @@ export async function clearCurrentSession() {
   await chrome.storage.local.set({ currentSession: null });
 }
 
+export async function endSession() {
+  const { currentSession, sessions } = await chrome.storage.local.get([
+    'currentSession',
+    'sessions',
+  ]);
+
+  if (!currentSession || currentSession.videos.length === 0) return;
+
+  const closedSession = {
+    ...currentSession,
+    endTime: new Date().toISOString(),
+  };
+
+  const updatedSessions = [...(sessions ?? []), closedSession];
+
+  await chrome.storage.local.set({
+    sessions: updatedSessions,
+    currentSession: null,
+  });
+}
+
 export async function getLastWatchedAt() {
   const { lastWatchedAt } = await chrome.storage.local.get('lastWatchedAt');
   return lastWatchedAt ?? null;


### PR DESCRIPTION
## 개요
마지막 영상 시청 후 30분이 경과하면 현재 세션을 자동으로 종료 처리하는 기능을 구현합니다.
`chrome.alarms` API를 사용해 background service worker가 비활성 상태로 종료된 경우에도 타임아웃 감지를 보장합니다.

## 변경 사항
- **`extension/manifest.json`**: `"alarms"` 권한 추가
- **`extension/storage.js`**
  - `_addVideo()`: 중복 여부와 무관하게 영상 감지 시 `lastWatchedAt` 타임스탬프를 `chrome.storage.local` 독립 키로 갱신
  - `getLastWatchedAt()`: alarm 체크에서 사용하는 헬퍼 함수 추가
  - `endSession()`: `currentSession`에 `endTime` 기록 후 `sessions` 배열로 이동, `currentSession`을 null로 초기화
- **`extension/background.js`**
  - service worker 시작 시 1분 주기 `SESSION_TIMEOUT_CHECK` alarm 등록
  - `chrome.alarms.onAlarm` 리스너에서 `lastWatchedAt` 기준 30분 경과 여부 판단 후 `endSession()` 호출

## 관련 이슈

- closes #59

## 테스트 확인
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/21cd0fe0-d97a-466b-955e-c51ba863ac0f" />

- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 영상 감지 후 Service Worker DevTools 콘솔에서
      chrome.storage.local.get('lastWatchedAt', console.log) 로
      타임스탬프가 갱신됐는지 확인
- [x] 같은 영상 반복 재생(새로고침) 시에도 lastWatchedAt이 갱신되는지 확인
- [x] 30분 경과 시뮬레이션:
      Service Worker 콘솔에서
      chrome.storage.local.set({ lastWatchedAt: new Date(Date.now() - 31 * 60 * 1000).toISOString() })
      실행 후 1분 내 "[background] 30분 비활성 감지, 세션 종료" 로그 확인
- [x] 종료 후 chrome.storage.local.get('sessions', console.log) 로
      sessionId, startTime, endTime이 모두 포함된 세션 객체 확인

## 참고 사항

**`setInterval` 대신 `chrome.alarms`를 선택한 이유**
service worker는 이벤트가 없으면 수십 초 내로 종료되므로 `setInterval`의 타이머 유지를 보장할 수 없습니다. `chrome.alarms`는 OS 수준에서 스케줄링되어 service worker를 직접 깨우므로 30분 타임아웃 감지를 안정적으로 보장합니다.

**`chrome.alarms.create`를 top-level에서 호출하는 이유**
service worker는 이벤트마다 새로 시작될 수 있습니다. top-level 호출로 매 시작 시 alarm을 재등록하며, 같은 이름의 alarm은 Chrome이 자동으로 교체하므로 중복 등록 문제가 없습니다.

**`endSession()`의 단일 read/write 설계**
`currentSession`과 `sessions`를 한 번의 `get`으로 읽고 한 번의 `set`으로 씁니다. 두 번으로 나누면 alarm 재진입 시 같은 세션이 두 번 닫히는 레이스 컨디션이 발생할 수 있습니다.

**`lastWatchedAt`은 세션 종료 후에도 초기화되지 않음.**
`endSession() 실행 후`에도 lastWatchedAt 값이 storage에 그대로 남습니다. 이후 alarm이 다시 발화되면 checkSessionTimeout()이 또 호출되지만, `endSession() 내부`의 !currentSession 가드로 인해 빈 동작으로 종료되므로 중복 저장이나 데이터 오염은 발생하지 않습니다.
다음 영상을 시청하는 순간 l`astWatchedAt`이 현재 시각으로 갱신되므로 실사용에서는 문제가 없습니다. 향후 endSession() 안에서 lastWatchedAt: null을 함께 초기화하는 방식으로 개선 가능합니다.
