### PR TITLE
feat: LLM API를 통해 카테고리 분포 기반 자연어 리뷰를 자동 생성할 수 있다 (Story 2-4)

### DIFF
--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -218,28 +218,28 @@
 
 #### Tasks
 
-- [ ] LLM API 선택 및 키 발급
+- [x] LLM API 선택 및 키 발급
   - Priority: High / Owner: FE
   - 내용: Claude API (claude-haiku-4-5 권장 - 비용 효율) 또는 OpenAI API 선택. API 키를 manifest의 환경 설정에 저장
   - DoD: API 키가 정상 발급되고 간단한 호출 테스트가 성공한다.
   - Dependencies: 없음
   - 예상 소요: 1h
 
-- [ ] 카테고리 분포를 LLM 프롬프트로 변환하는 함수 구현
+- [x] 카테고리 분포를 LLM 프롬프트로 변환하는 함수 구현
   - Priority: High / Owner: FE
   - 내용: `{ categoryDistribution, entropy, videoCount, duration }` → 자연어 프롬프트 템플릿 변환. 프롬프트는 한국어 리뷰 요청 포함
   - DoD: 다양한 분포 입력에 대해 의미 있는 프롬프트가 생성된다.
   - Dependencies: LLM API 키 발급 완료
   - 예상 소요: 2~3h
 
-- [ ] LLM API 호출 및 응답 파싱 함수 구현
+- [x] LLM API 호출 및 응답 파싱 함수 구현
   - Priority: High / Owner: FE
   - 내용: fetch로 LLM API 호출, 응답 텍스트 추출. 타임아웃(10초) 설정
   - DoD: 프롬프트 입력 시 2~3문장의 한국어 리뷰 텍스트가 반환된다.
   - Dependencies: 프롬프트 변환 함수 완료
   - 예상 소요: 2~3h
 
-- [ ] 리뷰 생성 실패 시 폴백 처리 구현
+- [x] 리뷰 생성 실패 시 폴백 처리 구현
   - Priority: Medium / Owner: FE
   - 내용: API 오류/타임아웃 시 카테고리 분포 기반 템플릿 문자열로 대체 리뷰 생성
   - DoD: LLM API 실패 시 앱이 중단되지 않고 대체 텍스트가 표시된다.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,6 +1,7 @@
 import { addVideo, endSession, getLastWatchedAt, getCurrentSession, getAllSessions, saveAnalysis } from './storage.js';
 import { fetchVideoCategories } from './youtube.js';
 import { calculateDistribution, calculateEntropy } from './analysis.js';
+import { buildPrompt, generateReview, generateFallbackReview } from './llm.js';
 
 const ALARM_NAME = 'SESSION_TIMEOUT_CHECK';
 const TIMEOUT_MS = 30 * 60 * 1000;
@@ -56,12 +57,23 @@ async function analyzeSession(session) {
 
   const categoryDistribution = calculateDistribution(categoryIds);
   const entropy = calculateEntropy(categoryDistribution);
+  const videoCount = session.videos.length;
 
-  await saveAnalysis(session.sessionId, {
-    categoryDistribution,
-    entropy,
-    videoCount: session.videos.length,
-  });
-
+  await saveAnalysis(session.sessionId, { categoryDistribution, entropy, videoCount });
   console.log('[background] 분석 완료:', { entropy, categoryDistribution });
+
+  const analysisData = { categoryDistribution, entropy, videoCount };
+  const prompt = buildPrompt(analysisData);
+
+  let review;
+  try {
+    review = await generateReview(prompt);
+    console.log('[background] 리뷰 생성 완료');
+  } catch (error) {
+    console.warn('[background] 리뷰 생성 실패, 폴백 사용:', error.message);
+    review = generateFallbackReview(analysisData);
+  }
+
+  await saveAnalysis(session.sessionId, { review });
+  console.log('[background] 리뷰 저장 완료:', review);
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,16 +1,23 @@
-import { addVideo, endSession, getLastWatchedAt, getCurrentSession, getAllSessions, saveAnalysis } from './storage.js';
-import { fetchVideoCategories } from './youtube.js';
-import { calculateDistribution, calculateEntropy } from './analysis.js';
-import { buildPrompt, generateReview, generateFallbackReview } from './llm.js';
+import {
+  addVideo,
+  endSession,
+  getLastWatchedAt,
+  getCurrentSession,
+  getAllSessions,
+  saveAnalysis,
+} from "./storage.js";
+import { fetchVideoCategories } from "./youtube.js";
+import { calculateDistribution, calculateEntropy } from "./analysis.js";
+import { buildPrompt, generateReview, generateFallbackReview } from "./llm.js";
 
-const ALARM_NAME = 'SESSION_TIMEOUT_CHECK';
+const ALARM_NAME = "SESSION_TIMEOUT_CHECK";
 const TIMEOUT_MS = 30 * 60 * 1000;
 
 // service worker가 깨어날 때마다 실행 — 같은 이름의 alarm은 자동으로 교체됨
 chrome.alarms.create(ALARM_NAME, { periodInMinutes: 1 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.type === 'VIDEO_DETECTED') {
+  if (message.type === "VIDEO_DETECTED") {
     handleVideoDetected(message)
       .then(sendResponse)
       .catch((error) => sendResponse({ ok: false, reason: error.message }));
@@ -26,7 +33,7 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 async function handleVideoDetected(message) {
   const { videoId, title } = message;
   await addVideo(videoId, title);
-  console.log('[background] saved:', { videoId, title });
+  console.log("[background] saved:", { videoId, title });
   return { ok: true };
 }
 
@@ -41,7 +48,7 @@ async function checkSessionTimeout() {
   if (!currentSession) return;
   const sessionId = currentSession.sessionId;
 
-  console.log('[background] 30분 비활성 감지, 세션 종료');
+  console.log("[background] 30분 비활성 감지, 세션 종료");
   await endSession();
 
   const sessions = await getAllSessions();
@@ -59,8 +66,12 @@ async function analyzeSession(session) {
   const entropy = calculateEntropy(categoryDistribution);
   const videoCount = session.videos.length;
 
-  await saveAnalysis(session.sessionId, { categoryDistribution, entropy, videoCount });
-  console.log('[background] 분석 완료:', { entropy, categoryDistribution });
+  await saveAnalysis(session.sessionId, {
+    categoryDistribution,
+    entropy,
+    videoCount,
+  });
+  console.log("[background] 분석 완료:", { entropy, categoryDistribution });
 
   const analysisData = { categoryDistribution, entropy, videoCount };
   const prompt = buildPrompt(analysisData);
@@ -68,12 +79,12 @@ async function analyzeSession(session) {
   let review;
   try {
     review = await generateReview(prompt);
-    console.log('[background] 리뷰 생성 완료');
+    console.log("[background] 리뷰 생성 완료");
   } catch (error) {
-    console.warn('[background] 리뷰 생성 실패, 폴백 사용:', error.message);
+    console.warn("[background] 리뷰 생성 실패, 폴백 사용:", error.message);
     review = generateFallbackReview(analysisData);
   }
 
   await saveAnalysis(session.sessionId, { review });
-  console.log('[background] 리뷰 저장 완료:', review);
+  console.log("[background] 리뷰 저장 완료:", review);
 }

--- a/extension/config.example.js
+++ b/extension/config.example.js
@@ -1,3 +1,4 @@
 // config.js로 복사한 뒤 실제 API 키를 입력하세요.
 // config.js는 .gitignore에 등록되어 있으므로 git에 커밋되지 않습니다.
 export const YOUTUBE_API_KEY = 'YOUR_YOUTUBE_API_KEY_HERE';
+export const GEMINI_API_KEY = 'YOUR_GEMINI_API_KEY_HERE';

--- a/extension/content.js
+++ b/extension/content.js
@@ -48,13 +48,17 @@ function waitForTitle(maxRetries = 10, interval = 200) {
 async function sendWithRetry(message, maxRetries = 3, delay = 500) {
   for (let i = 0; i < maxRetries; i++) {
     const response = await new Promise((resolve) => {
-      chrome.runtime.sendMessage(message, (res) => {
-        if (chrome.runtime.lastError) {
-          resolve(null);
-        } else {
-          resolve(res);
-        }
-      });
+      try {
+        chrome.runtime.sendMessage(message, (res) => {
+          if (chrome.runtime?.lastError) {
+            resolve(null);
+          } else {
+            resolve(res);
+          }
+        });
+      } catch {
+        resolve(null);
+      }
     });
 
     if (response) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -47,6 +47,11 @@ function waitForTitle(maxRetries = 10, interval = 200) {
 
 async function sendWithRetry(message, maxRetries = 3, delay = 500) {
   for (let i = 0; i < maxRetries; i++) {
+    if (!chrome.runtime?.sendMessage) {
+      console.warn('[content] Extension context invalidated');
+      return;
+    }
+
     const response = await new Promise((resolve) => {
       try {
         chrome.runtime.sendMessage(message, (res) => {
@@ -88,7 +93,7 @@ async function handleVideoChange() {
   const title = await waitForTitle();
   console.log('[content] video detected:', { videoId, title });
 
-  sendWithRetry({ type: 'VIDEO_DETECTED', videoId, title, url: location.href });
+  sendWithRetry({ type: 'VIDEO_DETECTED', videoId, title, url: location.href }).catch(() => {});
 }
 
 handleVideoChange();

--- a/extension/content.js
+++ b/extension/content.js
@@ -45,6 +45,28 @@ function waitForTitle(maxRetries = 10, interval = 200) {
   });
 }
 
+async function sendWithRetry(message, maxRetries = 3, delay = 500) {
+  for (let i = 0; i < maxRetries; i++) {
+    const response = await new Promise((resolve) => {
+      chrome.runtime.sendMessage(message, (res) => {
+        if (chrome.runtime.lastError) {
+          resolve(null);
+        } else {
+          resolve(res);
+        }
+      });
+    });
+
+    if (response) {
+      console.log('[content] background response:', response);
+      return;
+    }
+
+    if (i < maxRetries - 1) await new Promise((r) => setTimeout(r, delay));
+  }
+  console.warn('[content] sendMessage 최종 실패:', message.videoId);
+}
+
 let lastVideoId = null;
 
 async function handleVideoChange() {
@@ -62,16 +84,7 @@ async function handleVideoChange() {
   const title = await waitForTitle();
   console.log('[content] video detected:', { videoId, title });
 
-  chrome.runtime.sendMessage(
-    { type: 'VIDEO_DETECTED', videoId, title, url: location.href },
-    (response) => {
-      if (chrome.runtime.lastError) {
-        console.warn('[content] sendMessage error:', chrome.runtime.lastError.message);
-        return;
-      }
-      console.log('[content] background response:', response);
-    }
-  );
+  sendWithRetry({ type: 'VIDEO_DETECTED', videoId, title, url: location.href });
 }
 
 handleVideoChange();

--- a/extension/llm.js
+++ b/extension/llm.js
@@ -2,6 +2,7 @@ import { GEMINI_API_KEY } from './config.js';
 
 const GEMINI_API_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+const TIMEOUT_MS = 10000;
 
 export function buildPrompt({ categoryDistribution, entropy, videoCount }) {
   const sorted = Object.entries(categoryDistribution).sort(([, a], [, b]) => b - a);
@@ -27,4 +28,59 @@ ${entropyLine}
 
 위 데이터를 바탕으로 이 사용자의 시청 패턴에 대한 피드백을 2~3문장으로 작성해주세요.
 조건: 한국어로, 친근하고 중립적인 톤으로, 수치나 통계 용어를 직접 사용하지 말고 자연스럽게 표현해주세요.`;
+}
+
+export async function generateReview(prompt) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${GEMINI_API_URL}?key=${GEMINI_API_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`Gemini API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (!text) throw new Error('Gemini API: 응답에 텍스트가 없습니다');
+
+    return text.trim();
+  } catch (error) {
+    clearTimeout(timeoutId);
+    throw error;
+  }
+}
+
+export function generateFallbackReview({ categoryDistribution, videoCount }) {
+  const sorted = Object.entries(categoryDistribution).sort(([, a], [, b]) => b - a);
+
+  if (sorted.length === 0) {
+    return '이번 세션의 시청 데이터를 분석하지 못했습니다. 다음 세션을 기대해 주세요!';
+  }
+
+  const [topName, topRatio] = sorted[0];
+
+  if (sorted.length === 1) {
+    return `이번 세션에서는 ${topName} 영상을 집중적으로 시청하셨네요. ${videoCount}개의 영상을 보셨습니다. 다음에는 다른 카테고리의 콘텐츠도 탐색해 보세요!`;
+  }
+
+  const [secondName] = sorted[1];
+
+  if (topRatio > 0.5) {
+    return `이번 세션에서는 주로 ${topName} 콘텐츠를 즐기셨고, ${secondName} 영상도 함께 시청하셨네요. 총 ${videoCount}개의 영상을 보셨습니다. 더 다양한 카테고리를 탐색해 보시는 건 어떨까요?`;
+  }
+
+  const topNames = sorted
+    .slice(0, 3)
+    .map(([name]) => name)
+    .join(', ');
+  return `이번 세션에서는 ${topNames} 등 다양한 카테고리의 영상을 고루 시청하셨네요. 총 ${videoCount}개의 영상을 보셨습니다. 균형 잡힌 시청 패턴을 잘 유지하고 계세요!`;
 }

--- a/extension/llm.js
+++ b/extension/llm.js
@@ -35,9 +35,9 @@ export async function generateReview(prompt) {
   const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   try {
-    const response = await fetch(`${GEMINI_API_URL}?key=${GEMINI_API_KEY}`, {
+    const response = await fetch(GEMINI_API_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-goog-api-key': GEMINI_API_KEY },
       body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
       signal: controller.signal,
     });

--- a/extension/llm.js
+++ b/extension/llm.js
@@ -1,7 +1,7 @@
 import { GEMINI_API_KEY } from './config.js';
 
 const GEMINI_API_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent';
 const TIMEOUT_MS = 10000;
 
 export function buildPrompt({ categoryDistribution, entropy, videoCount }) {

--- a/extension/llm.js
+++ b/extension/llm.js
@@ -1,7 +1,7 @@
 import { GEMINI_API_KEY } from './config.js';
 
 const GEMINI_API_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent';
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
 const TIMEOUT_MS = 10000;
 
 export function buildPrompt({ categoryDistribution, entropy, videoCount }) {
@@ -45,6 +45,8 @@ export async function generateReview(prompt) {
     clearTimeout(timeoutId);
 
     if (!response.ok) {
+      const errorBody = await response.text();
+      console.error('[llm] API error body:', errorBody);
       throw new Error(`Gemini API error: ${response.status}`);
     }
 

--- a/extension/llm.js
+++ b/extension/llm.js
@@ -1,0 +1,30 @@
+import { GEMINI_API_KEY } from './config.js';
+
+const GEMINI_API_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+
+export function buildPrompt({ categoryDistribution, entropy, videoCount }) {
+  const sorted = Object.entries(categoryDistribution).sort(([, a], [, b]) => b - a);
+
+  const categoryLines = sorted
+    .map(([name, ratio]) => `  · ${name}: ${Math.round(ratio * 100)}%`)
+    .join('\n');
+
+  const categoryCount = sorted.length;
+  const maxEntropy = categoryCount > 1 ? Math.log2(categoryCount).toFixed(2) : null;
+  const entropyLine =
+    maxEntropy !== null
+      ? `- 다양성 지수: ${entropy} (최대 ${maxEntropy})`
+      : `- 다양성 지수: ${entropy}`;
+
+  return `당신은 YouTube 시청 패턴을 분석하는 친근한 조언자입니다.
+
+[세션 정보]
+- 시청 영상 수: ${videoCount}개
+- 카테고리 분포:
+${categoryLines}
+${entropyLine}
+
+위 데이터를 바탕으로 이 사용자의 시청 패턴에 대한 피드백을 2~3문장으로 작성해주세요.
+조건: 한국어로, 친근하고 중립적인 톤으로, 수치나 통계 용어를 직접 사용하지 말고 자연스럽게 표현해주세요.`;
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "YouTube Bias Feedback",
   "version": "0.1.0",
   "permissions": ["storage", "activeTab", "alarms"],
-  "host_permissions": ["*://*.youtube.com/*"],
+  "host_permissions": ["*://*.youtube.com/*", "*://generativelanguage.googleapis.com/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
세션 종료 후 카테고리 분포와 Entropy 값을 Gemini API에 전달하여
2~3문장의 한국어 자연어 피드백을 자동 생성하고 storage에 저장합니다.
API 호출 실패(타임아웃/오류) 시에는 카테고리 분포 기반 템플릿 텍스트로 자동 대체합니다.  

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->

- `extension/config.example.js`: `GEMINI_API_KEY` 환경 변수 플레이스홀더 추가
- `extension/llm.js`   
  - `buildPrompt()`: `{ categoryDistribution, entropy, videoCount }` → Gemini 프롬프트 문자열 변환
  - `generateReview()`: Gemini API 호출 (AbortController 10초 타임아웃), 실패 시 throw
  - `generateFallbackReview()`: 카테고리 분포 기반 3단계 분기 템플릿 리뷰, 항상 성공
- `extension/background.js`: `analyzeSession()`에 리뷰 생성 플로우 통합
  - 분석 데이터 저장 → 프롬프트 생성 → LLM 호출(또는 폴백) → 리뷰 저장 순으로 실행  

## 관련 이슈

- closes #65 

## 테스트 확인

- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 세션 종료 후 `chrome.storage.local`의 sessions에 `review` 필드 저장 확인
- [x] config.js의 API 키를 임의 값으로 바꿨을 때 폴백 리뷰가 정상 저장되는지 확인  

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/35b7e7e1-7346-4695-b462-d7835a140433" />


## 참고 사항

<!-- 특별히 전달할 내용 -->

- 분석 데이터(`categoryDistribution`, `entropy`, `videoCount`)는 LLM 호출 이전에 먼저 저장됩니다.
  LLM이 실패해도 분석 결과는 손실되지 않습니다.  
- `saveAnalysis`의 spread merge 특성을 이용해 `review` 필드만 두 번째 호출로 추가합니다.
  기존 분석 필드를 덮어쓰지 않습니다.  
- Gemini API 키는 `config.js`에서 관리합니다 (`.gitignore` 등록, 커밋되지 않음)  
- 테스트 시 `background.js`의 `TIMEOUT_MS`를 `30 * 1000`(30초)으로 임시 변경하면
  세션 종료를 빠르게 트리거할 수 있습니다.  
- 디버깅을 위한  console.log 코드도 다음 작업에도 필요할 것 같아 일단 제외하지 않았음 