### PR TITLE
Feat/102 entropy based feedback

### DIFF
--- a/docs/03-잔여작업.md
+++ b/docs/03-잔여작업.md
@@ -60,28 +60,28 @@ Epic 1–5의 기본 구현은 완료되었으며, 이 문서는 배포 전 완�
 
 #### Tasks
 
-- [ ] Oracle Cloud a1.flex 인스턴스 생성 및 환경 구성
+- [x] Oracle Cloud a1.flex 인스턴스 생성 및 환경 구성
   - Priority: High / Owner: BE
   - 내용: Ampere ARM a1.flex 인스턴스 생성. Node.js 설치, 방화벽 인바운드 규칙(포트 3000 또는 80/443) 설정, pnpm 설치
   - DoD: 인스턴스에 SSH 접속 가능하고 Node.js + pnpm이 동작한다.
   - Dependencies: Oracle Cloud 계정
   - 예상 소요: 2~3h
 
-- [ ] 기존 e.1 인스턴스 DB 마이그레이션
+- [x] 기존 e.1 인스턴스 DB 마이그레이션
   - Priority: High / Owner: BE
   - 내용: e.1 인스턴스의 `youtube_bias.db` 파일을 SCP로 a1 인스턴스로 복사. 마이그레이션 후 테이블 row 수 비교로 정합성 확인
   - DoD: a1 인스턴스 DB에 기존 세션/참여자/영상이벤트 데이터가 동일하게 존재한다.
   - Dependencies: a1 인스턴스 환경 구성 완료
   - 예상 소요: 1~2h
 
-- [ ] GitHub Actions CI/CD 파이프라인 타겟 서버 변경
+- [x] GitHub Actions CI/CD 파이프라인 타겟 서버 변경
   - Priority: Medium / Owner: BE
   - 내용: `.github/workflows/` 배포 스크립트의 SSH 호스트 및 IP를 a1 인스턴스로 변경. secrets 업데이트 후 자동 배포 테스트
   - DoD: `main` 브랜치 push 시 a1 인스턴스에 자동 배포되고 `/health`가 정상 응답한다.
   - Dependencies: a1 인스턴스 환경 구성 완료
   - 예상 소요: 1~2h
 
-- [ ] `config.js` SERVER_URL을 a1 인스턴스 URL로 업데이트
+- [x] `config.js` SERVER_URL을 a1 인스턴스 URL로 업데이트
   - Priority: High / Owner: FE
   - 내용: `extension/config.js`의 `SERVER_URL`을 새 a1 서버 URL로 변경. `config.example.js`도 동기화
   - DoD: 확장 프로그램이 새 서버 URL로 세션 데이터를 정상 전송한다.

--- a/docs/03-잔여작업.md
+++ b/docs/03-잔여작업.md
@@ -21,21 +21,21 @@ Epic 1–5의 기본 구현은 완료되었으며, 이 문서는 배포 전 완�
 
 #### Tasks
 
-- [ ] `background.js`에서 분석 시 직전 세션 entropy 조회 및 전달
+- [x] `background.js`에서 분석 시 직전 세션 entropy 조회 및 전달
   - Priority: High / Owner: FE
   - 내용: `analyzeSession()`에서 `getAllSessions()`로 직전 분석 완료 세션의 entropy를 조회하여 `buildPrompt()`에 `prevEntropy`로 전달
   - DoD: `analyzeSession()` 호출 시 직전 세션의 entropy 값이 프롬프트 생성 함수에 전달된다.
   - Dependencies: 없음
   - 예상 소요: 1~2h
 
-- [ ] `buildPrompt()`에 entropy 변화량 및 편중 경고 반영
+- [x] `buildPrompt()`에 entropy 변화량 및 편중 경고 반영
   - Priority: High / Owner: FE
   - 내용: `llm.js`의 `buildPrompt()`에 `prevEntropy` 파라미터 추가. 전 세션 대비 Δ entropy와 최다 카테고리 비율이 70% 이상일 때 편중 경고 신호를 프롬프트에 포함
   - DoD: 편향이 심화된 세션과 다양해진 세션에서 각기 다른 방향의 피드백이 생성된다.
   - Dependencies: `prevEntropy` 전달 완료
   - 예상 소요: 2~3h
 
-- [ ] `generateFallbackReview()` 개선
+- [x] `generateFallbackReview()` 개선
   - Priority: Medium / Owner: FE
   - 내용: Gemini API 실패 시 사용되는 `generateFallbackReview()`에도 entropy 변화 방향 반영. "다양한 카테고리 탐색해보세요" 수준에서 편향 변화를 언급하는 구체적인 문구로 개선
   - DoD: 폴백 피드백도 편향 심화/개선 여부를 반영한다.

--- a/extension/background.js
+++ b/extension/background.js
@@ -62,6 +62,16 @@ async function checkSessionTimeout() {
   await analyzeSession(session);
 }
 
+// 현재 세션을 제외하고, 분석이 완료된(entropy가 유한 숫자인) 가장 최근 세션의 entropy를 반환
+function findPrevEntropy(sessions, currentSessionId) {
+  for (let i = sessions.length - 1; i >= 0; i--) {
+    const s = sessions[i];
+    if (s.sessionId === currentSessionId) continue;
+    if (Number.isFinite(s.entropy)) return s.entropy;
+  }
+  return null;
+}
+
 async function analyzeSession(session) {
   const videoIds = session.videos.map((v) => v.videoId);
   const categoryMap = await fetchVideoCategories(videoIds);
@@ -72,16 +82,21 @@ async function analyzeSession(session) {
   const videoCount = session.videos.length;
   const videoTitles = session.videos.map((v) => v.title).filter(Boolean);
 
+  // saveAnalysis로 현재 세션에 entropy를 저장하기 전에 직전 세션 entropy를 조회
+  const allSessions = await getAllSessions();
+  const prevEntropy = findPrevEntropy(allSessions, session.sessionId);
+
   await saveAnalysis(session.sessionId, {
     categoryDistribution,
     entropy,
     videoCount,
   });
-  console.log("[background] 분석 완료:", { entropy, categoryDistribution });
+  console.log("[background] 분석 완료:", { entropy, prevEntropy, categoryDistribution });
 
   const analysisData = {
     categoryDistribution,
     entropy,
+    prevEntropy,
     videoCount,
     videoTitles,
   };

--- a/extension/pipeline/llm.js
+++ b/extension/pipeline/llm.js
@@ -11,6 +11,12 @@ const BIAS_WARN_RATIO = 0.7;
 // 변화 분석/편중 경고를 신뢰할 수 있는 최소 영상 수
 const MIN_VIDEOS_FOR_TREND = 5;
 
+// entropy는 소수점 둘째 자리로 반올림된 값(analysis.js)이므로, 부동소수점 오차로
+// 경계(예: 정확히 0.1) 판정이 빗나가지 않도록 차이값도 같은 정밀도로 반올림
+function roundedDelta(entropy, prevEntropy) {
+  return Math.round((entropy - prevEntropy) * 100) / 100;
+}
+
 // prevEntropy 및 편중 비율을 LLM에게 줄 자연어 지시로 번역
 function buildTrendGuidance({ entropy, prevEntropy, topRatio, videoCount }) {
   if (videoCount < MIN_VIDEOS_FOR_TREND) {
@@ -20,7 +26,7 @@ function buildTrendGuidance({ entropy, prevEntropy, topRatio, videoCount }) {
   const lines = [];
 
   if (Number.isFinite(prevEntropy)) {
-    const delta = entropy - prevEntropy;
+    const delta = roundedDelta(entropy, prevEntropy);
     if (delta >= ENTROPY_DELTA_EPS) {
       lines.push('- 직전 세션보다 시청 다양성이 늘었습니다. 긍정적으로 격려하는 톤으로 작성해 주세요.');
     } else if (delta <= -ENTROPY_DELTA_EPS) {
@@ -138,7 +144,7 @@ export function generateFallbackReview({ categoryDistribution, entropy, prevEntr
   let recommendation = '';
   if (videoCount >= MIN_VIDEOS_FOR_TREND) {
     const hasPrev = Number.isFinite(prevEntropy);
-    const delta = hasPrev ? entropy - prevEntropy : 0;
+    const delta = hasPrev ? roundedDelta(entropy, prevEntropy) : 0;
 
     if (hasPrev) {
       if (delta >= ENTROPY_DELTA_EPS) trend = '직전 세션보다 시청 다양성이 늘었어요.';

--- a/extension/pipeline/llm.js
+++ b/extension/pipeline/llm.js
@@ -109,7 +109,7 @@ export async function generateReview(prompt) {
   }
 }
 
-export function generateFallbackReview({ categoryDistribution, videoCount }) {
+export function generateFallbackReview({ categoryDistribution, entropy, prevEntropy = null, videoCount }) {
   const sorted = Object.entries(categoryDistribution).sort(([, a], [, b]) => b - a);
 
   if (sorted.length === 0) {
@@ -117,26 +117,44 @@ export function generateFallbackReview({ categoryDistribution, videoCount }) {
   }
 
   const [topName, topRatio] = sorted[0];
-
-  if (sorted.length === 1) {
-    return {
-      topic: topName,
-      feedback: `이번 세션에서는 ${topName} 영상을 집중적으로 시청하셨네요. ${videoCount}개의 영상을 보셨습니다. 다음에는 다른 카테고리의 콘텐츠도 탐색해 보세요!`,
-    };
-  }
-
-  const [secondName] = sorted[1];
-
-  if (topRatio > 0.5) {
-    return {
-      topic: topName,
-      feedback: `이번 세션에서는 주로 ${topName} 콘텐츠를 즐기셨고, ${secondName} 영상도 함께 시청하셨네요. 총 ${videoCount}개의 영상을 보셨습니다. 더 다양한 카테고리를 탐색해 보시는 건 어떨까요?`,
-    };
-  }
-
   const topNames = sorted.slice(0, 3).map(([name]) => name).join(', ');
-  return {
-    topic: topNames,
-    feedback: `이번 세션에서는 ${topNames} 등 다양한 카테고리의 영상을 고루 시청하셨네요. 총 ${videoCount}개의 영상을 보셨습니다. 균형 잡힌 시청 패턴을 잘 유지하고 계세요!`,
-  };
+
+  // [무엇을 봤는지]
+  let summary;
+  let topic;
+  if (sorted.length === 1) {
+    topic = topName;
+    summary = `이번 세션에서는 ${topName} 영상을 ${videoCount}개 집중적으로 시청하셨네요.`;
+  } else if (topRatio > 0.5) {
+    topic = topName;
+    summary = `이번 세션에서는 주로 ${topName} 콘텐츠를 즐기셨고, ${sorted[1][0]} 영상도 함께 총 ${videoCount}개를 시청하셨네요.`;
+  } else {
+    topic = topNames;
+    summary = `이번 세션에서는 ${topNames} 등 다양한 카테고리의 영상을 총 ${videoCount}개 고루 시청하셨네요.`;
+  }
+
+  // [변화 추세] + [권장/격려] — 프롬프트 경로와 동일한 상수/임계값 사용
+  let trend = '';
+  let recommendation = '';
+  if (videoCount >= MIN_VIDEOS_FOR_TREND) {
+    const hasPrev = Number.isFinite(prevEntropy);
+    const delta = hasPrev ? entropy - prevEntropy : 0;
+
+    if (hasPrev) {
+      if (delta >= ENTROPY_DELTA_EPS) trend = '직전 세션보다 시청 다양성이 늘었어요.';
+      else if (delta <= -ENTROPY_DELTA_EPS) trend = '직전 세션보다 시청 다양성이 다소 줄었어요.';
+      else trend = '직전 세션과 비슷한 다양성을 유지하고 있어요.';
+    }
+
+    if (topRatio >= BIAS_WARN_RATIO) {
+      recommendation = '한 가지 주제에 시청이 크게 쏠려 있으니, 다양한 카테고리를 탐색해 보시는 건 어떨까요?';
+    } else if (hasPrev && delta <= -ENTROPY_DELTA_EPS) {
+      recommendation = '다른 주제의 콘텐츠도 곁들여 보시는 걸 추천해요.';
+    } else if (hasPrev && delta >= ENTROPY_DELTA_EPS) {
+      recommendation = '균형 잡힌 시청 패턴을 잘 유지하고 계세요!';
+    }
+  }
+
+  const feedback = [summary, trend, recommendation].filter(Boolean).join(' ');
+  return { topic, feedback };
 }

--- a/extension/pipeline/llm.js
+++ b/extension/pipeline/llm.js
@@ -4,7 +4,40 @@ const GEMINI_API_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
 const TIMEOUT_MS = 10000;
 
-export function buildPrompt({ categoryDistribution, entropy, videoCount, videoTitles = [] }) {
+// 다양성 변화로 인정할 최소 entropy 변화량(bits) — 노이즈 무시
+const ENTROPY_DELTA_EPS = 0.1;
+// 단일 카테고리 편중 경고 임계 비율
+const BIAS_WARN_RATIO = 0.7;
+// 변화 분석/편중 경고를 신뢰할 수 있는 최소 영상 수
+const MIN_VIDEOS_FOR_TREND = 5;
+
+// prevEntropy 및 편중 비율을 LLM에게 줄 자연어 지시로 번역
+function buildTrendGuidance({ entropy, prevEntropy, topRatio, videoCount }) {
+  if (videoCount < MIN_VIDEOS_FOR_TREND) {
+    return '- 이번 세션은 시청한 영상 수가 적어 패턴을 단정하기 어렵습니다. 단정적인 평가나 강한 권유는 피하고 가볍게 언급해 주세요.';
+  }
+
+  const lines = [];
+
+  if (Number.isFinite(prevEntropy)) {
+    const delta = entropy - prevEntropy;
+    if (delta >= ENTROPY_DELTA_EPS) {
+      lines.push('- 직전 세션보다 시청 다양성이 늘었습니다. 긍정적으로 격려하는 톤으로 작성해 주세요.');
+    } else if (delta <= -ENTROPY_DELTA_EPS) {
+      lines.push('- 직전 세션보다 시청 다양성이 줄었습니다. 다양한 카테고리를 탐색해 보도록 부드럽게 권장해 주세요.');
+    } else {
+      lines.push('- 직전 세션과 비슷한 다양성을 유지하고 있습니다. 중립적인 톤으로 현재 패턴을 언급해 주세요.');
+    }
+  }
+
+  if (topRatio >= BIAS_WARN_RATIO) {
+    lines.push('- 한 카테고리에 시청이 크게 쏠려 있습니다. 다양한 카테고리를 탐색해 보도록 권장하는 문구를 반드시 포함해 주세요.');
+  }
+
+  return lines.join('\n');
+}
+
+export function buildPrompt({ categoryDistribution, entropy, prevEntropy = null, videoCount, videoTitles = [] }) {
   const sorted = Object.entries(categoryDistribution).sort(([, a], [, b]) => b - a);
 
   const categoryLines = sorted
@@ -22,13 +55,17 @@ export function buildPrompt({ categoryDistribution, entropy, videoCount, videoTi
     ? `\n- 시청한 영상 제목:\n${videoTitles.slice(0, 10).map(t => `  · ${t}`).join('\n')}`
     : '';
 
+  const topRatio = sorted.length > 0 ? sorted[0][1] : 0;
+  const trendGuidance = buildTrendGuidance({ entropy, prevEntropy, topRatio, videoCount });
+  const trendSection = trendGuidance ? `\n\n[피드백 작성 지침]\n${trendGuidance}` : '';
+
   return `당신은 YouTube 시청 패턴을 분석하는 친근한 조언자입니다.
 
 [세션 정보]
 - 시청 영상 수: ${videoCount}개
 - 카테고리 분포:
 ${categoryLines}
-${entropyLine}${titleLines}
+${entropyLine}${titleLines}${trendSection}
 
 위 데이터를 바탕으로 아래 JSON 형식으로만 응답해주세요. 다른 텍스트는 포함하지 마세요.
 


### PR DESCRIPTION
## 개요

Gemini 프롬프트를 단순 카테고리 분포 기반에서 벗어나, 전 세션 대비 entropy 변화와 편중 경고를 반영한 연구 목적 개인화 피드백으로 개선  
## 변경 사항

- **`background.js`** — `analyzeSession()`에서 직전 분석 완료 세션의 entropy를 조회해 전달
  - `findPrevEntropy()` 추가: 세션 배열을 뒤에서부터 순회하며 현재 세션 제외 + `Number.isFinite(entropy)`인 가장 최근 세션의 entropy 반환 (없으면 `null`)
  - `saveAnalysis()` 호출 **전에** 조회하여 자기 자신을 직전 세션으로 집계하는 문제 차단
  - `analysisData`에 `prevEntropy` 추가해 `buildPrompt()`/`generateFallbackReview()`로 전달
- **`llm.js` `buildPrompt()`** — 수치를 LLM 지시문으로 번역하는 `[피드백 작성 지침]` 섹션 추가
  - Δ entropy 방향: 증가 → 격려 / 감소 → 다양성 탐색 권장 / 유지 → 중립 (`prevEntropy`가 숫자일 때만)
  - 최다 카테고리 비율 ≥ 70% → 다양성 탐색 권장 문구 강제 포함 (Δ와 독립 평가)
  - 영상 5개 미만이면 변화·경고 신호를 끄고 "표본 적음, 단정 회피" 지시로 대체
- **`llm.js` `generateFallbackReview()`** — Gemini API 실패 시에도 동일 상수/임계값을 재사용해 편향 변화 방향을 반영한 문구 생성 (성공/폴백 경로 일관성 확보)
- **`docs/03-잔여작업.md`** — Story 6-1, 7-1 완료 Task 체크박스 업데이트

판정 기준은 상수로 분리: `ENTROPY_DELTA_EPS = 0.1`, `BIAS_WARN_RATIO = 0.7`, `MIN_VIDEOS_FOR_TREND = 5` (실험 로그 기반 튜닝 가능).

## 관련 이슈

- closes #102 

## 테스트 확인

- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [x] 콘솔 에러 없음

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/fb27a94e-ad15-4ea1-9f27-87e76c1dae0c" />
 
> 순수 함수(`buildPrompt`/`generateFallbackReview`)는 검증 스크립트를 작성하여 Node로 6개 케이스(편향 심화/개선, 70% 편중, 첫 세션, 영상 부족, 개선+편중 동시)를 검증하여 성공·폴백 경로의 피드백 방향이 일치함을 확인  

## 참고 사항

- `config.example.js`는 `YOUR_SERVER_URL_HERE` 플레이스홀더를 의도적으로 유지 (실 URL 노출 방지)  