### PR TITLE
feat: 온보딩 시 anonymousId(UUID) 생성 및 반환

### DIFF
--- a/extension/storage.js
+++ b/extension/storage.js
@@ -85,13 +85,15 @@ export async function getLastWatchedAt() {
 export const VALID_GROUPS = ['EXP', 'CON', 'TEST'];
 
 export async function getOnboarding() {
-  const { group, installDate, surveyStatus } = await chrome.storage.local.get([
+  const { anonymousId, group, installDate, surveyStatus } = await chrome.storage.local.get([
+    'anonymousId',
     'group',
     'installDate',
     'surveyStatus',
   ]);
   if (!group) return null;
   return {
+    anonymousId,
     group,
     installDate,
     surveyStatus: surveyStatus ?? { week1: false, week2: false, week3: false },
@@ -100,6 +102,7 @@ export async function getOnboarding() {
 
 export async function saveOnboarding(group) {
   await chrome.storage.local.set({
+    anonymousId: crypto.randomUUID(),
     group,
     installDate: new Date().toISOString(),
     surveyStatus: { week1: false, week2: false, week3: false },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
온보딩 시 참여자에게 익명 식별자(UUID)를 부여한다.
기존에는 `saveOnboarding()`이 `group`, `installDate`, `surveyStatus`만 저장해
서버 전송 시 필수 필드인 `anonymousId`가 누락되는 상태였다.
  
## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->

- `saveOnboarding()`: `crypto.randomUUID()`로 UUID를 생성해 `chrome.storage.local`에 저장  
- `getOnboarding()`: `anonymousId`를 storage에서 읽어 반환값에 포함  

## 관련 이슈

- closes #88 

## 테스트 확인

- [ ] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [ ] 콘솔 에러 없음

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

## 참고 사항

<!-- 특별히 전달할 내용 -->
- `crypto.randomUUID()`는 Chrome 92+에서 지원되며 Manifest V3 service worker 환경에서 사용 가능  
- 재설치 시 UUID가 재생성되므로 연구 참여자에게 실험 기간 중 재설치 자제 안내 필요  
- 다음 PR(`feat/session-server-sync`)에서 이 `anonymousId`를 서버 전송 페이로드에 포함할 예정  