### PR TITLE
feat: POST /api/sessions - 익명화된 세션 분석 결과 수신하여 DB에 저장할 수 있다 (Story 4-1)

### DIFF
--- a/docs/02-작업구조.md
+++ b/docs/02-작업구조.md
@@ -362,28 +362,28 @@
 
 #### Tasks
 
-- [ ] db.js 작성 - SQLite 연결 및 테이블 초기화
+- [x] db.js 작성 - SQLite 연결 및 테이블 초기화
   - Priority: High / Owner: BE
   - 내용: `better-sqlite3`로 DB 연결. 서버 시작 시 테이블이 없으면 자동 생성하는 `initializeDB()` 함수 구현
   - DoD: 서버 기동 시 `youtube_bias.db` 파일이 생성되고 테이블이 초기화된다.
   - Dependencies: 없음
   - 예상 소요: 2~3h
 
-- [ ] sessions 테이블 스키마 정의
+- [x] sessions 테이블 스키마 정의
   - Priority: High / Owner: BE
   - 내용: `id`, `anonymousId`, `sessionId`(UNIQUE), `startTime`, `endTime`, `videoCount`, `categoryDistribution`(JSON TEXT), `entropy`, `createdAt` 컬럼 정의
   - DoD: 스키마가 `db.js`에 정의되고 테이블이 정상 생성된다.
   - Dependencies: db.js 작성 완료
   - 예상 소요: 1~2h
 
-- [ ] POST /api/sessions 라우터 구현
+- [x] POST /api/sessions 라우터 구현
   - Priority: High / Owner: BE
   - 내용: `routes/sessions.js` 작성. 요청 body에서 필드 추출 → DB INSERT → `success()` 응답 반환. `sessionId` 중복 시 `DUPLICATE_SESSION` 에러 반환
   - DoD: 유효한 요청 시 201이 아닌 200으로 성공 응답이 반환되고 DB에 저장된다.
   - Dependencies: sessions 테이블 스키마 완료
   - 예상 소요: 2~3h
 
-- [ ] sessions 라우터 입력값 검증 로직 구현
+- [x] sessions 라우터 입력값 검증 로직 구현
   - Priority: High / Owner: BE
   - 내용: `anonymousId`, `sessionId`, `startTime`, `endTime` 필수 필드 검증. 누락 시 `MISSING_REQUIRED_FIELD`, 형식 오류 시 `INVALID_FIELD_VALUE` 반환
   - DoD: 각 에러 케이스에 대해 올바른 에러 코드와 HTTP 상태가 반환된다.

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,9 @@ require("dotenv").config();
 const express = require("express");
 const cors = require("cors");
 const { success, errorHandler } = require("./middleware/responseHandler");
+const { initializeDB } = require("./db");
+
+initializeDB();
 
 const app = express();
 

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,24 @@
+const Database = require("better-sqlite3");
+const path = require("path");
+
+const DB_PATH = path.join(__dirname, "youtube_bias.db");
+
+const db = new Database(DB_PATH);
+
+function initializeDB() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      anonymousId          TEXT    NOT NULL,
+      sessionId            TEXT    NOT NULL UNIQUE,
+      startTime            TEXT    NOT NULL,
+      endTime              TEXT    NOT NULL,
+      videoCount           INTEGER,
+      categoryDistribution TEXT,
+      entropy              REAL,
+      createdAt            TEXT    DEFAULT (datetime('now'))
+    )
+  `);
+}
+
+module.exports = { db, initializeDB };

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -29,7 +29,7 @@ function validateSession(body) {
   if (videoCount !== undefined && (!Number.isInteger(videoCount) || videoCount < 0)) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "videoCount" };
   }
-  if (entropy !== undefined && (typeof entropy !== "number" || entropy < 0)) {
+  if (entropy !== undefined && (typeof entropy !== "number" || !Number.isFinite(entropy) || entropy < 0)) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "entropy" };
   }
 

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -1,7 +1,13 @@
 const express = require("express");
+const { db } = require("../db");
 const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
 
 const router = express.Router();
+
+const insertSession = db.prepare(`
+  INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy)
+  VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy)
+`);
 
 function validateSession(body) {
   const { anonymousId, sessionId, startTime, endTime, videoCount, entropy } = body;
@@ -30,10 +36,29 @@ function validateSession(body) {
   return null;
 }
 
-router.post("/", (req, res) => {
+router.post("/", (req, res, next) => {
   const error = validateSession(req.body);
   if (error) {
     return fail(res, 400, error.code, `${error.field} 필드가 올바르지 않습니다.`, error.field);
+  }
+
+  const { anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy } = req.body;
+
+  try {
+    insertSession.run({
+      anonymousId,
+      sessionId,
+      startTime,
+      endTime,
+      videoCount: videoCount ?? null,
+      categoryDistribution: categoryDistribution !== undefined ? JSON.stringify(categoryDistribution) : null,
+      entropy: entropy ?? null,
+    });
+  } catch (err) {
+    if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {
+      return fail(res, 400, ERROR_CODES.DUPLICATE_SESSION, "이미 존재하는 세션입니다.", sessionId);
+    }
+    return next(err);
   }
 
   return success(res);

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -1,9 +1,41 @@
 const express = require("express");
-const { success } = require("../middleware/responseHandler");
+const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
 
 const router = express.Router();
 
+function validateSession(body) {
+  const { anonymousId, sessionId, startTime, endTime, videoCount, entropy } = body;
+
+  const requiredFields = ["anonymousId", "sessionId", "startTime", "endTime"];
+  for (const field of requiredFields) {
+    const value = body[field];
+    if (value === undefined || value === null || String(value).trim() === "") {
+      return { code: ERROR_CODES.MISSING_REQUIRED_FIELD, field };
+    }
+  }
+
+  if (isNaN(Date.parse(startTime))) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "startTime" };
+  }
+  if (isNaN(Date.parse(endTime))) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "endTime" };
+  }
+  if (videoCount !== undefined && (!Number.isInteger(videoCount) || videoCount < 0)) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "videoCount" };
+  }
+  if (entropy !== undefined && (typeof entropy !== "number" || entropy < 0)) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "entropy" };
+  }
+
+  return null;
+}
+
 router.post("/", (req, res) => {
+  const error = validateSession(req.body);
+  if (error) {
+    return fail(res, 400, error.code, `${error.field} 필드가 올바르지 않습니다.`, error.field);
+  }
+
   return success(res);
 });
 

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -51,7 +51,7 @@ router.post("/", (req, res, next) => {
       startTime,
       endTime,
       videoCount: videoCount ?? null,
-      categoryDistribution: categoryDistribution !== undefined ? JSON.stringify(categoryDistribution) : null,
+      categoryDistribution: categoryDistribution != null ? JSON.stringify(categoryDistribution) : null,
       entropy: entropy ?? null,
     });
   } catch (err) {

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const { success } = require("../middleware/responseHandler");
+
+const router = express.Router();
+
+router.post("/", (req, res) => {
+  return success(res);
+});
+
+module.exports = router;

--- a/server/routes/surveys.js
+++ b/server/routes/surveys.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const { success } = require("../middleware/responseHandler");
+
+const router = express.Router();
+
+router.post("/", (req, res) => {
+  return success(res);
+});
+
+module.exports = router;

--- a/server/test.http
+++ b/server/test.http
@@ -1,0 +1,79 @@
+# 서버를 먼저 실행한 뒤 각 요청 위의 "Send Request" 클릭
+# 기대 응답이 맞으면 PR의 테스트 확인 체크박스를 체크하세요
+
+### 1. 정상 저장
+# PR 체크: "유효한 요청 → 200 응답, DB 레코드 저장 확인"
+# 모든 필드가 올바르게 채워진 정상 요청
+# 기대 응답: 200 { "success": true }
+POST http://localhost:3000/api/sessions
+Content-Type: application/json
+
+{
+  "anonymousId": "user-test-001",
+  "sessionId": "session-test-001",
+  "startTime": "2024-01-01T10:00:00Z",
+  "endTime": "2024-01-01T10:30:00Z",
+  "videoCount": 3,
+  "categoryDistribution": { "음악": 0.5, "게임": 0.3, "교육": 0.2 },
+  "entropy": 1.49
+}
+
+### 2. 중복 sessionId → DUPLICATE_SESSION
+# PR 체크: "동일 sessionId 재요청 → DUPLICATE_SESSION 400 응답 확인"
+# 위 1번 요청과 sessionId가 동일 (session-test-001)
+# 기대 응답: 400 { "code": "DUPLICATE_SESSION" }
+POST http://localhost:3000/api/sessions
+Content-Type: application/json
+
+{
+  "anonymousId": "user-test-001",
+  "sessionId": "session-test-001",
+  "startTime": "2024-01-01T10:00:00Z",
+  "endTime": "2024-01-01T10:30:00Z"
+}
+
+### 3. 필수 필드 누락 → MISSING_REQUIRED_FIELD
+# PR 체크: "필수 필드 누락 → MISSING_REQUIRED_FIELD 400 응답 확인"
+# sessionId 필드가 빠져 있음
+# 기대 응답: 400 { "code": "MISSING_REQUIRED_FIELD", "detail": "sessionId" }
+POST http://localhost:3000/api/sessions
+Content-Type: application/json
+
+{
+  "anonymousId": "user-test-001",
+  "startTime": "2024-01-01T10:00:00Z",
+  "endTime": "2024-01-01T10:30:00Z"
+}
+
+### 4. 날짜 형식 오류 → INVALID_FIELD_VALUE
+# PR 체크: "날짜 형식 오류 → INVALID_FIELD_VALUE 400 응답 확인"
+# startTime이 ISO 날짜 형식이 아닌 일반 문자열
+# 기대 응답: 400 { "code": "INVALID_FIELD_VALUE", "detail": "startTime" }
+POST http://localhost:3000/api/sessions
+Content-Type: application/json
+
+{
+  "anonymousId": "user-test-001",
+  "sessionId": "session-test-002",
+  "startTime": "이건날짜가아님",
+  "endTime": "2024-01-01T10:30:00Z"
+}
+
+### 5. 선택 필드 없이 최소 요청
+# PR 체크: "선택 필드 미전송 시 null로 정상 저장 확인"
+# videoCount, categoryDistribution, entropy 없이 필수 필드만 전송
+# 기대 응답: 200 { "success": true } (선택 필드는 DB에 null로 저장)
+POST http://localhost:3000/api/sessions
+Content-Type: application/json
+
+{
+  "anonymousId": "user-test-001",
+  "sessionId": "session-test-003",
+  "startTime": "2024-01-02T10:00:00Z",
+  "endTime": "2024-01-02T10:30:00Z"
+}
+
+### 6. 헬스 체크
+# 서버가 정상적으로 기동되었는지 확인
+# 기대 응답: 200 { "status": "healthy" }
+GET http://localhost:3000/health


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
확장 프로그램이 세션 종료 후 분석 결과를 POST /api/sessions로 전송하면 서버가 SQLite DB에 저장하는 기능. 원시 데이터(videoId, 영상 제목)는 포함하지 않으며, 익명화된 분석 결과만 수신한다.

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->

- server/db.js 추가: better-sqlite3로 SQLite 연결 및 sessions 테이블 자동 초기화 (CREATE TABLE IF NOT EXISTS)  
- server/routes/sessions.js 추가: 입력값 검증, DB INSERT, 중복 세션 처리  
- server/routes/surveys.js 추가: Story 4-2 작업에 필요 (서버 기동 차단 해소)  
- server/app.js 수정: 서버 시작 시 initializeDB() 호출 추가   

## 관련 이슈

- closes #73 

## 테스트 확인
POSTMAN으로토 테스트 가능  
`VSC에서 .http 파일을 만들면 버튼 클릭으로 요청을 보낼 수 있음`  
`REST Client 확장을 설치하고 테스트 파일 생성`  
`cd server와 npm run dev로 서버 실행`  
`.http 파일을 열면 각 요청 위에 버튼이 생기고 순서대로 클릭하면 응답까지 표시`  

- [X] 서버 기동 시 youtube_bias.db 생성 및 sessions 테이블 자동 초기화 확인  
- [X]  유효한 요청 → 200 응답, DB 레코드 저장 확인  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/29a9d253-12b3-435b-b011-48c55150e0fa" />

- [x] 동일 sessionId 재요청 → DUPLICATE_SESSION 400 응답 확인  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/78186a48-583b-4105-856e-58014c05c30f" />

- [X] 필수 필드 누락 → MISSING_REQUIRED_FIELD 400 응답 확인  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/17a65bf5-4430-45fe-a45a-7fdd042b2691" />

- [X] 날짜 형식 오류 → INVALID_FIELD_VALUE 400 응답 확인  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d6276854-a4a9-405f-8b25-34cb3b9bcf18" />

- [X] 선택 필드 미전송 시 null로 정상 저장 확인  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/680507b6-8f9d-46b4-a28c-f19a89febc19" />
 
- [X] categoryDistribution 한글 키 포함 JSON 직렬화 저장 확인  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d6a5d2e7-6c3e-4489-a58b-95261a78cdf4" />


## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

## 참고 사항

<!-- 특별히 전달할 내용 -->
- categoryDistribution은 SQLite에 JSON 타입이 없어 TEXT로 직렬화 저장 (JSON.stringify / JSON.parse)   
- sessionId UNIQUE 제약을 DB 레벨에 걸어 SELECT 없이 INSERT 에러 하나로 중복 감지 처리   
 