### PR TITLE
feat: 주간 리포트를 통해 기간별 카테고리 소비 패턴 변화를 확인할 수 있다 (Story 3-3)

### DIFF
--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -323,21 +323,21 @@
 
 #### Tasks
 
-- [ ] 최근 7일 누적 세션 데이터 집계 함수 구현
+- [x] 최근 7일 누적 세션 데이터 집계 함수 구현
   - Priority: Medium / Owner: FE
   - 내용: storage의 sessions 배열에서 최근 7일 데이터 필터링 및 일별 카테고리 비율 집계
   - DoD: 7일치 데이터 입력 시 일별 카테고리 분포 배열이 반환된다.
   - Dependencies: Story 2-3 완료
   - 예상 소요: 2~3h
 
-- [ ] 주간 카테고리 분포 변화 시각화 구현
+- [x] 주간 카테고리 분포 변화 시각화 구현
   - Priority: Medium / Owner: FE
   - 내용: 날짜별 카테고리 비율 스택 바차트 또는 라인차트 구현
   - DoD: 7일치 데이터로 날짜별 변화가 시각적으로 구분된다.
   - Dependencies: 집계 함수 완료
   - 예상 소요: 3~4h
 
-- [ ] Entropy 변화 추이 표시 구현
+- [x] Entropy 변화 추이 표시 구현
   - Priority: Medium / Owner: FE
   - 내용: 날짜별 Entropy 값을 라인차트로 표시. 베이스라인(1주차) 대비 변화 강조
   - DoD: Entropy 변화 추이가 라인차트로 표시된다.

--- a/extension/analysis.js
+++ b/extension/analysis.js
@@ -38,7 +38,7 @@ export function aggregateDailyData(sessions) {
 
   const byDate = {};
   for (const session of analyzed) {
-    const date = new Date(session.endTime).toLocaleDateString('sv'); // KST 기준 YYYY-MM-DD
+    const date = new Date(session.endTime).toLocaleDateString('sv'); // 로컬 시간대 기준 YYYY-MM-DD
     if (!byDate[date]) byDate[date] = [];
     byDate[date].push(session);
   }

--- a/extension/analysis.js
+++ b/extension/analysis.js
@@ -30,3 +30,44 @@ export function calculateEntropy(distribution) {
 
   return Math.round(H * 100) / 100 || 0;
 }
+
+export function aggregateDailyData(sessions) {
+  const analyzed = sessions.filter(
+    (s) => s.endTime && s.categoryDistribution && Object.keys(s.categoryDistribution).length > 0
+  );
+
+  if (analyzed.length === 0) return { dates: [], distributions: [], entropies: [] };
+
+  const byDate = {};
+  for (const session of analyzed) {
+    const date = new Date(session.endTime).toLocaleDateString('sv'); // KST 기준 YYYY-MM-DD
+    if (!byDate[date]) byDate[date] = [];
+    byDate[date].push(session);
+  }
+
+  const dates = Object.keys(byDate).sort();
+  const distributions = [];
+  const entropies = [];
+
+  for (const date of dates) {
+    const daySessions = byDate[date];
+    const totalVideos = daySessions.reduce((sum, s) => sum + (s.videoCount ?? 1), 0);
+
+    const merged = {};
+    for (const session of daySessions) {
+      const weight = (session.videoCount ?? 1) / totalVideos;
+      for (const [cat, ratio] of Object.entries(session.categoryDistribution)) {
+        merged[cat] = (merged[cat] ?? 0) + ratio * weight;
+      }
+    }
+
+    for (const cat of Object.keys(merged)) {
+      merged[cat] = Math.round(merged[cat] * 1000) / 1000;
+    }
+
+    distributions.push(merged);
+    entropies.push(calculateEntropy(merged));
+  }
+
+  return { dates, distributions, entropies };
+}

--- a/extension/analysis.js
+++ b/extension/analysis.js
@@ -36,8 +36,6 @@ export function aggregateDailyData(sessions) {
     (s) => s.endTime && s.categoryDistribution && Object.keys(s.categoryDistribution).length > 0
   );
 
-  if (analyzed.length === 0) return { dates: [], distributions: [], entropies: [] };
-
   const byDate = {};
   for (const session of analyzed) {
     const date = new Date(session.endTime).toLocaleDateString('sv'); // KST 기준 YYYY-MM-DD
@@ -45,14 +43,27 @@ export function aggregateDailyData(sessions) {
     byDate[date].push(session);
   }
 
-  const dates = Object.keys(byDate).sort();
+  // 오늘 기준 최근 7일을 고정 생성 (오름차순)
+  const dates = [];
+  const now = new Date();
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    dates.push(d.toLocaleDateString('sv'));
+  }
+
   const distributions = [];
   const entropies = [];
 
   for (const date of dates) {
     const daySessions = byDate[date];
-    const totalVideos = daySessions.reduce((sum, s) => sum + (s.videoCount ?? 1), 0);
+    if (!daySessions) {
+      distributions.push(null);
+      entropies.push(null);
+      continue;
+    }
 
+    const totalVideos = daySessions.reduce((sum, s) => sum + (s.videoCount ?? 1), 0);
     const merged = {};
     for (const session of daySessions) {
       const weight = (session.videoCount ?? 1) / totalVideos;
@@ -60,7 +71,6 @@ export function aggregateDailyData(sessions) {
         merged[cat] = (merged[cat] ?? 0) + ratio * weight;
       }
     }
-
     for (const cat of Object.keys(merged)) {
       merged[cat] = Math.round(merged[cat] * 1000) / 1000;
     }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -231,6 +231,29 @@ body {
   padding: 12px;
 }
 
+/* Entropy 라인차트 */
+.entropy-delta {
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 6px;
+  text-align: center;
+}
+
+.entropy-delta--up {
+  color: #10b981;
+}
+
+.entropy-delta--down {
+  color: #ef4444;
+}
+
+.entropy-single {
+  font-size: 13px;
+  color: #3c3c3c;
+  text-align: center;
+  padding: 12px 0;
+}
+
 /* 빈 상태 */
 .empty-state {
   text-align: center;

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -38,6 +38,30 @@ body {
   color: #0f0f0f;
 }
 
+/* 탭 내비게이션 */
+.tab-nav {
+  display: flex;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.tab-nav__btn {
+  flex: 1;
+  padding: 9px 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: #909090;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab-nav__btn--active {
+  color: #0f0f0f;
+  border-bottom-color: #ff4444;
+}
+
 /* Main */
 .main {
   padding: 16px;
@@ -54,6 +78,11 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.06em;
   margin-bottom: 10px;
+}
+
+/* 주간 리포트 */
+.weekly-section__entropy-title {
+  margin-top: 20px;
 }
 
 /* 막대그래프 */

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -115,6 +115,14 @@ body {
   min-height: 1px;
 }
 
+.weekly-chart__bar--empty {
+  flex: 1;
+  width: 100%;
+  border-radius: 3px;
+  background: #f5f5f5;
+  border: 1.5px dashed #e0e0e0;
+}
+
 .weekly-chart__date {
   font-size: 10px;
   color: #909090;

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -80,9 +80,68 @@ body {
   margin-bottom: 10px;
 }
 
-/* 주간 리포트 */
+/* 주간 리포트 - 카테고리 분포 바차트 */
 .weekly-section__entropy-title {
   margin-top: 20px;
+}
+
+.weekly-chart__bars {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  height: 90px;
+  margin-bottom: 8px;
+}
+
+.weekly-chart__bar-group {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
+}
+
+.weekly-chart__bar {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.weekly-chart__segment {
+  width: 100%;
+  min-height: 1px;
+}
+
+.weekly-chart__date {
+  font-size: 10px;
+  color: #909090;
+  margin-top: 5px;
+  white-space: nowrap;
+}
+
+.weekly-chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 12px;
+  margin-top: 10px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: #3c3c3c;
+}
+
+.legend-item__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
 }
 
 /* 막대그래프 */

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -37,12 +37,14 @@
       </div>
 
       <section id="weekly-section" class="section" hidden>
-        <h2 class="section__title">7일 카테고리 분포</h2>
-        <div id="weekly-chart"></div>
-        <h2 class="section__title weekly-section__entropy-title">Entropy 변화 추이</h2>
-        <div id="entropy-chart"></div>
+        <div id="weekly-content">
+          <h2 class="section__title">7일 카테고리 분포</h2>
+          <div id="weekly-chart"></div>
+          <h2 class="section__title weekly-section__entropy-title">Entropy 변화 추이</h2>
+          <div id="entropy-chart"></div>
+        </div>
         <p id="weekly-empty" class="empty-state" hidden>
-          7일 이상의 데이터가 필요합니다.
+          분석된 데이터가 없습니다.
           <span class="empty-state__sub">세션이 쌓이면 여기에 추이가 표시됩니다.</span>
         </p>
       </section>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -10,6 +10,11 @@
       <h1 class="header__title">시청 편향 분석</h1>
     </header>
 
+    <nav class="tab-nav" role="tablist">
+      <button class="tab-nav__btn tab-nav__btn--active" data-tab="session" role="tab" aria-selected="true">최근 세션</button>
+      <button class="tab-nav__btn" data-tab="weekly" role="tab" aria-selected="false">주간 리포트</button>
+    </nav>
+
     <main class="main">
       <section id="chart-section" class="section">
         <h2 class="section__title">카테고리 분포</h2>
@@ -30,6 +35,17 @@
         <p>아직 분석된 세션이 없습니다.</p>
         <p class="empty-state__sub">YouTube를 시청한 뒤 30분이 지나면 자동으로 분석됩니다.</p>
       </div>
+
+      <section id="weekly-section" class="section" hidden>
+        <h2 class="section__title">7일 카테고리 분포</h2>
+        <div id="weekly-chart"></div>
+        <h2 class="section__title weekly-section__entropy-title">Entropy 변화 추이</h2>
+        <div id="entropy-chart"></div>
+        <p id="weekly-empty" class="empty-state" hidden>
+          7일 이상의 데이터가 필요합니다.
+          <span class="empty-state__sub">세션이 쌓이면 여기에 추이가 표시됩니다.</span>
+        </p>
+      </section>
     </main>
 
     <script type="module" src="popup.js"></script>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -222,7 +222,80 @@ function renderWeeklyChart(dailyData) {
 }
 
 function renderEntropyChart(dailyData) {
-  // Step 6에서 구현
+  const container = document.getElementById('entropy-chart');
+  container.innerHTML = '';
+
+  const { dates, entropies } = dailyData;
+
+  if (dates.length === 1) {
+    const single = document.createElement('p');
+    single.className = 'entropy-single';
+    single.textContent = `현재 Entropy: ${entropies[0]}`;
+    container.appendChild(single);
+    return;
+  }
+
+  const VB_W = 300;
+  const VB_H = 80;
+  const PAD = { top: 8, right: 12, bottom: 20, left: 12 };
+  const chartW = VB_W - PAD.left - PAD.right;
+  const chartH = VB_H - PAD.top - PAD.bottom;
+
+  const yMax = Math.max(Math.max(...entropies) * 1.2, 1);
+  const xStep = chartW / (dates.length - 1);
+  const toX = (i) => PAD.left + i * xStep;
+  const toY = (val) => PAD.top + chartH - (val / yMax) * chartH;
+
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${VB_W} ${VB_H}`);
+  svg.setAttribute('width', '100%');
+  svg.setAttribute('height', String(VB_H));
+  svg.setAttribute('aria-label', 'Entropy 변화 추이 라인차트');
+
+  const points = entropies.map((val, i) => `${toX(i)},${toY(val)}`).join(' ');
+  const polyline = document.createElementNS(svgNS, 'polyline');
+  polyline.setAttribute('points', points);
+  polyline.setAttribute('fill', 'none');
+  polyline.setAttribute('stroke', '#6366f1');
+  polyline.setAttribute('stroke-width', '1.5');
+  polyline.setAttribute('stroke-linejoin', 'round');
+  svg.appendChild(polyline);
+
+  for (let i = 0; i < dates.length; i++) {
+    const cx = toX(i);
+    const cy = toY(entropies[i]);
+    const isBaseline = i === 0;
+
+    const circle = document.createElementNS(svgNS, 'circle');
+    circle.setAttribute('cx', String(cx));
+    circle.setAttribute('cy', String(cy));
+    circle.setAttribute('r', isBaseline ? '4' : '3');
+    circle.setAttribute('fill', isBaseline ? '#f59e0b' : '#6366f1');
+    svg.appendChild(circle);
+
+    const label = document.createElementNS(svgNS, 'text');
+    label.setAttribute('x', String(cx));
+    label.setAttribute('y', String(VB_H - 2));
+    label.setAttribute('text-anchor', 'middle');
+    label.setAttribute('font-size', '9');
+    label.setAttribute('fill', '#909090');
+    label.textContent = dates[i].slice(5).replace('-', '/');
+    svg.appendChild(label);
+  }
+
+  container.appendChild(svg);
+
+  const delta = Math.round((entropies.at(-1) - entropies[0]) * 100) / 100;
+  if (delta !== 0) {
+    const deltaEl = document.createElement('p');
+    deltaEl.className = `entropy-delta entropy-delta--${delta > 0 ? 'up' : 'down'}`;
+    deltaEl.textContent =
+      delta > 0
+        ? `▲ ${delta.toFixed(2)} 다양성 증가`
+        : `▼ ${Math.abs(delta).toFixed(2)} 편향 심화`;
+    container.appendChild(deltaEl);
+  }
 }
 
 init();

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,4 +1,7 @@
-import { getAllSessions } from './storage.js';
+import { getAllSessions, getRecentSessions } from './storage.js';
+import { aggregateDailyData } from './analysis.js';
+
+let hasSessionData = false;
 
 async function init() {
   const sessions = await getAllSessions();
@@ -9,6 +12,7 @@ async function init() {
     return;
   }
 
+  hasSessionData = true;
   renderChart(latestAnalyzed.categoryDistribution);
   renderReview(latestAnalyzed.review);
 }
@@ -76,4 +80,63 @@ function renderReview(review) {
   text.textContent = review;
 }
 
+function initTabs() {
+  const buttons = document.querySelectorAll('.tab-nav__btn');
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      buttons.forEach((b) => {
+        b.classList.remove('tab-nav__btn--active');
+        b.setAttribute('aria-selected', 'false');
+      });
+      btn.classList.add('tab-nav__btn--active');
+      btn.setAttribute('aria-selected', 'true');
+
+      if (btn.dataset.tab === 'weekly') {
+        showWeeklyTab();
+      } else {
+        showSessionTab();
+      }
+    });
+  });
+}
+
+function showSessionTab() {
+  document.getElementById('weekly-section').hidden = true;
+  if (hasSessionData) {
+    document.getElementById('chart-section').hidden = false;
+    document.getElementById('review-section').hidden = false;
+  } else {
+    document.getElementById('empty-state').hidden = false;
+  }
+}
+
+async function showWeeklyTab() {
+  document.getElementById('chart-section').hidden = true;
+  document.getElementById('review-section').hidden = true;
+  document.getElementById('empty-state').hidden = true;
+  document.getElementById('weekly-section').hidden = false;
+
+  const sessions = await getRecentSessions(7);
+  const dailyData = aggregateDailyData(sessions);
+
+  const hasData = dailyData.dates.length > 0;
+  document.getElementById('weekly-empty').hidden = hasData;
+  document.getElementById('weekly-chart').hidden = !hasData;
+  document.getElementById('entropy-chart').hidden = !hasData;
+
+  if (hasData) {
+    renderWeeklyChart(dailyData);
+    renderEntropyChart(dailyData);
+  }
+}
+
+function renderWeeklyChart(dailyData) {
+  // Step 5에서 구현
+}
+
+function renderEntropyChart(dailyData) {
+  // Step 6에서 구현
+}
+
 init();
+initTabs();

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -130,8 +130,95 @@ async function showWeeklyTab() {
   }
 }
 
+const CATEGORY_COLORS = [
+  '#ff4444', '#4a90d9', '#27ae60', '#f39c12', '#9b59b6',
+  '#e67e22', '#1abc9c', '#3498db', '#e74c3c', '#95a5a6',
+];
+const OTHER_COLOR = '#d0d0d0';
+const MAX_CATEGORIES = 5;
+
+function buildColorMap(distributions) {
+  const totals = {};
+  for (const dist of distributions) {
+    for (const [cat, ratio] of Object.entries(dist)) {
+      totals[cat] = (totals[cat] ?? 0) + ratio;
+    }
+  }
+  const sorted = Object.keys(totals).sort((a, b) => totals[b] - totals[a]);
+  const top = sorted.slice(0, MAX_CATEGORIES);
+  const colorMap = {};
+  top.forEach((cat, i) => {
+    colorMap[cat] = CATEGORY_COLORS[i];
+  });
+  return { colorMap, topCategories: top, hasOther: sorted.length > MAX_CATEGORIES };
+}
+
 function renderWeeklyChart(dailyData) {
-  // Step 5에서 구현
+  const container = document.getElementById('weekly-chart');
+  container.innerHTML = '';
+
+  const { dates, distributions } = dailyData;
+  const { colorMap, topCategories, hasOther } = buildColorMap(distributions);
+
+  const barsEl = document.createElement('div');
+  barsEl.className = 'weekly-chart__bars';
+
+  for (let i = 0; i < dates.length; i++) {
+    const dist = distributions[i];
+
+    let otherRatio = 0;
+    const topEntries = topCategories
+      .filter((cat) => dist[cat] != null)
+      .map((cat) => [cat, dist[cat]]);
+    for (const [cat, ratio] of Object.entries(dist)) {
+      if (!topCategories.includes(cat)) otherRatio += ratio;
+    }
+
+    const group = document.createElement('div');
+    group.className = 'weekly-chart__bar-group';
+
+    const bar = document.createElement('div');
+    bar.className = 'weekly-chart__bar';
+
+    for (const [cat, ratio] of topEntries) {
+      const seg = document.createElement('div');
+      seg.className = 'weekly-chart__segment';
+      seg.style.flex = String(ratio);
+      seg.style.background = colorMap[cat];
+      bar.appendChild(seg);
+    }
+    if (otherRatio > 0) {
+      const seg = document.createElement('div');
+      seg.className = 'weekly-chart__segment';
+      seg.style.flex = String(otherRatio);
+      seg.style.background = OTHER_COLOR;
+      bar.appendChild(seg);
+    }
+
+    const dateLabel = document.createElement('span');
+    dateLabel.className = 'weekly-chart__date';
+    dateLabel.textContent = dates[i].slice(5).replace('-', '/');
+
+    group.append(bar, dateLabel);
+    barsEl.appendChild(group);
+  }
+
+  const legendEl = document.createElement('div');
+  legendEl.className = 'weekly-chart__legend';
+  const legendCategories = [...topCategories, ...(hasOther ? ['기타'] : [])];
+  for (const cat of legendCategories) {
+    const item = document.createElement('span');
+    item.className = 'legend-item';
+    const dot = document.createElement('span');
+    dot.className = 'legend-item__dot';
+    dot.style.background = colorMap[cat] ?? OTHER_COLOR;
+    const name = document.createElement('span');
+    name.textContent = cat;
+    item.append(dot, name);
+    legendEl.appendChild(item);
+  }
+
+  container.append(barsEl, legendEl);
 }
 
 function renderEntropyChart(dailyData) {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -119,7 +119,7 @@ async function showWeeklyTab() {
   const sessions = await getRecentSessions(7);
   const dailyData = aggregateDailyData(sessions);
 
-  const hasData = dailyData.dates.length > 0;
+  const hasData = dailyData.distributions.some((d) => d !== null);
   document.getElementById('weekly-empty').hidden = hasData;
   document.getElementById('weekly-chart').hidden = !hasData;
   document.getElementById('entropy-chart').hidden = !hasData;
@@ -140,6 +140,7 @@ const MAX_CATEGORIES = 5;
 function buildColorMap(distributions) {
   const totals = {};
   for (const dist of distributions) {
+    if (!dist) continue;
     for (const [cat, ratio] of Object.entries(dist)) {
       totals[cat] = (totals[cat] ?? 0) + ratio;
     }
@@ -166,33 +167,36 @@ function renderWeeklyChart(dailyData) {
   for (let i = 0; i < dates.length; i++) {
     const dist = distributions[i];
 
-    let otherRatio = 0;
-    const topEntries = topCategories
-      .filter((cat) => dist[cat] != null)
-      .map((cat) => [cat, dist[cat]]);
-    for (const [cat, ratio] of Object.entries(dist)) {
-      if (!topCategories.includes(cat)) otherRatio += ratio;
-    }
-
     const group = document.createElement('div');
     group.className = 'weekly-chart__bar-group';
 
     const bar = document.createElement('div');
-    bar.className = 'weekly-chart__bar';
 
-    for (const [cat, ratio] of topEntries) {
-      const seg = document.createElement('div');
-      seg.className = 'weekly-chart__segment';
-      seg.style.flex = String(ratio);
-      seg.style.background = colorMap[cat];
-      bar.appendChild(seg);
-    }
-    if (otherRatio > 0) {
-      const seg = document.createElement('div');
-      seg.className = 'weekly-chart__segment';
-      seg.style.flex = String(otherRatio);
-      seg.style.background = OTHER_COLOR;
-      bar.appendChild(seg);
+    if (!dist) {
+      bar.className = 'weekly-chart__bar weekly-chart__bar--empty';
+    } else {
+      bar.className = 'weekly-chart__bar';
+      let otherRatio = 0;
+      const topEntries = topCategories
+        .filter((cat) => dist[cat] != null)
+        .map((cat) => [cat, dist[cat]]);
+      for (const [cat, ratio] of Object.entries(dist)) {
+        if (!topCategories.includes(cat)) otherRatio += ratio;
+      }
+      for (const [cat, ratio] of topEntries) {
+        const seg = document.createElement('div');
+        seg.className = 'weekly-chart__segment';
+        seg.style.flex = String(ratio);
+        seg.style.background = colorMap[cat];
+        bar.appendChild(seg);
+      }
+      if (otherRatio > 0) {
+        const seg = document.createElement('div');
+        seg.className = 'weekly-chart__segment';
+        seg.style.flex = String(otherRatio);
+        seg.style.background = OTHER_COLOR;
+        bar.appendChild(seg);
+      }
     }
 
     const dateLabel = document.createElement('span');
@@ -227,10 +231,11 @@ function renderEntropyChart(dailyData) {
 
   const { dates, entropies } = dailyData;
 
-  if (dates.length === 1) {
+  const nonNullEntropies = entropies.filter((e) => e !== null);
+  if (nonNullEntropies.length === 1) {
     const single = document.createElement('p');
     single.className = 'entropy-single';
-    single.textContent = `현재 Entropy: ${entropies[0]}`;
+    single.textContent = `현재 Entropy: ${nonNullEntropies[0]}`;
     container.appendChild(single);
     return;
   }
@@ -241,8 +246,8 @@ function renderEntropyChart(dailyData) {
   const chartW = VB_W - PAD.left - PAD.right;
   const chartH = VB_H - PAD.top - PAD.bottom;
 
-  const yMax = Math.max(Math.max(...entropies) * 1.2, 1);
-  const xStep = chartW / (dates.length - 1);
+  const yMax = Math.max(Math.max(...nonNullEntropies) * 1.2, 1);
+  const xStep = chartW / (dates.length - 1); // 항상 7일 고정이므로 / 6
   const toX = (i) => PAD.left + i * xStep;
   const toY = (val) => PAD.top + chartH - (val / yMax) * chartH;
 
@@ -253,40 +258,53 @@ function renderEntropyChart(dailyData) {
   svg.setAttribute('height', String(VB_H));
   svg.setAttribute('aria-label', 'Entropy 변화 추이 라인차트');
 
-  const points = entropies.map((val, i) => `${toX(i)},${toY(val)}`).join(' ');
-  const polyline = document.createElementNS(svgNS, 'polyline');
-  polyline.setAttribute('points', points);
-  polyline.setAttribute('fill', 'none');
-  polyline.setAttribute('stroke', '#6366f1');
-  polyline.setAttribute('stroke-width', '1.5');
-  polyline.setAttribute('stroke-linejoin', 'round');
-  svg.appendChild(polyline);
+  // null인 날에서 라인을 끊어 연속 구간별로 polyline 생성
+  let segment = [];
+  for (let i = 0; i <= dates.length; i++) {
+    if (i < dates.length && entropies[i] !== null) {
+      segment.push(i);
+    } else {
+      if (segment.length >= 2) {
+        const pts = segment.map((j) => `${toX(j)},${toY(entropies[j])}`).join(' ');
+        const polyline = document.createElementNS(svgNS, 'polyline');
+        polyline.setAttribute('points', pts);
+        polyline.setAttribute('fill', 'none');
+        polyline.setAttribute('stroke', '#6366f1');
+        polyline.setAttribute('stroke-width', '1.5');
+        polyline.setAttribute('stroke-linejoin', 'round');
+        svg.appendChild(polyline);
+      }
+      segment = [];
+    }
+  }
+
+  // 첫 번째 non-null 인덱스가 베이스라인
+  const baselineIdx = entropies.findIndex((e) => e !== null);
 
   for (let i = 0; i < dates.length; i++) {
-    const cx = toX(i);
-    const cy = toY(entropies[i]);
-    const isBaseline = i === 0;
-
-    const circle = document.createElementNS(svgNS, 'circle');
-    circle.setAttribute('cx', String(cx));
-    circle.setAttribute('cy', String(cy));
-    circle.setAttribute('r', isBaseline ? '4' : '3');
-    circle.setAttribute('fill', isBaseline ? '#f59e0b' : '#6366f1');
-    svg.appendChild(circle);
-
     const label = document.createElementNS(svgNS, 'text');
-    label.setAttribute('x', String(cx));
+    label.setAttribute('x', String(toX(i)));
     label.setAttribute('y', String(VB_H - 2));
     label.setAttribute('text-anchor', 'middle');
     label.setAttribute('font-size', '9');
     label.setAttribute('fill', '#909090');
     label.textContent = dates[i].slice(5).replace('-', '/');
     svg.appendChild(label);
+
+    if (entropies[i] === null) continue;
+
+    const circle = document.createElementNS(svgNS, 'circle');
+    circle.setAttribute('cx', String(toX(i)));
+    circle.setAttribute('cy', String(toY(entropies[i])));
+    circle.setAttribute('r', i === baselineIdx ? '4' : '3');
+    circle.setAttribute('fill', i === baselineIdx ? '#f59e0b' : '#6366f1');
+    svg.appendChild(circle);
   }
 
   container.appendChild(svg);
 
-  const delta = Math.round((entropies.at(-1) - entropies[0]) * 100) / 100;
+  const latestEntropy = nonNullEntropies.at(-1);
+  const delta = Math.round((latestEntropy - nonNullEntropies[0]) * 100) / 100;
   if (delta !== 0) {
     const deltaEl = document.createElement('p');
     deltaEl.className = `entropy-delta entropy-delta--${delta > 0 ? 'up' : 'down'}`;

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -121,8 +121,7 @@ async function showWeeklyTab() {
 
   const hasData = dailyData.distributions.some((d) => d !== null);
   document.getElementById('weekly-empty').hidden = hasData;
-  document.getElementById('weekly-chart').hidden = !hasData;
-  document.getElementById('entropy-chart').hidden = !hasData;
+  document.getElementById('weekly-content').hidden = !hasData;
 
   if (hasData) {
     renderWeeklyChart(dailyData);

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -36,6 +36,14 @@ export async function getAllSessions() {
   return sessions ?? [];
 }
 
+export async function getRecentSessions(days = 7) {
+  const sessions = await getAllSessions();
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  return sessions.filter(
+    (s) => s.endTime && new Date(s.endTime).getTime() >= cutoff
+  );
+}
+
 export async function clearCurrentSession() {
   await chrome.storage.local.set({ currentSession: null });
 }

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -38,7 +38,8 @@ export async function getAllSessions() {
 
 export async function getRecentSessions(days = 7) {
   const sessions = await getAllSessions();
-  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const now = new Date();
+  const cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate() - (days - 1)).getTime();
   return sessions.filter(
     (s) => s.endTime && new Date(s.endTime).getTime() >= cutoff
   );


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
팝업에 주간 리포트 탭을 추가하고, 최근 7일간의 카테고리 분포 변화(스택 바차트)와 Entropy 변화 추이(라인차트)를 시각화  

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->  

- **`extension/storage.js`**: `getRecentSessions(days = 7)` 함수 추가, `endTime` 기준 KST rolling 7일 이내 세션 필터링  
- **`extension/analysis.js`**: `aggregateDailyData(sessions)` 함수 추가, 날짜별 그룹핑 및 `videoCount` 기반 가중 평균 카테고리 분포 집계, Entropy 재계산  
- **`extension/popup.html`**: 탭 내비게이션(`최근 세션` / `주간 리포트`) 및 주간 리포트 섹션 HTML 추가  
- **`extension/popup.js`**: 탭 전환 로직, `renderWeeklyChart()`, `renderEntropyChart()` 구현
- **`extension/popup.css`**: 탭 내비게이션, 스택 바차트, Entropy 라인차트 스타일 추가  

## 관련 이슈

- closes #71 

## 테스트 확인

- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 주간 리포트 탭 전환 시 세션 뷰 ↔ 주간 리포트 뷰 정상 토글
- [x] 분석된 세션 데이터 있을 때 카테고리 분포 스택 바차트 정상 렌더링
- [x] 분석된 세션 데이터 있을 때 Entropy 라인차트 정상 렌더링
- [x] 세션 데이터 없을 때 빈 상태 메시지 표시
- [x] 세션 탭으로 복귀 시 기존 뷰 정상 복원  

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->
#### 주간 데이터가 있을 때 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4f28cc5c-a16a-4ab8-bf3c-05fb560ddd12" />

#### 주간 데이터가 없을 때  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d5672b5c-8c2a-42aa-ad9a-f1bd870dc1dc" />

#### Entropy가 감소하는 경우  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/758a7cc7-eb43-4241-b792-1e0c77041715" />


## 참고 사항

<!-- 특별히 전달할 내용 -->
- 날짜 기준은 `toLocaleDateString('sv')` 사용으로 KST 적용 (실험 대상이 한국 사용자)
- 차트는 외부 라이브러리 없이 순수 CSS flex(바차트) + SVG(라인차트)로 구현
- 베이스라인(첫날) Entropy 포인트는 주황색(`#f59e0b`)으로 강조
- 같은 날짜에 복수 세션이 있으면 `videoCount` 기반 가중 평균으로 합산  