### PR TITLE
feat: 서버 URL을 HTTPS 도메인으로 변경

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,7 +19,7 @@
       "128": "assets/icons/icon128.png"
     }
   },
-  "host_permissions": ["*://*.youtube.com/*", "*://generativelanguage.googleapis.com/*", "http://168.107.51.12/*"],
+  "host_permissions": ["*://*.youtube.com/*", "*://generativelanguage.googleapis.com/*", "http://217.142.128.179/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,7 +19,7 @@
       "128": "assets/icons/icon128.png"
     }
   },
-  "host_permissions": ["*://*.youtube.com/*", "*://generativelanguage.googleapis.com/*", "http://217.142.128.179/*"],
+  "host_permissions": ["*://*.youtube.com/*", "*://generativelanguage.googleapis.com/*", "https://viewlens.site/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->
서버 URL을 raw IP + HTTP에서 도메인 + HTTPS로 변경합니다.  

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->

- extension/config.js: SERVER_URL을 http://217.xxx.xxx.179:3000 → https://viewlens.site로 변경  
- extension/manifest.json: host_permissions를 http://217.xxx.xxx.179/* → https://viewlens.site/*로 변경  

## 관련 이슈

closes #

## 테스트 확인

- [ ] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [ ] 콘솔 에러 없음

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

## 참고 사항

<!-- 특별히 전달할 내용 -->
- Let's Encrypt 인증서 발급 완료 (만료일: 2026-09-19, 자동 갱신 설정됨)  
- Nginx 리버스 프록시로 443 → 3000 포워딩 구성  
- https://viewlens.site/health 200 응답 확인 완료  