### PR TITLE
chore: 배포 zip에서 디자인 스튜디오 전용 파일 제외

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -50,7 +50,8 @@ jobs:
           cd extension
           zip -r ../youtube-bias-feedback.zip . \
             --exclude "*.md" \
-            --exclude "config.example.js"
+            --exclude "config.example.js" \
+            --exclude "studio/*"
 
       - name: Upload to Draft Release
         if: steps.check.outputs.changed == 'true'

--- a/docs/03-잔여작업.md
+++ b/docs/03-잔여작업.md
@@ -230,14 +230,14 @@ Epic 1–5의 기본 구현은 완료되었으며, 이 문서는 배포 전 완�
 
 #### Tasks
 
-- [ ] `popup.js` 미사용 여부 최종 확인 및 제거
+- [x] `popup.js` 미사용 여부 최종 확인 및 제거
   - Priority: Low / Owner: FE
   - 내용: `popup.html`, `manifest.json`, 모든 스크립트에서 `popup.js` 참조 여부 확인 후 파일 삭제
   - DoD: `popup.js` 삭제 후 팝업 열기, 온보딩, 세션 데이터 표시가 정상 동작한다.
   - Dependencies: 없음
   - 예상 소요: 30m
 
-- [ ] 웹 스토어 배포 zip에서 불필요한 파일 제외 목록 정의
+- [x] 웹 스토어 배포 zip에서 불필요한 파일 제외 목록 정의
   - Priority: Low / Owner: FE
   - 내용: `ViewLens.html`(디자인 스튜디오 전용), `tweaks-panel.*`(디자인 스튜디오 전용), `config.example.js` 등 배포 시 포함할 필요 없는 파일 목록 정의. `.zipignore` 또는 패키징 스크립트로 관리
   - DoD: 배포 zip에 개발 전용 파일이 포함되지 않는다.


### PR DESCRIPTION
## 개요

배포(zip) 패키지에서 디자인 스튜디오 전용 개발 파일을 제외하여, 웹 스토어 제출용 빌드에 불필요한 파일이 포함되지 않도록 정리 (Epic 9 / Story 9-1)

## 변경 사항

- **`.github/workflows/release-extension.yml`**: zip 패키징 단계의 제외 목록에 `studio/*` 추가
  - 제외 대상: `studio/ViewLens.html`, `studio/tweaks-panel.css`, `studio/tweaks-panel.js` (디자인 스튜디오 전용, 확장 동작에서 미참조)
  - 기존 제외(`*.md`, `config.example.js`)는 유지
- **`docs/03-잔여작업.md`** — Story 9-1 Task 2개 완료 체크
  - `popup.js`는 이미 제거된 상태로 확인되어(파일·git 인덱스·origin 모두 부재) Task 1도 완료 처리
  
## 테스트 확인

- [ ] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [ ] 콘솔 에러 없음

> 이 PR은 CI 패키징(zip 생성) 설정 변경으로 확장 프로그램 **런타임 동작에는 영향이 없음**. 제외 규칙은 동일 로직 시뮬레이션으로 검증
> - 제외됨: `studio/*` 3개 파일, `config.example.js`
> - 포함됨: `manifest.json`, `background.js`, `content.js`, `popup/*`, `pipeline/*`, `assets/*`, `storage.js` 등 핵심 파일 전체

## 스크린샷 (UI 변경 시)

해당 없음 (UI 변경 없음)

## 참고 사항

- `manifest.json` 버전(`0.1.0`)은 이번 PR에서 변경하지 않음
- 후속: 이 브랜치는 `develop` 기반이며, 이후 `develop → main` PR로 Story 6-1 + 9-1을 함께 배포할 예정
