### PR TITLE
feat: 팝업에서 세션 종료 후 자동 생성된 자연어 리뷰를 확인할 수 있다 (Story 3-2)

### DIFF
--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -297,14 +297,14 @@
 
 #### Tasks
 
-- [ ] 리뷰 텍스트 표시 영역 구현
+- [x] 리뷰 텍스트 표시 영역 구현
   - Priority: High / Owner: FE
   - 내용: storage의 `review` 필드를 읽어 팝업에 텍스트로 렌더링
   - DoD: 리뷰 텍스트가 팝업에 정상 출력된다.
   - Dependencies: popup.html 기본 구조 완료
   - 예상 소요: 1~2h
 
-- [ ] 리뷰 생성 로딩 상태 UI 구현
+- [x] 리뷰 생성 로딩 상태 UI 구현
   - Priority: Medium / Owner: FE
   - 내용: 세션 종료 후 LLM 응답 대기 중 스피너 또는 "분석 중..." 메시지 표시
   - DoD: 리뷰 미생성 상태에서 팝업 열기 시 로딩 UI가 표시된다.

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -16,7 +16,11 @@
 body {
   width: 350px;
   min-height: 200px;
-  font-family: 'Noto Sans KR', system-ui, -apple-system, sans-serif;
+  font-family:
+    "Noto Sans KR",
+    system-ui,
+    -apple-system,
+    sans-serif;
   font-size: 14px;
   color: #1a1a1a;
   background: #ffffff;
@@ -68,7 +72,7 @@ body {
 .bar-item__label {
   font-size: 12px;
   color: #3c3c3c;
-  text-align: right;
+  text-align: left;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -95,8 +99,16 @@ body {
 
 /* 로딩 UI */
 @keyframes pulse {
-  0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
-  40%           { transform: scale(1);   opacity: 1;   }
+  0%,
+  80%,
+  100% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 .review-loading {
@@ -114,8 +126,12 @@ body {
   animation: pulse 1.2s ease-in-out infinite;
 }
 
-.review-loading__dot:nth-child(2) { animation-delay: 0.16s; }
-.review-loading__dot:nth-child(3) { animation-delay: 0.32s; }
+.review-loading__dot:nth-child(2) {
+  animation-delay: 0.16s;
+}
+.review-loading__dot:nth-child(3) {
+  animation-delay: 0.32s;
+}
 
 /* AI 리뷰 */
 .review-text {

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -88,6 +88,30 @@ body {
   color: #909090;
 }
 
+/* 로딩 UI */
+@keyframes pulse {
+  0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
+  40%           { transform: scale(1);   opacity: 1;   }
+}
+
+.review-loading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px;
+}
+
+.review-loading__dot {
+  width: 8px;
+  height: 8px;
+  background: #ff4444;
+  border-radius: 50%;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.review-loading__dot:nth-child(2) { animation-delay: 0.16s; }
+.review-loading__dot:nth-child(3) { animation-delay: 0.32s; }
+
 /* AI 리뷰 */
 .review-text {
   font-size: 13px;

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -7,6 +7,11 @@
   padding: 0;
 }
 
+/* display를 명시한 CSS가 hidden 속성을 덮어쓰는 것을 방지 */
+[hidden] {
+  display: none !important;
+}
+
 /* Base */
 body {
   width: 350px;

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -18,7 +18,12 @@
 
       <section id="review-section" class="section">
         <h2 class="section__title">AI 리뷰</h2>
-        <p id="review-text" class="review-text"></p>
+        <div id="review-loading" class="review-loading" hidden>
+          <span class="review-loading__dot"></span>
+          <span class="review-loading__dot"></span>
+          <span class="review-loading__dot"></span>
+        </div>
+        <p id="review-text" class="review-text" hidden></p>
       </section>
 
       <div id="empty-state" class="empty-state" hidden>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -18,10 +18,10 @@
 
       <section id="review-section" class="section">
         <h2 class="section__title">AI 리뷰</h2>
-        <div id="review-loading" class="review-loading" hidden>
-          <span class="review-loading__dot"></span>
-          <span class="review-loading__dot"></span>
-          <span class="review-loading__dot"></span>
+        <div id="review-loading" class="review-loading" hidden role="status" aria-label="AI 리뷰 생성 중">
+          <span class="review-loading__dot" aria-hidden="true"></span>
+          <span class="review-loading__dot" aria-hidden="true"></span>
+          <span class="review-loading__dot" aria-hidden="true"></span>
         </div>
         <p id="review-text" class="review-text" hidden></p>
       </section>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -65,7 +65,7 @@ function renderReview(review) {
   const loading = document.getElementById('review-loading');
   const text = document.getElementById('review-text');
 
-  if (!review) {
+  if (review == null) {
     loading.hidden = false;
     text.hidden = true;
     return;

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -62,12 +62,18 @@ function createBarItem(category, ratio) {
 }
 
 function renderReview(review) {
-  const section = document.getElementById('review-section');
+  const loading = document.getElementById('review-loading');
+  const text = document.getElementById('review-text');
+
   if (!review) {
-    section.hidden = true;
+    loading.hidden = false;
+    text.hidden = true;
     return;
   }
-  document.getElementById('review-text').textContent = review;
+
+  loading.hidden = true;
+  text.hidden = false;
+  text.textContent = review;
 }
 
 init();


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
세션 분석이 완료되면 LLM이 생성한 자연어 리뷰를 팝업에 표시한다.
`review` 필드 존재 여부에 따라 리뷰 텍스트와 로딩 UI를 전환하며,
세 점 pulse 애니메이션으로 LLM 응답 대기 중임을 시각적으로 표현한다.

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->

- `popup.html`: `#review-loading`(세 점 마크업) 추가, `#review-text`에 `hidden` 초기값 설정
- `popup.js`: `renderReview()` 수정 — `review` 있을 때 텍스트 표시, 없을 때 로딩 UI 표시
- `popup.css`: `@keyframes pulse` 정의 및 `.review-loading` / `.review-loading__dot` 스타일 추가

## 관련 이슈

- closes #69  

## 테스트 확인

- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] `review` 필드가 있는 세션에서 팝업 열기 시 리뷰 텍스트 정상 출력 확인
- [x] `categoryDistribution`은 있고 `review`가 없는 세션에서 팝업 열기 시 세 점 로딩 애니메이션 표시 확인  

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

#### 분석 완료  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/41e573ab-41f6-4c6c-97b8-08afea387588" />  

#### LLM 대기 중  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/546ce2ab-73f2-4075-83dd-d13f00df4c0d" />

#### review == null 수정 검증  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8ffb9d88-1f26-4dd3-983e-e87bfe010b17" />

#### 빈 상태
<img width="500" alt="image" src="https://github.com/user-attachments/assets/80ee997b-4ecd-4e3d-84ad-26b650ed2306" />


## 참고 사항

<!-- 특별히 전달할 내용 -->

- 로딩 UI는 CSS `@keyframes`만으로 구현 — JS 타이머 불필요
- `#review-section` 자체는 숨기지 않음: `categoryDistribution`이 존재하는 세션이면 "AI 리뷰" 섹션 타이틀은 항상 표시