### PR TITLE
feat: 오늘의 시청 UX 개선(날짜 네비, 실시간 영상 수, 피드백 카운트다운)

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -24,7 +24,7 @@ jobs:
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create config.js
+      - name: Create config.js and patch manifest.json
         if: steps.check.outputs.changed == 'true'
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
@@ -33,6 +33,16 @@ jobs:
         run: |
           printf "export const YOUTUBE_API_KEY = '%s';\nexport const GEMINI_API_KEY = '%s';\nexport const SERVER_URL = '%s';\n" \
             "$YOUTUBE_API_KEY" "$GEMINI_API_KEY" "$SERVER_URL" > extension/config.js
+
+          node -e "
+            const fs = require('fs');
+            const manifest = JSON.parse(fs.readFileSync('extension/manifest.json', 'utf8'));
+            const serverOrigin = new URL('$SERVER_URL').origin + '/*';
+            if (!manifest.host_permissions.includes(serverOrigin)) {
+              manifest.host_permissions.push(serverOrigin);
+            }
+            fs.writeFileSync('extension/manifest.json', JSON.stringify(manifest, null, 2) + '\n');
+          "
 
       - name: Zip Extension
         if: steps.check.outputs.changed == 'true'

--- a/extension/background.js
+++ b/extension/background.js
@@ -50,7 +50,7 @@ async function checkSessionTimeout() {
   if (!currentSession) return;
   const sessionId = currentSession.sessionId;
 
-  console.log("[background] 30분 비활성 감지, 세션 종료");
+  console.log("[background] 10분 비활성 감지, 세션 종료");
   await endSession();
 
   const sessions = await getAllSessions();
@@ -76,7 +76,12 @@ async function analyzeSession(session) {
   });
   console.log("[background] 분석 완료:", { entropy, categoryDistribution });
 
-  const analysisData = { categoryDistribution, entropy, videoCount, videoTitles };
+  const analysisData = {
+    categoryDistribution,
+    entropy,
+    videoCount,
+    videoTitles,
+  };
   const prompt = buildPrompt(analysisData);
 
   let result;
@@ -88,15 +93,25 @@ async function analyzeSession(session) {
     result = generateFallbackReview(analysisData);
   }
 
-  await saveAnalysis(session.sessionId, { review: result.feedback, reviewTopic: result.topic });
+  await saveAnalysis(session.sessionId, {
+    review: result.feedback,
+    reviewTopic: result.topic,
+  });
   console.log("[background] 리뷰 저장 완료:", result);
 
   await postSessionToServer(session, categoryDistribution, entropy, videoCount);
 }
 
-async function postSessionToServer(session, categoryDistribution, entropy, videoCount) {
+async function postSessionToServer(
+  session,
+  categoryDistribution,
+  entropy,
+  videoCount,
+) {
   if (!SERVER_URL || SERVER_URL.startsWith("YOUR_")) {
-    console.warn("[background] SERVER_URL이 설정되지 않았습니다. config.js 설정을 확인해주세요.");
+    console.warn(
+      "[background] SERVER_URL이 설정되지 않았습니다. config.js 설정을 확인해주세요.",
+    );
     return;
   }
 
@@ -119,7 +134,10 @@ async function postSessionToServer(session, categoryDistribution, entropy, video
         endTime: session.endTime,
         videoCount,
         categoryDistribution,
-        entropy: typeof entropy === "number" && Number.isFinite(entropy) ? entropy : undefined,
+        entropy:
+          typeof entropy === "number" && Number.isFinite(entropy)
+            ? entropy
+            : undefined,
       }),
     });
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -13,7 +13,7 @@ import { buildPrompt, generateReview, generateFallbackReview } from "./llm.js";
 import { SERVER_URL } from "./config.js";
 
 const ALARM_NAME = "SESSION_TIMEOUT_CHECK";
-const TIMEOUT_MS = 30 * 60 * 1000;
+const TIMEOUT_MS = 10 * 60 * 1000;
 
 // service worker가 깨어날 때마다 실행 — 같은 이름의 alarm은 자동으로 교체됨
 chrome.alarms.create(ALARM_NAME, { periodInMinutes: 1 });

--- a/extension/background.js
+++ b/extension/background.js
@@ -18,6 +18,9 @@ const TIMEOUT_MS = 10 * 60 * 1000;
 // service worker가 깨어날 때마다 실행 — 같은 이름의 alarm은 자동으로 교체됨
 chrome.alarms.create(ALARM_NAME, { periodInMinutes: 1 });
 
+// content script가 읽을 수 있도록 SERVER_URL을 storage에 저장
+chrome.storage.local.set({ serverUrl: SERVER_URL });
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "VIDEO_DETECTED") {
     handleVideoDetected(message)

--- a/extension/content.js
+++ b/extension/content.js
@@ -45,35 +45,43 @@ function waitForTitle(maxRetries = 10, interval = 200) {
   });
 }
 
-async function sendWithRetry(message, maxRetries = 5, delay = 1000) {
-  for (let i = 0; i < maxRetries; i++) {
-    if (!chrome.runtime?.sendMessage) {
-      console.warn("[content] Extension context invalidated");
-      return;
+// 서비스 워커 수면과 무관하게 storage에 직접 기록
+let writeQueue = Promise.resolve();
+
+function recordVideo(videoId, title) {
+  writeQueue = writeQueue.then(async () => {
+    const now = new Date().toISOString();
+    const { currentSession, anonymousId, serverUrl } = await chrome.storage.local.get([
+      "currentSession",
+      "anonymousId",
+      "serverUrl",
+    ]);
+
+    const session = currentSession ?? {
+      sessionId: String(Date.now()),
+      startTime: now,
+      videos: [],
+    };
+
+    await chrome.storage.local.set({ lastWatchedAt: now });
+
+    const lastSaved = session.videos.at(-1);
+    if (lastSaved?.videoId === videoId) return;
+
+    session.videos.push({ videoId, title, watchedAt: now });
+    await chrome.storage.local.set({ currentSession: session });
+    console.log("[content] recorded:", { videoId, title });
+
+    // 서버에 즉시 전송
+    if (anonymousId && serverUrl && !serverUrl.startsWith("YOUR_")) {
+      fetch(`${serverUrl.replace(/\/$/, "")}/api/video-events`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ anonymousId, videoId, title: title ?? null, watchedAt: now }),
+      }).catch(() => {});
     }
-
-    const response = await new Promise((resolve) => {
-      try {
-        chrome.runtime.sendMessage(message, (res) => {
-          if (chrome.runtime?.lastError) {
-            resolve(null);
-          } else {
-            resolve(res);
-          }
-        });
-      } catch {
-        resolve(null);
-      }
-    });
-
-    if (response) {
-      console.log("[content] background response:", response);
-      return;
-    }
-
-    if (i < maxRetries - 1) await new Promise((r) => setTimeout(r, delay));
-  }
-  console.warn("[content] sendMessage 최종 실패:", message.videoId);
+  });
+  return writeQueue;
 }
 
 let lastVideoId = null;
@@ -93,12 +101,7 @@ async function handleVideoChange() {
   const title = await waitForTitle();
   console.log("[content] video detected:", { videoId, title });
 
-  sendWithRetry({
-    type: "VIDEO_DETECTED",
-    videoId,
-    title,
-    url: location.href,
-  }).catch(() => {});
+  await recordVideo(videoId, title);
 }
 
 handleVideoChange();

--- a/extension/content.js
+++ b/extension/content.js
@@ -45,7 +45,7 @@ function waitForTitle(maxRetries = 10, interval = 200) {
   });
 }
 
-async function sendWithRetry(message, maxRetries = 3, delay = 1000) {
+async function sendWithRetry(message, maxRetries = 5, delay = 1000) {
   for (let i = 0; i < maxRetries; i++) {
     if (!chrome.runtime?.sendMessage) {
       console.warn("[content] Extension context invalidated");

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,7 +19,7 @@
       "128": "icon128.png"
     }
   },
-  "host_permissions": ["*://*.youtube.com/*", "*://generativelanguage.googleapis.com/*"],
+  "host_permissions": ["*://*.youtube.com/*", "*://generativelanguage.googleapis.com/*", "http://168.107.51.12/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/extension/viewlens-app.js
+++ b/extension/viewlens-app.js
@@ -1,3 +1,15 @@
+function _collectingTimerText() {
+  const lastWatchedAt = VL._lastWatchedAt;
+  if (!lastWatchedAt) return "";
+  const TIMEOUT_MS = 10 * 60 * 1000;
+  const elapsed = Date.now() - new Date(lastWatchedAt).getTime();
+  const remaining = Math.max(0, TIMEOUT_MS - elapsed);
+  if (remaining <= 0) return "";
+  const mins = Math.floor(remaining / 60000);
+  const secs = Math.floor((remaining % 60000) / 1000);
+  return `피드백까지 ${mins}분 ${String(secs).padStart(2, "0")}초`;
+}
+
 function _popupHeader(groupCfg, day) {
   const badge =
     groupCfg.code === "TEST"
@@ -98,9 +110,9 @@ class ViewLensPopup {
 
     if (this._tab === "today") {
       const d = buildDataForDate(VL._allSessions || [], this._selectedDate);
-      d.collectingCount = this._selectedDate.toDateString() === new Date().toDateString()
-        ? (VL.today?.collectingCount ?? 0)
-        : 0;
+      const isToday = this._selectedDate.toDateString() === new Date().toDateString();
+      d.collectingCount = isToday ? (VL.today?.collectingCount ?? 0) : 0;
+      d.collectingTimer = isToday ? _collectingTimerText() : "";
       VL.today = d;
     }
 

--- a/extension/viewlens-app.js
+++ b/extension/viewlens-app.js
@@ -110,7 +110,8 @@ class ViewLensPopup {
 
     if (this._tab === "today") {
       const d = buildDataForDate(VL._allSessions || [], this._selectedDate);
-      const isToday = this._selectedDate.toDateString() === new Date().toDateString();
+      const isToday =
+        this._selectedDate.toDateString() === new Date().toDateString();
       d.collectingCount = isToday ? (VL.today?.collectingCount ?? 0) : 0;
       d.collectingTimer = isToday ? _collectingTimerText() : "";
       VL.today = d;
@@ -268,7 +269,7 @@ class Studio {
           ${wordmarkHTML({ size: 26, accent, sub: "YouTube Bias Feedback" })}
           <div style="text-align:right;max-width:360px">
             <div style="font-size:13px;font-weight:700;color:#3a3531">시청 편향 피드백 · 크롬 확장 프로그램</div>
-            <div style="font-size:12px;color:#8a837c;margin-top:3px;line-height:1.5">세션별 카테고리 다양성(Shannon Entropy)을 분석해 부드러운 코치 노트로 돌려줍니다.</div>
+            <div style="font-size:12px;color:#8a837c;margin-top:3px;line-height:1.5">세션별 카테고리 다양성(Shannon Entropy)을 분석해 명확한 시청 분석으로 돌려줍니다.</div>
           </div>
         </div>
 
@@ -383,8 +384,13 @@ class Studio {
       ])
       .addToggle("다크 모드", "dark")
       .addSection("참여 · 그룹")
-      .addRadio("그룹", "group",
-        Object.entries(VL.GROUPS).map(([k, v]) => ({ value: k, label: v.name })),
+      .addRadio(
+        "그룹",
+        "group",
+        Object.entries(VL.GROUPS).map(([k, v]) => ({
+          value: k,
+          label: v.name,
+        })),
       )
       .addButton(
         "온보딩 다시 보기",

--- a/extension/viewlens-app.js
+++ b/extension/viewlens-app.js
@@ -50,6 +50,7 @@ class ViewLensPopup {
     this._completed = {}; // { [week]: true }
     this._snoozed = false;
     this._selWeek = 1;
+    this._selectedDate = new Date();
     // External app state (set via mount)
     this._onboarded = false;
     this._group = null;
@@ -94,6 +95,14 @@ class ViewLensPopup {
     const surveyWeek = tl.surveyWeek;
     const surveyPending = surveyWeek != null && !this._completed[surveyWeek];
     const showModal = surveyPending && !this._snoozed;
+
+    if (this._tab === "today") {
+      const d = buildDataForDate(VL._allSessions || [], this._selectedDate);
+      d.collectingCount = this._selectedDate.toDateString() === new Date().toDateString()
+        ? (VL.today?.collectingCount ?? 0)
+        : 0;
+      VL.today = d;
+    }
 
     let bodyHTML;
     if (groupCfg.feedback) {
@@ -168,6 +177,31 @@ class ViewLensPopup {
           }
         });
       });
+    // Date navigation
+    const prevBtn = this.container.querySelector("#vl-date-prev");
+    const nextBtn = this.container.querySelector("#vl-date-next");
+    if (prevBtn) {
+      prevBtn.addEventListener("click", () => {
+        const d = new Date(this._selectedDate);
+        d.setDate(d.getDate() - 1);
+        const installDate = VL._installDate ? new Date(VL._installDate) : null;
+        if (!installDate || d >= new Date(installDate.toDateString())) {
+          this._selectedDate = d;
+          this.render();
+        }
+      });
+    }
+    if (nextBtn) {
+      nextBtn.addEventListener("click", () => {
+        const today = new Date();
+        if (this._selectedDate.toDateString() !== today.toDateString()) {
+          const d = new Date(this._selectedDate);
+          d.setDate(d.getDate() + 1);
+          this._selectedDate = d;
+          this.render();
+        }
+      });
+    }
   }
 }
 

--- a/extension/viewlens-logo.js
+++ b/extension/viewlens-logo.js
@@ -1,6 +1,3 @@
-// viewlens-logo.js — ViewLens brand mark helpers (returns HTML strings)
-// Exports (window): markSVG, wordmarkHTML
-
 const VL_APERTURE_LINES = [
   [71, 50, 69.5, 16.2],
   [60.5, 31.8, 30.5, 16.2],
@@ -18,14 +15,19 @@ const VL_APERTURE_LINES = [
  * @param {string}  opts.accent  - accent color (default var(--vl-accent))
  * @param {string}  opts.face    - stroke color on filled bg (default var(--vl-on-accent))
  */
-function markSVG({ size = 40, filled = true, accent = 'var(--vl-accent)', face = 'var(--vl-on-accent)' } = {}) {
+function markSVG({
+  size = 40,
+  filled = true,
+  accent = "var(--vl-accent)",
+  face = "var(--vl-on-accent)",
+} = {}) {
   const ink = filled ? face : accent;
   const bg = filled
     ? `<rect x="0" y="0" width="100" height="100" rx="28" ry="28" fill="${accent}"/>`
-    : '';
-  const lines = VL_APERTURE_LINES
-    .map(([x1, y1, x2, y2]) => `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}"/>`)
-    .join('');
+    : "";
+  const lines = VL_APERTURE_LINES.map(
+    ([x1, y1, x2, y2]) => `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}"/>`,
+  ).join("");
   return `<svg width="${size}" height="${size}" viewBox="0 0 100 100"
       style="display:block;flex-shrink:0" aria-label="ViewLens"
       xmlns="http://www.w3.org/2000/svg">
@@ -47,11 +49,18 @@ function markSVG({ size = 40, filled = true, accent = 'var(--vl-accent)', face =
  * @param {string}  opts.color   - logotype base color
  * @param {string}  [opts.sub]   - optional subline text
  */
-function wordmarkHTML({ size = 22, gap = 11, accent = 'var(--vl-accent)', filled = true, color = 'var(--vl-ink)', sub } = {}) {
+function wordmarkHTML({
+  size = 22,
+  gap = 11,
+  accent = "var(--vl-accent)",
+  filled = true,
+  color = "var(--vl-ink)",
+  sub,
+} = {}) {
   const markSize = Math.round(size * 1.55);
   const subLine = sub
     ? `<span style="margin-top:5px;font-family:'JetBrains Mono',monospace;font-weight:500;font-size:${size * 0.42}px;letter-spacing:0.14em;text-transform:uppercase;color:var(--vl-ink-3)">${sub}</span>`
-    : '';
+    : "";
   return `<div style="display:flex;align-items:center;gap:${gap}px">
     ${markSVG({ size: markSize, filled, accent })}
     <div style="display:flex;flex-direction:column;line-height:1">

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -412,16 +412,21 @@ async function boot() {
     },
   });
 
+  // 로컬 캐시 — storage.onChanged로 갱신, setInterval에서는 캐시만 읽음
+  let localCurrentSession = stored.currentSession || null;
+  let localLastWatchedAt = stored.lastWatchedAt || null;
+
   // sessions가 바뀌면(분석 완료, 리뷰 저장 등) 즉시 today 데이터를 갱신하고 re-render
-  chrome.storage.onChanged.addListener(async (changes, area) => {
-    if (area !== "local" || !changes.sessions) return;
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "local") return;
+    if (changes.currentSession) localCurrentSession = changes.currentSession.newValue || null;
+    if (changes.lastWatchedAt) localLastWatchedAt = changes.lastWatchedAt.newValue || null;
+    if (!changes.sessions) return;
     const updatedSessions = changes.sessions.newValue || [];
     VL._allSessions = updatedSessions;
-    const { currentSession: cs, lastWatchedAt: lwa } =
-      await chrome.storage.local.get(["currentSession", "lastWatchedAt"]);
     const freshToday = buildDataForDate(updatedSessions, new Date());
-    freshToday.collectingCount = cs?.videos?.length ?? 0;
-    freshToday.collectingTimer = _computeTimerText(lwa);
+    freshToday.collectingCount = localCurrentSession?.videos?.length ?? 0;
+    freshToday.collectingTimer = _computeTimerText(localLastWatchedAt);
     VL.today = freshToday;
     if (installDate) {
       VL.weeks = buildWeeksData(updatedSessions, installDate);
@@ -430,19 +435,14 @@ async function boot() {
     popup.render();
   });
 
-  // 수집 중 표시 실시간 업데이트 (1초 간격)
-  // 수집 상태가 바뀌면 popup 전체를 re-render해서 DOM 엘리먼트를 생성/제거
+  // 수집 중 표시 실시간 업데이트 (1초 간격) — 캐시된 로컬 변수만 참조
   let prevIsCollecting = collectingCount > 0 || !!realToday.collectingTimer;
 
-  setInterval(async () => {
-    const { currentSession, lastWatchedAt } = await chrome.storage.local.get([
-      "currentSession",
-      "lastWatchedAt",
-    ]);
-    VL._lastWatchedAt = lastWatchedAt || null;
+  setInterval(() => {
+    VL._lastWatchedAt = localLastWatchedAt;
 
-    const count = currentSession?.videos?.length ?? 0;
-    const timerText = _computeTimerText(lastWatchedAt);
+    const count = localCurrentSession?.videos?.length ?? 0;
+    const timerText = _computeTimerText(localLastWatchedAt);
     const isNowCollecting = count > 0 || !!timerText;
 
     if (isNowCollecting !== prevIsCollecting) {
@@ -462,7 +462,7 @@ async function boot() {
 
     countEl.textContent = count > 0 ? `영상 ${count}개 수집 중` : "분석 중...";
     timerEl.textContent =
-      timerText || (lastWatchedAt ? "피드백 생성 중..." : "");
+      timerText || (localLastWatchedAt ? "피드백 생성 중..." : "");
   }, 1000);
 }
 

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -1,4 +1,7 @@
 const EXPERIMENT_DAYS = 21;
+
+window.buildDataForDate = buildDataForDate;
+window.koreanDateLabel = koreanDateLabel;
 const DEFAULT_TONE = "indigo";
 
 // ── Category name (Korean) → VL short key ─────────────────────────────────────
@@ -110,7 +113,7 @@ function buildDataForDate(allSessions, targetDate) {
 
   const sourceSessions = todaySess;
 
-  const sourceDate = new Date(sourceSessions[0].endTime);
+  const sourceDate = targetDate;
   const sourceDateStr = dateStr(sourceDate);
   const distObj = mergeDist(sourceSessions);
   const distArr = VL.dist(distObj);
@@ -340,7 +343,10 @@ async function boot() {
 
   // Inject real data into VL globals before popup renders
   const collectingCount = stored.currentSession?.videos?.length ?? 0;
-  const realToday = buildTodayData(sessions);
+  VL._allSessions = sessions;
+  VL._installDate = installDate;
+
+  const realToday = buildDataForDate(sessions, new Date());
   realToday.collectingCount = collectingCount;
   VL.today = realToday;
 

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -83,8 +83,8 @@ function topKey(sess) {
 
 // ── Build VL.today ────────────────────────────────────────────────────────────
 
-function buildTodayData(allSessions) {
-  const todayStr = dateStr(new Date());
+function buildDataForDate(allSessions, targetDate) {
+  const todayStr = dateStr(targetDate);
 
   const todaySess = allSessions.filter(
     (s) =>
@@ -97,7 +97,7 @@ function buildTodayData(allSessions) {
   if (todaySess.length === 0) {
     return {
       isEmpty: true,
-      dateLabel: koreanDateLabel(new Date()),
+      dateLabel: koreanDateLabel(targetDate),
       videoCount: 0,
       sessionCount: 0,
       dist: [],
@@ -330,6 +330,7 @@ async function boot() {
     "sessions",
     "tone",
     "dark",
+    "currentSession",
   ]);
 
   const sessions = stored.sessions || [];
@@ -338,8 +339,10 @@ async function boot() {
   const darkMode = !!stored.dark;
 
   // Inject real data into VL globals before popup renders
+  const collectingCount = stored.currentSession?.videos?.length ?? 0;
   const realToday = buildTodayData(sessions);
-  if (realToday) VL.today = realToday;
+  realToday.collectingCount = collectingCount;
+  VL.today = realToday;
 
   if (installDate) {
     VL.weeks = buildWeeksData(sessions, installDate);

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -367,7 +367,9 @@ async function boot() {
     timelineKey: calcTimelineKey(installDate),
     onChange: async ({ onboarded: ob, group: g }) => {
       if (ob && g) {
+        const { anonymousId } = await chrome.storage.local.get('anonymousId');
         await chrome.storage.local.set({
+          anonymousId: anonymousId || crypto.randomUUID(),
           group: g,
           installDate: new Date().toISOString(),
           surveyStatus: { week1: false, week2: false, week3: false },
@@ -375,6 +377,28 @@ async function boot() {
       }
     },
   });
+
+  // 수집 중 배너 실시간 업데이트 (1초 간격)
+  const TIMEOUT_MS = 10 * 60 * 1000;
+  setInterval(async () => {
+    const countEl = document.getElementById("vl-collecting-count");
+    const timerEl = document.getElementById("vl-collecting-timer");
+    if (!countEl || !timerEl) return;
+
+    const { currentSession, lastWatchedAt } = await chrome.storage.local.get(["currentSession", "lastWatchedAt"]);
+    const count = currentSession?.videos?.length ?? 0;
+    countEl.textContent = `영상 ${count}개 수집 중`;
+
+    if (lastWatchedAt) {
+      const elapsed = Date.now() - new Date(lastWatchedAt).getTime();
+      const remaining = Math.max(0, TIMEOUT_MS - elapsed);
+      const mins = Math.floor(remaining / 60000);
+      const secs = Math.floor((remaining % 60000) / 1000);
+      timerEl.textContent = remaining > 0
+        ? `분석까지 ${mins}분 ${String(secs).padStart(2, "0")}초`
+        : "분석 중...";
+    }
+  }, 1000);
 }
 
 boot().catch((err) => {

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -334,6 +334,7 @@ async function boot() {
     "tone",
     "dark",
     "currentSession",
+    "lastWatchedAt",
   ]);
 
   const sessions = stored.sessions || [];
@@ -345,9 +346,11 @@ async function boot() {
   const collectingCount = stored.currentSession?.videos?.length ?? 0;
   VL._allSessions = sessions;
   VL._installDate = installDate;
+  VL._lastWatchedAt = stored.lastWatchedAt || null;
 
   const realToday = buildDataForDate(sessions, new Date());
   realToday.collectingCount = collectingCount;
+  realToday.collectingTimer = _computeTimerText(stored.lastWatchedAt);
   VL.today = realToday;
 
   if (installDate) {
@@ -389,27 +392,44 @@ async function boot() {
     },
   });
 
-  // 수집 중 배너 실시간 업데이트 (1초 간격)
-  const TIMEOUT_MS = 10 * 60 * 1000;
+  // 수집 중 표시 실시간 업데이트 (1초 간격)
+  // 수집 상태가 바뀌면 popup 전체를 re-render해서 DOM 엘리먼트를 생성/제거
+  let prevIsCollecting = collectingCount > 0 || !!realToday.collectingTimer;
+
   setInterval(async () => {
+    const { currentSession, lastWatchedAt } = await chrome.storage.local.get(["currentSession", "lastWatchedAt"]);
+    VL._lastWatchedAt = lastWatchedAt || null;
+
+    const count = currentSession?.videos?.length ?? 0;
+    const timerText = _computeTimerText(lastWatchedAt);
+    const isNowCollecting = count > 0 || !!timerText;
+
+    if (isNowCollecting !== prevIsCollecting) {
+      prevIsCollecting = isNowCollecting;
+      VL.today = { ...VL.today, collectingCount: count, collectingTimer: timerText };
+      popup.render();
+      return;
+    }
+
     const countEl = document.getElementById("vl-collecting-count");
     const timerEl = document.getElementById("vl-collecting-timer");
     if (!countEl || !timerEl) return;
 
-    const { currentSession, lastWatchedAt } = await chrome.storage.local.get(["currentSession", "lastWatchedAt"]);
-    const count = currentSession?.videos?.length ?? 0;
-    countEl.textContent = `영상 ${count}개 수집 중`;
-
-    if (lastWatchedAt) {
-      const elapsed = Date.now() - new Date(lastWatchedAt).getTime();
-      const remaining = Math.max(0, TIMEOUT_MS - elapsed);
-      const mins = Math.floor(remaining / 60000);
-      const secs = Math.floor((remaining % 60000) / 1000);
-      timerEl.textContent = remaining > 0
-        ? `분석까지 ${mins}분 ${String(secs).padStart(2, "0")}초`
-        : "분석 중...";
-    }
+    countEl.textContent = count > 0 ? `영상 ${count}개 수집 중` : "분석 중...";
+    timerEl.textContent = timerText || (lastWatchedAt ? "피드백 생성 중..." : "");
   }, 1000);
+}
+
+const COLLECTING_TIMEOUT_MS = 10 * 60 * 1000;
+
+function _computeTimerText(lastWatchedAt) {
+  if (!lastWatchedAt) return "";
+  const elapsed = Date.now() - new Date(lastWatchedAt).getTime();
+  const remaining = Math.max(0, COLLECTING_TIMEOUT_MS - elapsed);
+  if (remaining <= 0) return "";
+  const mins = Math.floor(remaining / 60000);
+  const secs = Math.floor((remaining % 60000) / 1000);
+  return `피드백까지 ${mins}분 ${String(secs).padStart(2, "0")}초`;
 }
 
 boot().catch((err) => {

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -124,7 +124,7 @@ function buildDataForDate(allSessions, targetDate) {
   const review =
     sourceSessions.at(-1)?.review ||
     "시청 패턴을 분석하고 있어요. 잠시 후 코치 노트가 업데이트돼요.";
-  const reviewTopic = sourceSessions.at(-1)?.reviewTopic || '';
+  const reviewTopic = sourceSessions.at(-1)?.reviewTopic || "";
 
   const videos = sourceSessions
     .flatMap((sess) => {
@@ -335,7 +335,26 @@ async function boot() {
     "dark",
     "currentSession",
     "lastWatchedAt",
+    "anonymousId",
+    "serverUrl",
   ]);
+
+  // 이미 온보딩된 사용자 중 anonymousId가 없는 경우 생성
+  if (stored.group && !stored.anonymousId) {
+    stored.anonymousId = crypto.randomUUID();
+    await chrome.storage.local.set({ anonymousId: stored.anonymousId });
+    if (stored.serverUrl && !stored.serverUrl.startsWith("YOUR_")) {
+      fetch(`${stored.serverUrl.replace(/\/$/, "")}/api/participants`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          anonymousId: stored.anonymousId,
+          group_code: stored.group,
+          installDate: stored.installDate,
+        }),
+      }).catch(() => {});
+    }
+  }
 
   const sessions = stored.sessions || [];
   const installDate = stored.installDate || null;
@@ -370,7 +389,8 @@ async function boot() {
     timelineKey: calcTimelineKey(installDate),
     onChange: async ({ onboarded: ob, group: g }) => {
       if (ob && g) {
-        const { anonymousId: existing, serverUrl } = await chrome.storage.local.get(['anonymousId', 'serverUrl']);
+        const { anonymousId: existing, serverUrl } =
+          await chrome.storage.local.get(["anonymousId", "serverUrl"]);
         const anonymousId = existing || crypto.randomUUID();
         const installDate = new Date().toISOString();
 
@@ -392,12 +412,33 @@ async function boot() {
     },
   });
 
+  // sessions가 바뀌면(분석 완료, 리뷰 저장 등) 즉시 today 데이터를 갱신하고 re-render
+  chrome.storage.onChanged.addListener(async (changes, area) => {
+    if (area !== "local" || !changes.sessions) return;
+    const updatedSessions = changes.sessions.newValue || [];
+    VL._allSessions = updatedSessions;
+    const { currentSession: cs, lastWatchedAt: lwa } =
+      await chrome.storage.local.get(["currentSession", "lastWatchedAt"]);
+    const freshToday = buildDataForDate(updatedSessions, new Date());
+    freshToday.collectingCount = cs?.videos?.length ?? 0;
+    freshToday.collectingTimer = _computeTimerText(lwa);
+    VL.today = freshToday;
+    if (installDate) {
+      VL.weeks = buildWeeksData(updatedSessions, installDate);
+      VL.baselineH = VL.weeks[0]?.entropy ?? 0;
+    }
+    popup.render();
+  });
+
   // 수집 중 표시 실시간 업데이트 (1초 간격)
   // 수집 상태가 바뀌면 popup 전체를 re-render해서 DOM 엘리먼트를 생성/제거
   let prevIsCollecting = collectingCount > 0 || !!realToday.collectingTimer;
 
   setInterval(async () => {
-    const { currentSession, lastWatchedAt } = await chrome.storage.local.get(["currentSession", "lastWatchedAt"]);
+    const { currentSession, lastWatchedAt } = await chrome.storage.local.get([
+      "currentSession",
+      "lastWatchedAt",
+    ]);
     VL._lastWatchedAt = lastWatchedAt || null;
 
     const count = currentSession?.videos?.length ?? 0;
@@ -406,7 +447,11 @@ async function boot() {
 
     if (isNowCollecting !== prevIsCollecting) {
       prevIsCollecting = isNowCollecting;
-      VL.today = { ...VL.today, collectingCount: count, collectingTimer: timerText };
+      VL.today = {
+        ...VL.today,
+        collectingCount: count,
+        collectingTimer: timerText,
+      };
       popup.render();
       return;
     }
@@ -416,7 +461,8 @@ async function boot() {
     if (!countEl || !timerEl) return;
 
     countEl.textContent = count > 0 ? `영상 ${count}개 수집 중` : "분석 중...";
-    timerEl.textContent = timerText || (lastWatchedAt ? "피드백 생성 중..." : "");
+    timerEl.textContent =
+      timerText || (lastWatchedAt ? "피드백 생성 중..." : "");
   }, 1000);
 }
 

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -94,40 +94,21 @@ function buildTodayData(allSessions) {
       Object.keys(s.categoryDistribution).length > 0,
   );
 
-  // Fallback to last available day if today has no data
-  const sourceSessions =
-    todaySess.length > 0
-      ? todaySess
-      : (() => {
-          const analyzed = allSessions
-            .filter(
-              (s) =>
-                s.endTime &&
-                s.categoryDistribution &&
-                Object.keys(s.categoryDistribution).length > 0,
-            )
-            .sort((a, b) => new Date(b.endTime) - new Date(a.endTime));
-          if (analyzed.length === 0) return [];
-          const lastDate = dateStr(new Date(analyzed[0].endTime));
-          return analyzed.filter(
-            (s) => dateStr(new Date(s.endTime)) === lastDate,
-          );
-        })();
-
-  if (sourceSessions.length === 0) {
-    // No data at all — return placeholder
+  if (todaySess.length === 0) {
     return {
+      isEmpty: true,
       dateLabel: koreanDateLabel(new Date()),
       videoCount: 0,
       sessionCount: 0,
-      dist: VL.dist({ etc: 1 }),
+      dist: [],
       prevEntropy: 0,
       prevDateLabel: "—",
       videos: [],
-      review:
-        "아직 분석된 시청 기록이 없어요. YouTube를 시청하면 세션이 자동으로 분석돼요.",
+      review: "",
     };
   }
+
+  const sourceSessions = todaySess;
 
   const sourceDate = new Date(sourceSessions[0].endTime);
   const sourceDateStr = dateStr(sourceDate);

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -367,13 +367,24 @@ async function boot() {
     timelineKey: calcTimelineKey(installDate),
     onChange: async ({ onboarded: ob, group: g }) => {
       if (ob && g) {
-        const { anonymousId } = await chrome.storage.local.get('anonymousId');
+        const { anonymousId: existing, serverUrl } = await chrome.storage.local.get(['anonymousId', 'serverUrl']);
+        const anonymousId = existing || crypto.randomUUID();
+        const installDate = new Date().toISOString();
+
         await chrome.storage.local.set({
-          anonymousId: anonymousId || crypto.randomUUID(),
+          anonymousId,
           group: g,
-          installDate: new Date().toISOString(),
+          installDate,
           surveyStatus: { week1: false, week2: false, week3: false },
         });
+
+        if (serverUrl && !serverUrl.startsWith("YOUR_")) {
+          fetch(`${serverUrl.replace(/\/$/, "")}/api/participants`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ anonymousId, group_code: g, installDate }),
+          }).catch(() => {});
+        }
       }
     },
   });

--- a/extension/viewlens-popup.js
+++ b/extension/viewlens-popup.js
@@ -123,7 +123,7 @@ function buildDataForDate(allSessions, targetDate) {
   );
   const review =
     sourceSessions.at(-1)?.review ||
-    "시청 패턴을 분석하고 있어요. 잠시 후 코치 노트가 업데이트돼요.";
+    "시청 패턴을 분석하고 있어요. 잠시 후 시청 분석이 업데이트돼요.";
   const reviewTopic = sourceSessions.at(-1)?.reviewTopic || "";
 
   const videos = sourceSessions

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -39,7 +39,7 @@ function screenOnboarding() {
           ${_lockIcon(9)}
         </div>
         <p style="margin:0;font-size:11.5px;line-height:1.55;color:var(--vl-ink-2);text-wrap:pretty">
-          시청 기록은 기기 안에만 저장돼요. 연구에는 카테고리 분포와 다양성 점수 같은 분석 결과만 익명으로 쓰여요.
+          시청 기록은 익명으로 저장됩니다. 누가 어떤 영상을 봤는지는 특정되지 않으며, 수집된 데이터는 오직 연구 목적으로만 사용됩니다.
         </p>
       </div>
     </div>
@@ -111,9 +111,13 @@ function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
       </div>
       <div>
         <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "아직 오늘 시청 기록이 없어요" : "이 날 시청 기록이 없어요"}</div>
-        ${isToday ? `<p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
+        ${
+          isToday
+            ? `<p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
           유튜브를 시청하면 자동으로 수집이 시작돼요.<br>시청 종료 10분 후 분석 결과가 나타나요.
-        </p>` : ""}
+        </p>`
+            : ""
+        }
       </div>
       <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--vl-ink-3)">${dateLabel}</div>
     </div>
@@ -141,16 +145,24 @@ function screenToday() {
     )
     .join("");
 
-  const isToday = d.dateLabel === new Date().toLocaleDateString("ko-KR", { month: "long", day: "numeric", weekday: "long" });
+  const isToday =
+    d.dateLabel ===
+    new Date().toLocaleDateString("ko-KR", {
+      month: "long",
+      day: "numeric",
+      weekday: "long",
+    });
   const isCollecting = d.collectingCount > 0 || !!d.collectingTimer;
-  const collectingRow = isCollecting ? `
+  const collectingRow = isCollecting
+    ? `
     <div style="display:flex;align-items:center;gap:6px">
       <span style="width:6px;height:6px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
       <div style="display:flex;flex-direction:column;gap:1px">
         <span id="vl-collecting-count" style="font-size:11.5px;font-weight:600;color:var(--vl-accent)">${d.collectingCount > 0 ? `영상 ${d.collectingCount}개 수집 중` : "분석 중..."}</span>
         <span id="vl-collecting-timer" style="font-size:10.5px;color:var(--vl-accent);opacity:0.8">${d.collectingTimer || ""}</span>
       </div>
-    </div>` : "";
+    </div>`
+    : "";
   return `<div style="display:flex;flex-direction:column">
     <div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
     <div style="display:flex;align-items:center;justify-content:space-between">

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -145,13 +145,7 @@ function screenToday() {
     )
     .join("");
 
-  const isToday =
-    d.dateLabel ===
-    new Date().toLocaleDateString("ko-KR", {
-      month: "long",
-      day: "numeric",
-      weekday: "long",
-    });
+  const isToday = d.dateLabel === koreanDateLabel(new Date());
   const isCollecting = d.collectingCount > 0 || !!d.collectingTimer;
   const collectingRow = isCollecting
     ? `

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -80,28 +80,40 @@ function bindOnboarding(root, onSubmit) {
 
 // ── Today ─────────────────────────────────────────────────────────────────────
 
-function screenTodayEmpty(dateLabel) {
-  return `<div style="padding:40px 24px;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:400px;text-align:center;gap:20px">
-    <div style="position:relative;width:80px;height:80px">
-      <span style="position:absolute;inset:0;border-radius:50%;background:var(--vl-accent-soft);animation:vlPulse 2.4s ease-out infinite"></span>
-      <span style="position:absolute;inset:0;border-radius:50%;border:2px solid var(--vl-accent);opacity:0.4;animation:vlPulse 2.4s ease-out infinite 0.6s"></span>
-      <span style="position:absolute;inset:0;display:grid;place-items:center">
-        ${markSVG({ size: 36, filled: false, accent: "var(--vl-accent)" })}
-      </span>
+function _collectingBanner(count) {
+  if (!count) return "";
+  return `<div style="display:flex;align-items:center;gap:9px;padding:10px 16px;background:var(--vl-accent-soft);border-bottom:1px solid var(--vl-line)">
+    <span style="width:7px;height:7px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
+    <span style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">현재 세션 수집 중 · 영상 ${count}개</span>
+    <span style="margin-left:auto;font-size:11px;color:var(--vl-accent);opacity:0.7">종료 10분 후 분석</span>
+  </div>`;
+}
+
+function screenTodayEmpty(dateLabel, collectingCount) {
+  return `<div style="display:flex;flex-direction:column;min-height:100%">
+    ${_collectingBanner(collectingCount)}
+    <div style="flex:1;padding:40px 24px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:20px">
+      <div style="position:relative;width:80px;height:80px">
+        <span style="position:absolute;inset:0;border-radius:50%;background:var(--vl-accent-soft);animation:vlPulse 2.4s ease-out infinite"></span>
+        <span style="position:absolute;inset:0;border-radius:50%;border:2px solid var(--vl-accent);opacity:0.4;animation:vlPulse 2.4s ease-out infinite 0.6s"></span>
+        <span style="position:absolute;inset:0;display:grid;place-items:center">
+          ${markSVG({ size: 36, filled: false, accent: "var(--vl-accent)" })}
+        </span>
+      </div>
+      <div>
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">아직 오늘 시청 기록이 없어요</div>
+        <p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
+          유튜브를 시청하면 자동으로 수집이 시작돼요.<br>시청 종료 10분 후 분석 결과가 나타나요.
+        </p>
+      </div>
+      <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--vl-ink-3)">${dateLabel}</div>
     </div>
-    <div>
-      <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">아직 오늘 시청 기록이 없어요</div>
-      <p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
-        유튜브를 시청하면 자동으로 수집이 시작돼요.<br>시청 종료 10분 후 분석 결과가 나타나요.
-      </p>
-    </div>
-    <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--vl-ink-3)">${dateLabel}</div>
   </div>`;
 }
 
 function screenToday() {
   const d = VL.today;
-  if (d.isEmpty) return screenTodayEmpty(d.dateLabel);
+  if (d.isEmpty) return screenTodayEmpty(d.dateLabel, d.collectingCount);
   const h = VL.entropy(d.dist);
   const delta = h - d.prevEntropy;
 
@@ -117,7 +129,9 @@ function screenToday() {
     )
     .join("");
 
-  return `<div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
+  return `<div style="display:flex;flex-direction:column">
+    ${_collectingBanner(d.collectingCount)}
+    <div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
     <div style="display:flex;align-items:baseline;justify-content:space-between">
       <div>
         <div style="font-size:17px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">오늘의 시청</div>
@@ -163,6 +177,7 @@ function screenToday() {
     })}
 
     ${vlReview({ text: d.review, topic: d.reviewTopic, videos: d.videos })}
+  </div>
   </div>`;
 }
 

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -89,10 +89,15 @@ function _collectingBanner(count) {
   </div>`;
 }
 
-function screenTodayEmpty(dateLabel, collectingCount) {
+function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
   return `<div style="display:flex;flex-direction:column;min-height:100%">
     ${_collectingBanner(collectingCount)}
-    <div style="flex:1;padding:40px 24px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:20px">
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px 0">
+      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
+      <div style="font-size:13px;font-weight:700;color:var(--vl-ink-2)">${isToday ? "오늘" : dateLabel}</div>
+      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
+    </div>
+    <div style="flex:1;padding:24px 24px 40px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:20px">
       <div style="position:relative;width:80px;height:80px">
         <span style="position:absolute;inset:0;border-radius:50%;background:var(--vl-accent-soft);animation:vlPulse 2.4s ease-out infinite"></span>
         <span style="position:absolute;inset:0;border-radius:50%;border:2px solid var(--vl-accent);opacity:0.4;animation:vlPulse 2.4s ease-out infinite 0.6s"></span>
@@ -101,10 +106,10 @@ function screenTodayEmpty(dateLabel, collectingCount) {
         </span>
       </div>
       <div>
-        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">아직 오늘 시청 기록이 없어요</div>
-        <p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "아직 오늘 시청 기록이 없어요" : "이 날 시청 기록이 없어요"}</div>
+        ${isToday ? `<p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
           유튜브를 시청하면 자동으로 수집이 시작돼요.<br>시청 종료 10분 후 분석 결과가 나타나요.
-        </p>
+        </p>` : ""}
       </div>
       <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--vl-ink-3)">${dateLabel}</div>
     </div>
@@ -113,7 +118,10 @@ function screenTodayEmpty(dateLabel, collectingCount) {
 
 function screenToday() {
   const d = VL.today;
-  if (d.isEmpty) return screenTodayEmpty(d.dateLabel, d.collectingCount);
+  if (d.isEmpty) {
+    const isToday = d.dateLabel === koreanDateLabel(new Date());
+    return screenTodayEmpty(d.dateLabel, d.collectingCount, isToday);
+  }
   const h = VL.entropy(d.dist);
   const delta = h - d.prevEntropy;
 
@@ -129,14 +137,20 @@ function screenToday() {
     )
     .join("");
 
+  const isToday = d.dateLabel === new Date().toLocaleDateString("ko-KR", { month: "long", day: "numeric", weekday: "long" });
   return `<div style="display:flex;flex-direction:column">
     ${_collectingBanner(d.collectingCount)}
     <div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
+    <div style="display:flex;align-items:center;justify-content:space-between">
+      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
+      <div style="text-align:center">
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "오늘의 시청" : d.dateLabel}</div>
+        ${isToday ? `<div style="font-size:12px;color:var(--vl-ink-3);margin-top:2px">${d.dateLabel}</div>` : ""}
+      </div>
+      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
+    </div>
     <div style="display:flex;align-items:baseline;justify-content:space-between">
       <div>
-        <div style="font-size:17px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">오늘의 시청</div>
-        <div style="font-size:12px;color:var(--vl-ink-3);margin-top:2px">${d.dateLabel}</div>
-      </div>
       ${vlBadge({ text: `${d.videoCount}개 영상 · ${d.dist.length}개 분야`, tone: "neutral" })}
     </div>
 

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -307,7 +307,7 @@ function screenFeedback(currentWeek, selWeek) {
     `,
     })}
 
-    ${vlReview({ text: w.review, title: `${w.label} 코치 노트` })}
+    ${vlReview({ text: w.review, title: `${w.label} 돌아보기` })}
   </div>`;
 }
 

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -15,17 +15,17 @@ function screenOnboarding() {
         View<span style="color:var(--vl-accent)">Lens</span>
       </div>
       <p style="margin:10px 0 0;font-size:13.5px;line-height:1.6;color:var(--vl-ink-2);max-width:260px;text-wrap:pretty">
-        내 유튜브 시청 편향을 비춰 보는 연구용 렌즈예요. 시작하려면 연구자에게 받은 참여 코드를 입력해 주세요.
+        추천 알고리즘을 너머 당신의 시청 습관을 돌아봅니다. 연구자에게 받은 참여 코드를 입력하여 시작해 주세요.
       </p>
     </div>
 
     <div style="margin-top:30px">
-      <label style="font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--vl-ink-3)">참여 코드</label>
-      <input id="vl-onboard-input" value="" placeholder="예: EXP" spellcheck="false" autocomplete="off"
+      <label style="font-size:12px; font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--vl-ink-3)">참여 코드</label>
+      <input id="vl-onboard-input" value="" placeholder="연구자에게 받은 참여 코드" spellcheck="false" autocomplete="off"
         style="display:block;margin-top:9px;width:100%;box-sizing:border-box;padding:13px 15px;
           border:1.5px solid var(--vl-line-2);border-radius:13px;background:var(--vl-card-2);
-          color:var(--vl-ink);outline:none;font-family:'JetBrains Mono',monospace;
-          font-size:17px;font-weight:600;letter-spacing:0.22em;text-transform:uppercase"/>
+          color:var(--vl-ink);outline:none;
+          font-size:13px; letter-spacing:0.1em;text-transform:uppercase"/>
       <p id="vl-onboard-err" style="display:none;margin:9px 2px 0;font-size:12px;color:var(--vl-warn);line-height:1.5"></p>
       <button id="vl-onboard-btn"
         style="margin-top:14px;width:100%;padding:13px;border:none;border-radius:13px;
@@ -168,8 +168,7 @@ function screenToday() {
     <div style="display:flex;align-items:center;justify-content:space-between">
       <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
       <div style="text-align:center">
-        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "오늘의 시청" : d.dateLabel}</div>
-        ${isToday ? `<div style="font-size:12px;color:var(--vl-ink-3);margin-top:2px">${d.dateLabel}</div>` : ""}
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "오늘" : d.dateLabel}</div>
       </div>
       <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
     </div>

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -149,8 +149,7 @@ function screenToday() {
       </div>
       <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
     </div>
-    <div style="display:flex;align-items:baseline;justify-content:space-between">
-      <div>
+    <div style="display:flex;justify-content:flex-end">
       ${vlBadge({ text: `${d.videoCount}개 영상 · ${d.dist.length}개 분야`, tone: "neutral" })}
     </div>
 

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -82,10 +82,14 @@ function bindOnboarding(root, onSubmit) {
 
 function _collectingBanner(count) {
   if (!count) return "";
+  const timerText = VL.today?.collectingTimer || "";
   return `<div id="vl-collecting-banner" style="display:flex;align-items:center;gap:9px;padding:10px 16px;background:var(--vl-accent-soft);border-bottom:1px solid var(--vl-line)">
     <span style="width:7px;height:7px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
-    <span id="vl-collecting-count" style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">영상 ${count}개 수집 중</span>
-    <span id="vl-collecting-timer" style="margin-left:auto;font-size:11px;color:var(--vl-accent);opacity:0.7"></span>
+    <div style="flex:1;min-width:0">
+      <div id="vl-collecting-count" style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">영상 ${count}개 수집 중</div>
+      <div style="font-size:11px;color:var(--vl-accent);opacity:0.75;margin-top:1px">이 시간 안에 더 시청하지 않으면 피드백이 생성돼요</div>
+    </div>
+    <span id="vl-collecting-timer" style="font-size:11px;font-weight:600;color:var(--vl-accent);opacity:0.8;white-space:nowrap;flex-shrink:0">${timerText}</span>
   </div>`;
 }
 
@@ -138,8 +142,16 @@ function screenToday() {
     .join("");
 
   const isToday = d.dateLabel === new Date().toLocaleDateString("ko-KR", { month: "long", day: "numeric", weekday: "long" });
+  const isCollecting = d.collectingCount > 0 || !!d.collectingTimer;
+  const collectingRow = isCollecting ? `
+    <div style="display:flex;align-items:center;gap:6px">
+      <span style="width:6px;height:6px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
+      <div style="display:flex;flex-direction:column;gap:1px">
+        <span id="vl-collecting-count" style="font-size:11.5px;font-weight:600;color:var(--vl-accent)">${d.collectingCount > 0 ? `영상 ${d.collectingCount}개 수집 중` : "분석 중..."}</span>
+        <span id="vl-collecting-timer" style="font-size:10.5px;color:var(--vl-accent);opacity:0.8">${d.collectingTimer || ""}</span>
+      </div>
+    </div>` : "";
   return `<div style="display:flex;flex-direction:column">
-    ${_collectingBanner(d.collectingCount)}
     <div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
     <div style="display:flex;align-items:center;justify-content:space-between">
       <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
@@ -149,7 +161,8 @@ function screenToday() {
       </div>
       <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
     </div>
-    <div style="display:flex;justify-content:flex-end">
+    <div style="display:flex;align-items:center;justify-content:space-between">
+      <div>${collectingRow}</div>
       ${vlBadge({ text: `${d.videoCount}개 영상 · ${d.dist.length}개 분야`, tone: "neutral" })}
     </div>
 

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -196,9 +196,6 @@ function screenToday() {
           <span style="font-size:11px;font-weight:700;color:${delta >= 0 ? "var(--vl-good)" : "var(--vl-warn)"}">${delta >= 0 ? "더 다양해졌어요" : "더 편중됐어요"}</span>
         </div>
       </div>
-      <p style="margin:11px 0 0;font-size:10.5px;color:var(--vl-ink-3);line-height:1.5">
-        매일 보지 않아도 괜찮아요 — 어제가 아니라 마지막으로 시청한 날과 비교해요.
-      </p>
     `,
     })}
 

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -82,10 +82,10 @@ function bindOnboarding(root, onSubmit) {
 
 function _collectingBanner(count) {
   if (!count) return "";
-  return `<div style="display:flex;align-items:center;gap:9px;padding:10px 16px;background:var(--vl-accent-soft);border-bottom:1px solid var(--vl-line)">
+  return `<div id="vl-collecting-banner" style="display:flex;align-items:center;gap:9px;padding:10px 16px;background:var(--vl-accent-soft);border-bottom:1px solid var(--vl-line)">
     <span style="width:7px;height:7px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
-    <span style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">현재 세션 수집 중 · 영상 ${count}개</span>
-    <span style="margin-left:auto;font-size:11px;color:var(--vl-accent);opacity:0.7">종료 10분 후 분석</span>
+    <span id="vl-collecting-count" style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">영상 ${count}개 수집 중</span>
+    <span id="vl-collecting-timer" style="margin-left:auto;font-size:11px;color:var(--vl-accent);opacity:0.7"></span>
   </div>`;
 }
 

--- a/extension/viewlens-screens.js
+++ b/extension/viewlens-screens.js
@@ -80,8 +80,28 @@ function bindOnboarding(root, onSubmit) {
 
 // ── Today ─────────────────────────────────────────────────────────────────────
 
+function screenTodayEmpty(dateLabel) {
+  return `<div style="padding:40px 24px;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:400px;text-align:center;gap:20px">
+    <div style="position:relative;width:80px;height:80px">
+      <span style="position:absolute;inset:0;border-radius:50%;background:var(--vl-accent-soft);animation:vlPulse 2.4s ease-out infinite"></span>
+      <span style="position:absolute;inset:0;border-radius:50%;border:2px solid var(--vl-accent);opacity:0.4;animation:vlPulse 2.4s ease-out infinite 0.6s"></span>
+      <span style="position:absolute;inset:0;display:grid;place-items:center">
+        ${markSVG({ size: 36, filled: false, accent: "var(--vl-accent)" })}
+      </span>
+    </div>
+    <div>
+      <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">아직 오늘 시청 기록이 없어요</div>
+      <p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
+        유튜브를 시청하면 자동으로 수집이 시작돼요.<br>시청 종료 10분 후 분석 결과가 나타나요.
+      </p>
+    </div>
+    <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--vl-ink-3)">${dateLabel}</div>
+  </div>`;
+}
+
 function screenToday() {
   const d = VL.today;
+  if (d.isEmpty) return screenTodayEmpty(d.dateLabel);
   const h = VL.entropy(d.dist);
   const delta = h - d.prevEntropy;
 

--- a/extension/viewlens-ui.js
+++ b/extension/viewlens-ui.js
@@ -183,16 +183,23 @@ function vlMiniLine({ data = [], baseline = null, height = 64 } = {}) {
   </svg>`;
 }
 
-function vlReview({ text = '', topic = '', title = '오늘의 코치 노트', videos = [] } = {}) {
+function vlReview({
+  text = "",
+  topic = "",
+  title = "오늘 돌아보기",
+  videos = [],
+} = {}) {
   const cats = VL.CATS;
 
   const topicBlock = topic
     ? `<p style="margin:0 0 10px;font-size:17px;font-weight:800;color:var(--vl-ink);line-height:1.4;letter-spacing:-0.02em;text-wrap:pretty">
         당신은 '<span style="color:var(--vl-accent)">${topic}</span>'에 관심이 많습니다!
       </p>`
-    : '';
+    : "";
 
-  const videoList = videos.length > 0 ? `
+  const videoList =
+    videos.length > 0
+      ? `
     <details class="vl-vid-details" style="margin-top:13px;padding-top:12px;border-top:1px solid color-mix(in oklab,var(--vl-accent) 18%,transparent)">
       <summary style="display:flex;align-items:center;justify-content:space-between;padding:2px 0;border-radius:6px;user-select:none">
         <span style="display:flex;align-items:center;gap:5px;font-size:11.5px;font-weight:600;color:var(--vl-accent)">
@@ -202,25 +209,30 @@ function vlReview({ text = '', topic = '', title = '오늘의 코치 노트', vi
         <span style="font-size:11px;font-family:'JetBrains Mono',monospace;color:var(--vl-ink-3)">${videos.length}개</span>
       </summary>
       <div style="margin-top:9px;display:flex;flex-direction:column;gap:6px">
-        ${videos.map(v => {
-          const color = (cats[v.cat] || {}).color || 'var(--vl-ink-3)';
-          const ytUrl = v.videoId ? `https://www.youtube.com/watch?v=${encodeURIComponent(v.videoId)}` : null;
-          const dot   = `<span style="width:7px;height:7px;border-radius:2.5px;background:${color};flex-shrink:0"></span>`;
-          const label = `<span style="font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0">${v.title}</span>`;
-          const base  = `display:flex;align-items:center;gap:8px;min-width:0`;
-          return ytUrl
-            ? `<a href="${ytUrl}" target="_blank" rel="noopener" class="vl-vid-link"
+        ${videos
+          .map((v) => {
+            const color = (cats[v.cat] || {}).color || "var(--vl-ink-3)";
+            const ytUrl = v.videoId
+              ? `https://www.youtube.com/watch?v=${encodeURIComponent(v.videoId)}`
+              : null;
+            const dot = `<span style="width:7px;height:7px;border-radius:2.5px;background:${color};flex-shrink:0"></span>`;
+            const label = `<span style="font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0">${v.title}</span>`;
+            const base = `display:flex;align-items:center;gap:8px;min-width:0`;
+            return ytUrl
+              ? `<a href="${ytUrl}" target="_blank" rel="noopener" class="vl-vid-link"
                 style="${base};text-decoration:none;color:var(--vl-ink);padding:3px 4px;border-radius:6px"
               >${dot}${label}</a>`
-            : `<div style="${base};padding:3px 4px">${dot}${label}</div>`;
-        }).join('')}
+              : `<div style="${base};padding:3px 4px">${dot}${label}</div>`;
+          })
+          .join("")}
       </div>
     </details>
-  ` : '';
+  `
+      : "";
 
   return `<div style="background:var(--vl-accent-soft);border:1px solid color-mix(in oklab,var(--vl-accent) 22%,transparent);border-radius:16px;padding:15px">
     <div style="display:flex;align-items:center;gap:7px;margin-bottom:9px">
-      ${markSVG({ size: 18, filled: false, accent: 'var(--vl-accent)' })}
+      ${markSVG({ size: 18, filled: false, accent: "var(--vl-accent)" })}
       <span style="font-size:12.5px;font-weight:700;color:var(--vl-accent)">${title}</span>
     </div>
     ${topicBlock}

--- a/server/app.js
+++ b/server/app.js
@@ -18,6 +18,7 @@ app.get("/health", (_req, res) => {
 
 app.use("/api/sessions", require("./routes/sessions"));
 app.use("/api/surveys", require("./routes/surveys"));
+app.use("/api/video-events", require("./routes/video-events"));
 
 app.use(errorHandler);
 

--- a/server/app.js
+++ b/server/app.js
@@ -16,6 +16,7 @@ app.get("/health", (_req, res) => {
   return success(res, { status: "healthy", timestamp: Date.now() });
 });
 
+app.use("/api/participants", require("./routes/participants"));
 app.use("/api/sessions", require("./routes/sessions"));
 app.use("/api/surveys", require("./routes/surveys"));
 app.use("/api/video-events", require("./routes/video-events"));

--- a/server/db.js
+++ b/server/db.js
@@ -19,6 +19,14 @@ function initializeDB() {
       createdAt            TEXT    DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS participants (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      anonymousId TEXT    NOT NULL UNIQUE,
+      group_code  TEXT    NOT NULL,
+      installDate TEXT    NOT NULL,
+      createdAt   TEXT    DEFAULT (datetime('now'))
+    );
+
     CREATE TABLE IF NOT EXISTS video_events (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
       anonymousId TEXT    NOT NULL,

--- a/server/db.js
+++ b/server/db.js
@@ -17,7 +17,16 @@ function initializeDB() {
       categoryDistribution TEXT,
       entropy              REAL,
       createdAt            TEXT    DEFAULT (datetime('now'))
-    )
+    );
+
+    CREATE TABLE IF NOT EXISTS video_events (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      anonymousId TEXT    NOT NULL,
+      videoId     TEXT    NOT NULL,
+      title       TEXT,
+      watchedAt   TEXT    NOT NULL,
+      createdAt   TEXT    DEFAULT (datetime('now'))
+    );
   `);
 }
 

--- a/server/routes/participants.js
+++ b/server/routes/participants.js
@@ -1,0 +1,37 @@
+const express = require("express");
+const { db } = require("../db");
+const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
+
+const router = express.Router();
+
+const insertParticipant = db.prepare(`
+  INSERT INTO participants (anonymousId, group_code, installDate)
+  VALUES (@anonymousId, @group_code, @installDate)
+`);
+
+router.post("/", (req, res, next) => {
+  const { anonymousId, group_code, installDate } = req.body;
+
+  for (const field of ["anonymousId", "group_code", "installDate"]) {
+    if (!req.body[field]?.toString().trim()) {
+      return fail(res, 400, ERROR_CODES.MISSING_REQUIRED_FIELD, `${field} 필드가 올바르지 않습니다.`, field);
+    }
+  }
+
+  if (isNaN(Date.parse(installDate))) {
+    return fail(res, 400, ERROR_CODES.INVALID_FIELD_VALUE, "installDate 필드가 올바르지 않습니다.", "installDate");
+  }
+
+  try {
+    insertParticipant.run({ anonymousId, group_code, installDate });
+  } catch (err) {
+    if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {
+      return success(res); // 이미 등록된 참여자면 무시
+    }
+    return next(err);
+  }
+
+  return success(res);
+});
+
+module.exports = router;

--- a/server/routes/participants.js
+++ b/server/routes/participants.js
@@ -13,7 +13,8 @@ router.post("/", (req, res, next) => {
   const { anonymousId, group_code, installDate } = req.body;
 
   for (const field of ["anonymousId", "group_code", "installDate"]) {
-    if (!req.body[field]?.toString().trim()) {
+    const value = req.body[field];
+    if (typeof value !== "string" || !value.trim()) {
       return fail(res, 400, ERROR_CODES.MISSING_REQUIRED_FIELD, `${field} 필드가 올바르지 않습니다.`, field);
     }
   }

--- a/server/routes/video-events.js
+++ b/server/routes/video-events.js
@@ -1,0 +1,34 @@
+const express = require("express");
+const { db } = require("../db");
+const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
+
+const router = express.Router();
+
+const insertEvent = db.prepare(`
+  INSERT INTO video_events (anonymousId, videoId, title, watchedAt)
+  VALUES (@anonymousId, @videoId, @title, @watchedAt)
+`);
+
+router.post("/", (req, res, next) => {
+  const { anonymousId, videoId, watchedAt, title } = req.body;
+
+  for (const field of ["anonymousId", "videoId", "watchedAt"]) {
+    if (!req.body[field]?.toString().trim()) {
+      return fail(res, 400, ERROR_CODES.MISSING_REQUIRED_FIELD, `${field} 필드가 올바르지 않습니다.`, field);
+    }
+  }
+
+  if (isNaN(Date.parse(watchedAt))) {
+    return fail(res, 400, ERROR_CODES.INVALID_FIELD_VALUE, "watchedAt 필드가 올바르지 않습니다.", "watchedAt");
+  }
+
+  try {
+    insertEvent.run({ anonymousId, videoId, title: title ?? null, watchedAt });
+  } catch (err) {
+    return next(err);
+  }
+
+  return success(res);
+});
+
+module.exports = router;

--- a/server/routes/video-events.js
+++ b/server/routes/video-events.js
@@ -13,7 +13,8 @@ router.post("/", (req, res, next) => {
   const { anonymousId, videoId, watchedAt, title } = req.body;
 
   for (const field of ["anonymousId", "videoId", "watchedAt"]) {
-    if (!req.body[field]?.toString().trim()) {
+    const value = req.body[field];
+    if (typeof value !== "string" || !value.trim()) {
       return fail(res, 400, ERROR_CODES.MISSING_REQUIRED_FIELD, `${field} 필드가 올바르지 않습니다.`, field);
     }
   }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
오늘의 시청 탭 UX를 전반적으로 개선하고, 연구 데이터 수집 파이프라인을 보강합니다. 참여자가 진행 상황을 직관적으로 파악할 수 있도록 실시간 정보를 강화하고, 서버와의 연동을 안정화합니다.  

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->
### UX / 팝업

- 오늘의 시청 탭에 날짜 네비게이션(이전/다음 날) 추가
- 오늘 시청 데이터가 없을 때 빈 화면 상태 표시
- 현재 세션에서 수집 중인 영상 수 실시간 표시
- 영상 수집 개수 및 피드백까지 남은 시간 카운트다운 표시
- 세션 분석 완료 후 팝업이 자동 갱신되지 않던 버그 수정
- 온보딩 문구 및 코드 입력창 스타일 개선, Today 헤더 단순화
- 뷰렌즈의 의미에 맞도록 코치노트 키워드 제거
- 불필요한 안내 문구 제거

### 백엔드 / 데이터 수집

- `participants` 테이블 추가 및 온보딩 시 서버에 참여자 등록
- 영상 시청 즉시 `video_events` DB에 기록 (세션 종료 전에도 데이터 보존)

### 안정성

- 세션 타임아웃 30분 → 10분으로 단축
- 서비스 워커 재시도 횟수 5회로 상향
- `sendWithRetry` 기본 딜레이 1000ms로 연장
- 릴리즈 시 `manifest.json` `host_permissions`에 `SERVER_URL` 자동 추가
- 날짜 네비 추가로 깨진 헤더 구조 수정
- 확장 프로그램 아이콘 재생성

## 관련 이슈

- closes #95 

## 테스트 확인

- [ ] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [ ] 콘솔 에러 없음

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->  

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3a2f17a8-4c19-4907-a5db-ddda2b334b11" />    

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/ce00c38b-9b23-4d65-a416-181dfb225e22" />    
 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bba241ed-4bd7-40ea-b1bd-afce90ec76bf" />    

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f51aeb9f-68bb-45c9-aef5-12aca3c26d0b" />    

<img width="300" alt="image" src="https://github.com/user-attachments/assets/75e7a561-3cbc-402a-9fc8-4a5d85025036" />  

<img width="300" alt="image" src="https://github.com/user-attachments/assets/68d1fb66-6237-4527-84ef-03379c83a9a0" />  

## 참고 사항

<!-- 특별히 전달할 내용 -->
- `video_events` 테이블은 기존 `sessions` 기반 저장 방식을 보완하는 조기 저장 경로로, 세션이 정상 종료되지 않아도 시청 이력이 보존됩니다.
- `participants` 서버 등록은 온보딩 완료 시 1회 호출되며, 중복 등록은 서버에서 무시합니다.
EOF
)"  
- 작업을 진행하면서 발견하는 오류를 수정하다보니 PR의 볼륨이 방대해졌습니다. 현재 DB에 사용자의 uuid에 따라 데이터가 생성되지 않는 이슈가 있어 이슈 분리하여 해결 예정입니다. 