### PR TITLE
feat: 세션 분석 완료 후 서버로 결과 전송

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -95,14 +95,21 @@ async function analyzeSession(session) {
 }
 
 async function postSessionToServer(session, categoryDistribution, entropy, videoCount) {
+  if (!SERVER_URL || SERVER_URL.startsWith("YOUR_")) {
+    console.warn("[background] SERVER_URL이 설정되지 않았습니다. config.js 설정을 확인해주세요.");
+    return;
+  }
+
   const onboarding = await getOnboarding();
   if (!onboarding?.anonymousId) {
     console.warn("[background] anonymousId 없음, 서버 전송 건너뜀");
     return;
   }
 
+  const cleanUrl = SERVER_URL.replace(/\/$/, "");
+
   try {
-    const response = await fetch(`${SERVER_URL}/api/sessions`, {
+    const response = await fetch(`${cleanUrl}/api/sessions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -112,7 +119,7 @@ async function postSessionToServer(session, categoryDistribution, entropy, video
         endTime: session.endTime,
         videoCount,
         categoryDistribution,
-        entropy,
+        entropy: typeof entropy === "number" && Number.isFinite(entropy) ? entropy : undefined,
       }),
     });
 
@@ -124,6 +131,6 @@ async function postSessionToServer(session, categoryDistribution, entropy, video
 
     console.log("[background] 서버 전송 완료:", session.sessionId);
   } catch (error) {
-    console.warn("[background] 서버 전송 오류:", error.message);
+    console.warn("[background] 서버 전송 오류:", error);
   }
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -5,10 +5,12 @@ import {
   getCurrentSession,
   getAllSessions,
   saveAnalysis,
+  getOnboarding,
 } from "./storage.js";
 import { fetchVideoCategories } from "./youtube.js";
 import { calculateDistribution, calculateEntropy } from "./analysis.js";
 import { buildPrompt, generateReview, generateFallbackReview } from "./llm.js";
+import { SERVER_URL } from "./config.js";
 
 const ALARM_NAME = "SESSION_TIMEOUT_CHECK";
 const TIMEOUT_MS = 30 * 60 * 1000;
@@ -88,4 +90,40 @@ async function analyzeSession(session) {
 
   await saveAnalysis(session.sessionId, { review: result.feedback, reviewTopic: result.topic });
   console.log("[background] 리뷰 저장 완료:", result);
+
+  await postSessionToServer(session, categoryDistribution, entropy, videoCount);
+}
+
+async function postSessionToServer(session, categoryDistribution, entropy, videoCount) {
+  const onboarding = await getOnboarding();
+  if (!onboarding?.anonymousId) {
+    console.warn("[background] anonymousId 없음, 서버 전송 건너뜀");
+    return;
+  }
+
+  try {
+    const response = await fetch(`${SERVER_URL}/api/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        anonymousId: onboarding.anonymousId,
+        sessionId: session.sessionId,
+        startTime: session.startTime,
+        endTime: session.endTime,
+        videoCount,
+        categoryDistribution,
+        entropy,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      console.warn("[background] 서버 전송 실패:", response.status, body);
+      return;
+    }
+
+    console.log("[background] 서버 전송 완료:", session.sessionId);
+  } catch (error) {
+    console.warn("[background] 서버 전송 오류:", error.message);
+  }
 }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
세션 분석이 완료된 후 결과를 서버(`POST /api/sessions`)로 전송한다.
기존에는 분석 결과가 `chrome.storage.local`에만 저장되어 DB에 데이터가 쌓이지 않았다. 

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->
- `background.js`: `SERVER_URL`, `getOnboarding` import 추가  
- `background.js`: `analyzeSession()` 완료 후 `postSessionToServer()` 호출  
- `background.js`: `postSessionToServer()` 함수 추가: `anonymousId`, `sessionId`, `startTime`, `endTime`, `videoCount`, `categoryDistribution`, `entropy`를 서버로 전송  
- 서버 전송 실패 시 `console.warn`으로 기록하고 로컬 저장 결과에는 영향 없음  

## 관련 이슈

- closes #89 

## 테스트 확인

- [ ] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [ ] 콘솔 에러 없음
- [ ] 30분 세션 타임아웃 후 서버 DB에 레코드 추가 확인  

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

## 참고 사항

<!-- 특별히 전달할 내용 -->
- `anonymousId`가 없는 경우(온보딩 미완료) 서버 전송을 건너뜀  
- 서버 전송 실패가 사용자 경험에 영향을 주지 않도록 try/catch로 격리  