### PR TITLE
fix: 헤더 경과일을 installDate 기준 실제 일수로 표시 (v1.0.1)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ViewLens: YouTube Bias Feedback",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "permissions": ["storage", "alarms"],
   "icons": {
     "16": "assets/icons/icon16.png",

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -5,11 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>ViewLens</title>
 
-<!-- JetBrains Mono (CDN — not in local fonts) -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;600;700&display=swap" rel="stylesheet" />
-
 <!-- design tokens + local Pretendard -->
 <link rel="stylesheet" href="viewlens-tokens.css" />
 

--- a/extension/popup/viewlens-app.js
+++ b/extension/popup/viewlens-app.js
@@ -20,6 +20,21 @@ function _controlTotalCount() {
   return ended + (VL.today?.collectingCount ?? 0);
 }
 
+// 대조군 홈 — 오늘 시청한 영상 수 (오늘 종료된 세션 + 진행 중 세션).
+function _controlTodayCount() {
+  const sessions = VL._allSessions || [];
+  const todayStr = new Date().toDateString();
+  const ended = sessions.reduce(
+    (sum, s) =>
+      sum +
+      (s.endTime && new Date(s.endTime).toDateString() === todayStr
+        ? (s.videoCount ?? s.videos?.length ?? 0)
+        : 0),
+    0,
+  );
+  return ended + (VL.today?.collectingCount ?? 0);
+}
+
 // 설치일(installDate) 기준 실제 경과일(1일째부터). installDate가 없으면 목업 day로 폴백.
 function _elapsedDay(fallback) {
   if (!VL._installDate) return fallback;
@@ -148,7 +163,10 @@ class ViewLensPopup {
           ? screenToday()
           : screenFeedback(tl.currentWeek, selWeek);
     } else {
-      bodyHTML = screenControlHome(day, { totalCount: _controlTotalCount() });
+      bodyHTML = screenControlHome(day, {
+        todayCount: _controlTodayCount(),
+        totalCount: _controlTotalCount(),
+      });
     }
 
     this.container.innerHTML = `<div style="position:relative;height:100%;display:flex;flex-direction:column;background:var(--vl-bg)">

--- a/extension/popup/viewlens-app.js
+++ b/extension/popup/viewlens-app.js
@@ -38,7 +38,9 @@ function _controlTodayCount() {
 // 설치일(installDate) 기준 실제 경과일(1일째부터). installDate가 없으면 목업 day로 폴백.
 function _elapsedDay(fallback) {
   if (!VL._installDate) return fallback;
-  const d = Math.floor((Date.now() - new Date(VL._installDate).getTime()) / 86400000) + 1;
+  const d =
+    Math.floor((Date.now() - new Date(VL._installDate).getTime()) / 86400000) +
+    1;
   return Math.max(1, d);
 }
 
@@ -58,7 +60,7 @@ function _popupHeader(groupCfg, day) {
       ${markSVG({ size: 26, accent: "var(--vl-accent)" })}
       <div style="display:flex;flex-direction:column;line-height:1.1">
         <span style="font-size:15px;font-weight:800;letter-spacing:-0.02em;color:var(--vl-ink)">View<span style="color:var(--vl-accent)">Lens</span></span>
-        <span style="font-size:10.5px;color:var(--vl-ink-3);font-family:'JetBrains Mono',monospace;margin-top:2px">설치 ${day}일째 · 종료 D-${Math.max(0, VL.TOTAL_DAYS - day)}</span>
+        <span style="font-size:10.5px;color:var(--vl-ink-3);margin-top:2px">설치 ${day}일째 · 종료 D-${Math.max(0, VL.TOTAL_DAYS - day)}</span>
       </div>
     </div>
     ${rightArea}
@@ -258,7 +260,9 @@ class ViewLensPopup {
       });
     }
     // 연구자 모드 전용 — 온보딩 화면으로 돌아가기
-    const researcherReset = this.container.querySelector("#vl-researcher-reset");
+    const researcherReset = this.container.querySelector(
+      "#vl-researcher-reset",
+    );
     if (researcherReset) {
       researcherReset.addEventListener("click", () => {
         this._onboarded = false;
@@ -344,7 +348,7 @@ class Studio {
             <span style="color:#9aa0a6;font-size:14px;opacity:.7;margin-left:2px">⟳</span>
             <div style="flex:1;height:30px;border-radius:16px;background:#202124;display:flex;align-items:center;gap:8px;padding:0 14px;margin:0 8px">
               <span style="width:11px;height:11px;border-radius:50%;border:1.5px solid #9aa0a6;opacity:.6"></span>
-              <span style="color:#c9ccd1;font-size:12.5px;font-family:'JetBrains Mono',monospace">youtube.com<span style="color:#9aa0a6">/watch?v=dQw4w9WgXcQ</span></span>
+              <span style="color:#c9ccd1;font-size:12.5px;">youtube.com<span style="color:#9aa0a6">/watch?v=dQw4w9WgXcQ</span></span>
             </div>
             <!-- extension icon -->
             <div style="width:28px;height:28px;border-radius:8px;display:grid;place-items:center">
@@ -389,7 +393,7 @@ class Studio {
           </div>
         </div>
 
-        <div style="font-size:12px;color:#9a938c;font-family:'JetBrains Mono',monospace;letter-spacing:.04em">
+        <div style="font-size:12px;color:#9a938c;;letter-spacing:.04em">
           오른쪽 아래 <b id="vl-tweaks-hint" style="cursor:pointer">Tweaks ▲</b> 패널에서 톤 · 그룹 · 실험 시점을 바꿔 보세요
         </div>
       </div>

--- a/extension/popup/viewlens-app.js
+++ b/extension/popup/viewlens-app.js
@@ -10,6 +10,13 @@ function _collectingTimerText() {
   return `피드백까지 ${mins}분 ${String(secs).padStart(2, "0")}초`;
 }
 
+// 설치일(installDate) 기준 실제 경과일(1일째부터). installDate가 없으면 목업 day로 폴백.
+function _elapsedDay(fallback) {
+  if (!VL._installDate) return fallback;
+  const d = Math.floor((Date.now() - new Date(VL._installDate).getTime()) / 86400000) + 1;
+  return Math.max(1, d);
+}
+
 function _popupHeader(groupCfg, day) {
   const isTest = groupCfg.code.startsWith("TEST");
   const badge = isTest
@@ -26,7 +33,7 @@ function _popupHeader(groupCfg, day) {
       ${markSVG({ size: 26, accent: "var(--vl-accent)" })}
       <div style="display:flex;flex-direction:column;line-height:1.1">
         <span style="font-size:15px;font-weight:800;letter-spacing:-0.02em;color:var(--vl-ink)">View<span style="color:var(--vl-accent)">Lens</span></span>
-        <span style="font-size:10.5px;color:var(--vl-ink-3);font-family:'JetBrains Mono',monospace;margin-top:2px">설치 ${day}일째 · 종료 D-${VL.TOTAL_DAYS - day}</span>
+        <span style="font-size:10.5px;color:var(--vl-ink-3);font-family:'JetBrains Mono',monospace;margin-top:2px">설치 ${day}일째 · 종료 D-${Math.max(0, VL.TOTAL_DAYS - day)}</span>
       </div>
     </div>
     ${rightArea}
@@ -108,6 +115,7 @@ class ViewLensPopup {
       return;
     }
     const tl = VL.TIMELINE[this._timelineKey] || VL.TIMELINE.w1_mid;
+    const day = _elapsedDay(tl.day);
     const groupCfg = VL.GROUPS[this._group] || VL.GROUPS.EXP;
     const selWeek = Math.min(this._selWeek, tl.currentWeek);
     const surveyWeek = tl.surveyWeek;
@@ -130,11 +138,11 @@ class ViewLensPopup {
           ? screenToday()
           : screenFeedback(tl.currentWeek, selWeek);
     } else {
-      bodyHTML = screenControlHome(tl.day);
+      bodyHTML = screenControlHome(day);
     }
 
     this.container.innerHTML = `<div style="position:relative;height:100%;display:flex;flex-direction:column;background:var(--vl-bg)">
-      ${_popupHeader(groupCfg, tl.day)}
+      ${_popupHeader(groupCfg, day)}
       ${surveyPending && this._snoozed ? _surveyBanner(surveyWeek) : ""}
       ${groupCfg.feedback ? _tabs(this._tab) : ""}
       <div style="flex:1;overflow-y:auto;overflow-x:hidden">${bodyHTML}</div>

--- a/extension/popup/viewlens-app.js
+++ b/extension/popup/viewlens-app.js
@@ -10,6 +10,16 @@ function _collectingTimerText() {
   return `피드백까지 ${mins}분 ${String(secs).padStart(2, "0")}초`;
 }
 
+// 대조군 홈 — 실제 세션 데이터 기반 총 누적 시청 영상 수 (진행 중 세션 포함).
+function _controlTotalCount() {
+  const sessions = VL._allSessions || [];
+  const ended = sessions.reduce(
+    (sum, s) => sum + (s.videoCount ?? s.videos?.length ?? 0),
+    0,
+  );
+  return ended + (VL.today?.collectingCount ?? 0);
+}
+
 // 설치일(installDate) 기준 실제 경과일(1일째부터). installDate가 없으면 목업 day로 폴백.
 function _elapsedDay(fallback) {
   if (!VL._installDate) return fallback;
@@ -138,7 +148,7 @@ class ViewLensPopup {
           ? screenToday()
           : screenFeedback(tl.currentWeek, selWeek);
     } else {
-      bodyHTML = screenControlHome(day);
+      bodyHTML = screenControlHome(day, { totalCount: _controlTotalCount() });
     }
 
     this.container.innerHTML = `<div style="position:relative;height:100%;display:flex;flex-direction:column;background:var(--vl-bg)">

--- a/extension/popup/viewlens-app.js
+++ b/extension/popup/viewlens-app.js
@@ -38,9 +38,9 @@ function _controlTodayCount() {
 // 설치일(installDate) 기준 실제 경과일(1일째부터). installDate가 없으면 목업 day로 폴백.
 function _elapsedDay(fallback) {
   if (!VL._installDate) return fallback;
-  const d =
-    Math.floor((Date.now() - new Date(VL._installDate).getTime()) / 86400000) +
-    1;
+  const t = new Date(VL._installDate).getTime();
+  if (!Number.isFinite(t)) return fallback; // 손상된 installDate → NaN 방지
+  const d = Math.floor((Date.now() - t) / 86400000) + 1;
   return Math.max(1, d);
 }
 

--- a/extension/popup/viewlens-data.js
+++ b/extension/popup/viewlens-data.js
@@ -27,14 +27,6 @@ function entropy(arr) {
   return arr.reduce((h, d) => (d.p > 0 ? h - d.p * Math.log2(d.p) : h), 0);
 }
 
-function band(h) {
-  if (h < 1.2) return { label: '매우 편중', tone: 'warn' };
-  if (h < 1.9) return { label: '편중',      tone: 'warn' };
-  if (h < 2.5) return { label: '보통',      tone: 'mid'  };
-  if (h < 3.0) return { label: '다양',      tone: 'good' };
-  return           { label: '매우 다양',    tone: 'good' };
-}
-
 const H_MAX = 3.17;
 
 const today = {
@@ -122,7 +114,7 @@ const TONES = {
 };
 
 window.VL = {
-  CATS: VL_CATS, dist, entropy, band, H_MAX,
+  CATS: VL_CATS, dist, entropy, H_MAX,
   today, weeks, baselineH, TIMELINE, TOTAL_DAYS, GROUPS, TONES,
   con: { todayCount: 12, totalCount: 47 },
 };

--- a/extension/popup/viewlens-logo.js
+++ b/extension/popup/viewlens-logo.js
@@ -59,7 +59,7 @@ function wordmarkHTML({
 } = {}) {
   const markSize = Math.round(size * 1.55);
   const subLine = sub
-    ? `<span style="margin-top:5px;font-family:'JetBrains Mono',monospace;font-weight:500;font-size:${size * 0.42}px;letter-spacing:0.14em;text-transform:uppercase;color:var(--vl-ink-3)">${sub}</span>`
+    ? `<span style="margin-top:5px;;font-weight:500;font-size:${size * 0.42}px;letter-spacing:0.14em;text-transform:uppercase;color:var(--vl-ink-3)">${sub}</span>`
     : "";
   return `<div style="display:flex;align-items:center;gap:${gap}px">
     ${markSVG({ size: markSize, filled, accent })}

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -409,10 +409,11 @@ async function boot() {
     timelineKey: calcTimelineKey(installDate),
     onChange: async ({ onboarded: ob, group: g }) => {
       if (ob && g) {
+        const installDate = new Date().toISOString();
+        VL._installDate = installDate; // 온보딩 직후 첫 렌더부터 실제 경과일(1일째) 반영
         const { anonymousId: existing, serverUrl } =
           await chrome.storage.local.get(["anonymousId", "serverUrl"]);
         const anonymousId = existing || crypto.randomUUID();
-        const installDate = new Date().toISOString();
 
         await chrome.storage.local.set({
           anonymousId,

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -214,6 +214,9 @@ function screenToday() {
 function screenFeedback(currentWeek, selWeek) {
   const w = VL.weeks[selWeek - 1];
   const vsBase = w.entropy - VL.baselineH;
+  const prevW = selWeek >= 2 ? VL.weeks[selWeek - 2] : null;
+  const vsPrev = prevW ? w.entropy - prevW.entropy : 0;
+  const showPrev = selWeek >= 3; // 직전 주가 첫 주와 다를 때만 별도 표시
 
   const weekBtns = VL.weeks
     .map((wk) => {
@@ -230,27 +233,38 @@ function screenFeedback(currentWeek, selWeek) {
         ${locked ? _lockIcon(10) : ""}${wk.label}
       </span>
       <span style="font-size:9.5px;font-weight:500;color:inherit;opacity:0.8;font-family:'JetBrains Mono',monospace">
-        ${locked ? `${wk.week}주차 공개` : wk.isBaseline ? "기준선" : ""}
+        ${locked ? `${wk.week}주차 공개` : wk.isBaseline ? "첫 주" : ""}
       </span>
     </button>`;
     })
     .join("");
 
   const vsBaseContent = w.isBaseline
-    ? `<p style="margin:0;font-size:12px;line-height:1.55;color:var(--vl-ink-2)">이 주의 점수가 이후 주차를 비교하는 <b style="color:var(--vl-ink)">기준선</b>이 돼요.</p>`
+    ? `<p style="margin:0;font-size:12px;line-height:1.55;color:var(--vl-ink-2)">첫 주라 아직 비교할 이전 주가 없어요.</p>`
     : `<div>
-        <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">기준선(1주차) 대비</div>
+        <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">첫 주 대비</div>
         <div style="display:flex;align-items:center;gap:7px">
           ${vlDeltaChip({ value: vsBase })}
           <span style="font-size:12px;color:var(--vl-ink-2)">${vsBase >= 0 ? "더 다양해요" : "덜 다양해요"}</span>
         </div>
+        ${
+          showPrev
+            ? `<div style="margin-top:8px">
+          <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">직전 주(${prevW.label}) 대비</div>
+          <div style="display:flex;align-items:center;gap:7px">
+            ${vlDeltaChip({ value: vsPrev })}
+            <span style="font-size:12px;color:var(--vl-ink-2)">${vsPrev >= 0 ? "더 다양해요" : "덜 다양해요"}</span>
+          </div>
+        </div>`
+            : ""
+        }
       </div>`;
 
   const baselineLegend = !w.isBaseline
     ? `
     <div style="display:flex;align-items:center;gap:5px;margin-top:7px">
       <span style="width:14px;height:0;border-top:1px dashed var(--vl-ink-3)"></span>
-      <span style="font-size:10.5px;color:var(--vl-ink-3)">점선 = 기준선 ${VL.baselineH.toFixed(2)}</span>
+      <span style="font-size:10.5px;color:var(--vl-ink-3)">점선 = 첫 주 ${VL.baselineH.toFixed(2)}</span>
     </div>`
     : "";
 
@@ -261,7 +275,7 @@ function screenFeedback(currentWeek, selWeek) {
       <div>
         <div style="font-size:16px;font-weight:800;color:var(--vl-ink)">
           ${w.label} 리포트
-          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> · 베이스라인</span>' : ""}
+          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> · 첫 주</span>' : ""}
         </div>
         <div style="font-family:'JetBrains Mono',monospace;font-size:11.5px;color:var(--vl-ink-3);margin-top:2px">${w.range}</div>
       </div>

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -14,8 +14,8 @@ function screenOnboarding() {
       <div style="margin-top:18px;font-size:25px;font-weight:800;letter-spacing:-0.03em;color:var(--vl-ink)">
         View<span style="color:var(--vl-accent)">Lens</span>
       </div>
-      <p style="margin:10px 0 0;font-size:13.5px;line-height:1.6;color:var(--vl-ink-2);max-width:260px;text-wrap:pretty">
-        추천 알고리즘을 너머 당신의 시청 습관을 돌아봅니다. 연구자에게 받은 참여 코드를 입력하여 시작해 주세요.
+      <p style="margin:10px 0 0;font-size:13.5px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;word-break:keep-all">
+        추천 알고리즘을 넘어 당신의 시청 습관을 돌아봅니다.<br />연구자에게 받은 참여 코드를 입력하여 시작해 주세요.
       </p>
     </div>
 

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -271,9 +271,9 @@ function screenFeedback(currentWeek, selWeek) {
       pad: 16,
       children: `
       <div style="display:flex;align-items:center;gap:14px">
-        <div style="text-align:center;flex-shrink:0">
+        <div style="text-align:center;flex-shrink:0;cursor:help" title="시청한 영상이 여러 카테고리에 고르게 퍼져 있을수록 높아지는 점수예요. 한 가지 주제만 보면 낮고, 다양하게 볼수록 올라가요.">
           <div style="font-family:'JetBrains Mono',monospace;font-weight:700;font-size:30px;color:var(--vl-ink);line-height:1;letter-spacing:-0.02em">${w.entropy.toFixed(2)}</div>
-          <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">다양성 점수 (bits)</div>
+          <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">다양성 점수 ⓘ</div>
         </div>
         <div style="width:1px;align-self:stretch;background:var(--vl-line)"></div>
         <div style="flex:1">${vsBaseContent}</div>

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -306,7 +306,7 @@ function screenFeedback(currentWeek, selWeek) {
 
 function screenControlHome(day, stats = {}) {
   const cells = [
-    { v: `${VL.con.todayCount}개`, l: "오늘 시청한 영상" },
+    { v: `${stats.todayCount ?? VL.con.todayCount}개`, l: "오늘 시청한 영상" },
     { v: `${stats.totalCount ?? VL.con.totalCount}개`, l: "총 누적 시청" },
     { v: `${day}일째`, l: "설치 후" },
     { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "실험 종료까지" },

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -5,7 +5,7 @@ function _lockIcon(size = 12) {
   </svg>`;
 }
 
-// ── Onboarding ────────────────────────────────────────────────────────────────
+// ?? Onboarding ????????????????????????????????????????????????????????????????
 
 function screenOnboarding() {
   return `<div style="padding:34px 22px 26px;display:flex;flex-direction:column;min-height:100%;box-sizing:border-box">
@@ -15,13 +15,13 @@ function screenOnboarding() {
         View<span style="color:var(--vl-accent)">Lens</span>
       </div>
       <p style="margin:10px 0 0;font-size:13.5px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;word-break:keep-all">
-        추천 알고리즘을 넘어 당신의 시청 습관을 돌아봅니다.<br />연구자에게 받은 참여 코드를 입력하여 시작해 주세요.
+        異붿쿇 ?뚭퀬由ъ쬁???섏뼱 ?뱀떊???쒖껌 ?듦????뚯븘遊낅땲??<br />?곌뎄?먯뿉寃?諛쏆? 李몄뿬 肄붾뱶瑜??낅젰?섏뿬 ?쒖옉??二쇱꽭??
       </p>
     </div>
 
     <div style="margin-top:40px">
-      <label style="font-size:12px; font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--vl-ink-3)">참여 코드</label>
-      <input id="vl-onboard-input" value="" placeholder="연구자에게 받은 참여 코드" spellcheck="false" autocomplete="off"
+      <label style="font-size:12px; font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--vl-ink-3)">李몄뿬 肄붾뱶</label>
+      <input id="vl-onboard-input" value="" placeholder="?곌뎄?먯뿉寃?諛쏆? 李몄뿬 肄붾뱶" spellcheck="false" autocomplete="off"
         style="display:block;margin-top:9px;width:100%;box-sizing:border-box;padding:13px 15px;
           border:1.5px solid var(--vl-line-2);border-radius:13px;background:var(--vl-card-2);
           color:var(--vl-ink);outline:none;
@@ -30,16 +30,16 @@ function screenOnboarding() {
       <button id="vl-onboard-btn"
         style="margin-top:14px;width:100%;padding:13px;border:none;border-radius:13px;
           background:var(--vl-accent);color:var(--vl-on-accent);font-size:14.5px;
-          font-weight:700;cursor:pointer;font-family:inherit">시작하기</button>
+          font-weight:700;cursor:pointer;font-family:inherit">?쒖옉?섍린</button>
     </div>
 
     <div style="margin-top:auto;padding-top:22px">
       <div style="display:flex;align-items:flex-start;gap:9px;padding:12px 13px;background:var(--vl-card-2);border:1px solid var(--vl-line);border-radius:12px">
-        <div style="width:26px;height:26px;border-radius:7px;background:var(--vl-accent-soft);color:var(--vl-accent);display:grid;place-items:center;flex-shrink:0;margin-top:1px">
-          ${_lockIcon(20)}
+        <div style="width:25px;height:25px;border-radius:7px;background:var(--vl-accent-soft);color:var(--vl-accent);display:grid;place-items:center;flex-shrink:0;margin-top:1px">
+          ${_lockIcon(15)}
         </div>
         <p style="margin:0;font-size:11.5px;line-height:1.55;color:var(--vl-ink-2);text-wrap:pretty">
-          시청 기록은 익명으로 저장됩니다. 누가 어떤 영상을 봤는지는 특정되지 않으며, 수집된 데이터는 오직 연구 목적으로만 사용됩니다.
+          ?쒖껌 湲곕줉? ?듬챸?쇰줈 ??λ맗?덈떎. ?꾧? ?대뼡 ?곸긽??遊ㅻ뒗吏???뱀젙?섏? ?딆쑝硫? ?섏쭛???곗씠?곕뒗 ?ㅼ쭅 ?곌뎄 紐⑹쟻?쇰줈留??ъ슜?⑸땲??
         </p>
       </div>
     </div>
@@ -54,11 +54,11 @@ function bindOnboarding(root, onSubmit) {
   function submit() {
     const c = input.value.trim().toUpperCase();
     if (!c) {
-      showErr("코드를 입력해 주세요.");
+      showErr("肄붾뱶瑜??낅젰??二쇱꽭??");
       return;
     }
     if (!VL.GROUPS[c]) {
-      showErr("유효하지 않은 코드예요. 연구자에게 받은 코드를 확인해 주세요.");
+      showErr("?좏슚?섏? ?딆? 肄붾뱶?덉슂. ?곌뎄?먯뿉寃?諛쏆? 肄붾뱶瑜??뺤씤??二쇱꽭??");
       return;
     }
     onSubmit(c);
@@ -78,7 +78,7 @@ function bindOnboarding(root, onSubmit) {
   btn.addEventListener("click", submit);
 }
 
-// ── Today ─────────────────────────────────────────────────────────────────────
+// ?? Today ?????????????????????????????????????????????????????????????????????
 
 function _collectingBanner(count) {
   if (!count) return "";
@@ -86,8 +86,8 @@ function _collectingBanner(count) {
   return `<div id="vl-collecting-banner" style="display:flex;align-items:center;gap:9px;padding:10px 16px;background:var(--vl-accent-soft);border-bottom:1px solid var(--vl-line)">
     <span style="width:7px;height:7px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
     <div style="flex:1;min-width:0">
-      <div id="vl-collecting-count" style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">영상 ${count}개 수집 중</div>
-      <div style="font-size:11px;color:var(--vl-accent);opacity:0.75;margin-top:1px">이 시간 안에 더 시청하지 않으면 피드백이 생성돼요</div>
+      <div id="vl-collecting-count" style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">?곸긽 ${count}媛??섏쭛 以?/div>
+      <div style="font-size:11px;color:var(--vl-accent);opacity:0.75;margin-top:1px">???쒓컙 ?덉뿉 ???쒖껌?섏? ?딆쑝硫??쇰뱶諛깆씠 ?앹꽦?쇱슂</div>
     </div>
     <span id="vl-collecting-timer" style="font-size:11px;font-weight:600;color:var(--vl-accent);opacity:0.8;white-space:nowrap;flex-shrink:0">${timerText}</span>
   </div>`;
@@ -97,9 +97,9 @@ function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
   return `<div style="display:flex;flex-direction:column;min-height:100%">
     ${_collectingBanner(collectingCount)}
     <div style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px 0">
-      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
-      <div style="font-size:13px;font-weight:700;color:var(--vl-ink-2)">${isToday ? "오늘" : dateLabel}</div>
-      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
+      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">??/button>
+      <div style="font-size:13px;font-weight:700;color:var(--vl-ink-2)">${isToday ? "?ㅻ뒛" : dateLabel}</div>
+      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>??/button>
     </div>
     <div style="flex:1;padding:24px 24px 40px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:10px">
       <div style="position:relative;width:80px;height:80px">
@@ -110,11 +110,11 @@ function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
         </span>
       </div>
       <div>
-        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "아직 오늘 시청 기록이 없어요" : "이 날 시청 기록이 없어요"}</div>
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "?꾩쭅 ?ㅻ뒛 ?쒖껌 湲곕줉???놁뼱?? : "?????쒖껌 湲곕줉???놁뼱??}</div>
         ${
           isToday
             ? `<p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
-          유튜브를 시청하면 자동으로 수집이 시작돼요.<br>시청 종료 10분 후 분석 결과가 나타나요.
+          ?좏뒠釉뚮? ?쒖껌?섎㈃ ?먮룞?쇰줈 ?섏쭛???쒖옉?쇱슂.<br>?쒖껌 醫낅즺 10遺???遺꾩꽍 寃곌낵媛 ?섑??섏슂.
         </p>`
             : ""
         }
@@ -152,7 +152,7 @@ function screenToday() {
     <div style="display:flex;align-items:center;gap:6px">
       <span style="width:6px;height:6px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
       <div style="display:flex;flex-direction:column;gap:1px">
-        <span id="vl-collecting-count" style="font-size:11.5px;font-weight:600;color:var(--vl-accent)">${d.collectingCount > 0 ? `영상 ${d.collectingCount}개 수집 중` : "분석 중..."}</span>
+        <span id="vl-collecting-count" style="font-size:11.5px;font-weight:600;color:var(--vl-accent)">${d.collectingCount > 0 ? `?곸긽 ${d.collectingCount}媛??섏쭛 以? : "遺꾩꽍 以?.."}</span>
         <span id="vl-collecting-timer" style="font-size:10.5px;color:var(--vl-accent);opacity:0.8">${d.collectingTimer || ""}</span>
       </div>
     </div>`
@@ -160,34 +160,34 @@ function screenToday() {
   return `<div style="display:flex;flex-direction:column">
     <div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
     <div style="display:flex;align-items:center;justify-content:space-between">
-      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
+      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">??/button>
       <div style="text-align:center">
-        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "오늘" : d.dateLabel}</div>
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "?ㅻ뒛" : d.dateLabel}</div>
       </div>
-      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
+      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>??/button>
     </div>
     <div style="display:flex;align-items:center;justify-content:space-between">
       <div>${collectingRow}</div>
-      ${vlBadge({ text: `${d.videoCount}개 영상 · ${d.dist.length}개 분야`, tone: "neutral" })}
+      ${vlBadge({ text: `${d.videoCount}媛??곸긽 쨌 ${d.dist.length}媛?遺꾩빞`, tone: "neutral" })}
     </div>
 
     ${vlCard({
       pad: 16,
       children: `
-      <div style="font-size:11.5px;color:var(--vl-ink-3);font-weight:600;margin-bottom:11px">직전 시청일 대비 다양성</div>
+      <div style="font-size:11.5px;color:var(--vl-ink-3);font-weight:600;margin-bottom:11px">吏곸쟾 ?쒖껌???鍮??ㅼ뼇??/div>
       <div style="display:flex;align-items:center;gap:13px">
         <div style="text-align:center">
           <div style=";font-size:18px;font-weight:700;color:var(--vl-ink-3);line-height:1">${d.prevEntropy.toFixed(2)}</div>
           <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px">${d.prevDateLabel}</div>
         </div>
-        <span style="font-size:15px;color:var(--vl-ink-3)">→</span>
+        <span style="font-size:15px;color:var(--vl-ink-3)">??/span>
         <div style="text-align:center">
           <div style=";font-size:22px;font-weight:700;color:var(--vl-ink);line-height:1">${h.toFixed(2)}</div>
-          <div style="font-size:10.5px;color:var(--vl-accent);margin-top:4px;font-weight:700">오늘</div>
+          <div style="font-size:10.5px;color:var(--vl-accent);margin-top:4px;font-weight:700">?ㅻ뒛</div>
         </div>
         <div style="margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:3px">
           ${vlDeltaChip({ value: delta })}
-          <span style="font-size:11px;font-weight:700;color:${delta >= 0 ? "var(--vl-good)" : "var(--vl-warn)"}">${delta >= 0 ? "더 다양해졌어요" : "더 편중됐어요"}</span>
+          <span style="font-size:11px;font-weight:700;color:${delta >= 0 ? "var(--vl-good)" : "var(--vl-warn)"}">${delta >= 0 ? "???ㅼ뼇?댁죱?댁슂" : "???몄쨷?먯뼱??}</span>
         </div>
       </div>
     `,
@@ -196,7 +196,7 @@ function screenToday() {
     ${vlCard({
       pad: 16,
       children: `
-      ${vlSectionLabel({ text: "카테고리 분포", right: `<span style="font-size:11px;color:var(--vl-ink-3)">오늘 ${d.videoCount}개</span>` })}
+      ${vlSectionLabel({ text: "移댄뀒怨좊━ 遺꾪룷", right: `<span style="font-size:11px;color:var(--vl-ink-3)">?ㅻ뒛 ${d.videoCount}媛?/span>` })}
       <div style="display:flex;align-items:center;gap:16px;margin-top:6px">
         ${vlDonut({ data: d.dist, size: 124 })}
         <div style="flex:1;display:flex;flex-direction:column;gap:8px">${catRows}</div>
@@ -209,14 +209,14 @@ function screenToday() {
   </div>`;
 }
 
-// ── Feedback ──────────────────────────────────────────────────────────────────
+// ?? Feedback ??????????????????????????????????????????????????????????????????
 
 function screenFeedback(currentWeek, selWeek) {
   const w = VL.weeks[selWeek - 1];
   const vsBase = w.entropy - VL.baselineH;
   const prevW = selWeek >= 2 ? VL.weeks[selWeek - 2] : null;
   const vsPrev = prevW ? w.entropy - prevW.entropy : 0;
-  const showPrev = selWeek >= 3; // 직전 주가 첫 주와 다를 때만 별도 표시
+  const showPrev = selWeek >= 3; // 吏곸쟾 二쇨? 泥?二쇱? ?ㅻ? ?뚮쭔 蹂꾨룄 ?쒖떆
 
   const weekBtns = VL.weeks
     .map((wk) => {
@@ -233,27 +233,27 @@ function screenFeedback(currentWeek, selWeek) {
         ${locked ? _lockIcon(10) : ""}${wk.label}
       </span>
       <span style="font-size:9.5px;font-weight:500;color:inherit;opacity:0.8;">
-        ${locked ? `${wk.week}주차 공개` : wk.isBaseline ? "첫 주" : ""}
+        ${locked ? `${wk.week}二쇱감 怨듦컻` : wk.isBaseline ? "泥?二? : ""}
       </span>
     </button>`;
     })
     .join("");
 
   const vsBaseContent = w.isBaseline
-    ? `<p style="margin:0;font-size:12px;line-height:1.55;color:var(--vl-ink-2)">첫 주라 아직 비교할 이전 주가 없어요.</p>`
+    ? `<p style="margin:0;font-size:12px;line-height:1.55;color:var(--vl-ink-2)">泥?二쇰씪 ?꾩쭅 鍮꾧탳???댁쟾 二쇨? ?놁뼱??</p>`
     : `<div>
-        <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">첫 주 대비</div>
+        <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">泥?二??鍮?/div>
         <div style="display:flex;align-items:center;gap:7px">
           ${vlDeltaChip({ value: vsBase })}
-          <span style="font-size:12px;color:var(--vl-ink-2)">${vsBase >= 0 ? "더 다양해요" : "덜 다양해요"}</span>
+          <span style="font-size:12px;color:var(--vl-ink-2)">${vsBase >= 0 ? "???ㅼ뼇?댁슂" : "???ㅼ뼇?댁슂"}</span>
         </div>
         ${
           showPrev
             ? `<div style="margin-top:8px">
-          <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">직전 주(${prevW.label}) 대비</div>
+          <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">吏곸쟾 二?${prevW.label}) ?鍮?/div>
           <div style="display:flex;align-items:center;gap:7px">
             ${vlDeltaChip({ value: vsPrev })}
-            <span style="font-size:12px;color:var(--vl-ink-2)">${vsPrev >= 0 ? "더 다양해요" : "덜 다양해요"}</span>
+            <span style="font-size:12px;color:var(--vl-ink-2)">${vsPrev >= 0 ? "???ㅼ뼇?댁슂" : "???ㅼ뼇?댁슂"}</span>
           </div>
         </div>`
             : ""
@@ -264,7 +264,7 @@ function screenFeedback(currentWeek, selWeek) {
     ? `
     <div style="display:flex;align-items:center;gap:5px;margin-top:7px">
       <span style="width:14px;height:0;border-top:1px dashed var(--vl-ink-3)"></span>
-      <span style="font-size:10.5px;color:var(--vl-ink-3)">점선 = 첫 주 ${VL.baselineH.toFixed(2)}</span>
+      <span style="font-size:10.5px;color:var(--vl-ink-3)">?먯꽑 = 泥?二?${VL.baselineH.toFixed(2)}</span>
     </div>`
     : "";
 
@@ -274,8 +274,8 @@ function screenFeedback(currentWeek, selWeek) {
     <div style="display:flex;align-items:center;justify-content:space-between">
       <div>
         <div style="font-size:16px;font-weight:800;color:var(--vl-ink)">
-          ${w.label} 리포트
-          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> · ViewLens와 함께한 첫 주</span>' : ""}
+          ${w.label} 由ы룷??
+          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> 쨌 ViewLens? ?④퍡??泥?二?/span>' : ""}
         </div>
         <div style=";font-size:11.5px;color:var(--vl-ink-3);margin-top:2px">${w.range}</div>
       </div>
@@ -285,15 +285,15 @@ function screenFeedback(currentWeek, selWeek) {
       pad: 16,
       children: `
       <div style="display:flex;align-items:center;gap:14px">
-        <div class="vl-tip" data-tip="시청한 영상이 여러 카테고리에 고르게 퍼져 있을수록 높아지는 점수예요.&#10;한 주제만 보면 낮고, 다양하게 볼수록 올라가요." style="text-align:center;flex-shrink:0">
+        <div class="vl-tip" data-tip="?쒖껌???곸긽???щ윭 移댄뀒怨좊━??怨좊Ⅴ寃??쇱졇 ?덉쓣?섎줉 ?믪븘吏???먯닔?덉슂.&#10;??二쇱젣留?蹂대㈃ ??퀬, ?ㅼ뼇?섍쾶 蹂쇱닔濡??щ씪媛??" style="text-align:center;flex-shrink:0">
           <div style="font-weight:700;font-size:30px;color:var(--vl-ink);line-height:1;letter-spacing:-0.02em">${w.entropy.toFixed(2)}</div>
-          <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">다양성 점수 ⓘ</div>
+          <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">?ㅼ뼇???먯닔 ??/div>
         </div>
         <div style="width:1px;align-self:stretch;background:var(--vl-line)"></div>
         <div style="flex:1">${vsBaseContent}</div>
       </div>
       <div style="margin-top:14px;padding-top:14px;border-top:1px solid var(--vl-line)">
-        ${vlSectionLabel({ text: "일별 다양성 추이" })}
+        ${vlSectionLabel({ text: "?쇰퀎 ?ㅼ뼇??異붿씠" })}
         ${vlMiniLine({ data: w.daily, baseline: w.isBaseline ? null : VL.baselineH })}
         ${baselineLegend}
       </div>
@@ -303,23 +303,26 @@ function screenFeedback(currentWeek, selWeek) {
     ${vlCard({
       pad: 16,
       children: `
-      ${vlSectionLabel({ text: "주간 카테고리 분포" })}
+      ${vlSectionLabel({ text: "二쇨컙 移댄뀒怨좊━ 遺꾪룷" })}
       ${vlBarChart({ data: w.dist })}
     `,
     })}
 
-    ${vlReview({ text: w.review, title: `${w.label} 돌아보기` })}
+    ${vlReview({ text: w.review, title: `${w.label} ?뚯븘蹂닿린` })}
   </div>`;
 }
 
-// ── Control group home ────────────────────────────────────────────────────────
+// ?? Control group home ????????????????????????????????????????????????????????
 
 function screenControlHome(day, stats = {}) {
   const cells = [
-    { v: `${stats.todayCount ?? VL.con.todayCount}개`, l: "오늘 시청한 영상" },
-    { v: `${stats.totalCount ?? VL.con.totalCount}개`, l: "총 누적 시청" },
-    { v: `${day}일째`, l: "설치 후" },
-    { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "실험 종료까지" },
+    { v: `${stats.todayCount ?? VL.con.todayCount}媛?, l: "?ㅻ뒛 ?쒖껌???곸긽" },
+    {
+      v: `${stats.totalCount ?? VL.con.totalCount}媛?,
+      l: "吏湲덇퉴吏 ?꾩쟻 ?쒖껌???곸긽",
+    },
+    { v: `${day}?쇱㎏`, l: "ViewLens? ?④퍡??吏" },
+    { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "?ㅽ뿕 醫낅즺源뚯?" },
   ];
   const gridCells = cells
     .map(
@@ -344,9 +347,9 @@ function screenControlHome(day, stats = {}) {
           ${markSVG({ size: 36, filled: false, accent: "var(--vl-accent)" })}
         </span>
       </div>
-      <div style="margin-top:16px;font-size:16.5px;font-weight:800;color:var(--vl-ink)">시청 기록을 수집하고 있어요</div>
+      <div style="margin-top:16px;font-size:16.5px;font-weight:800;color:var(--vl-ink)">?쒖껌 湲곕줉???섏쭛?섍퀬 ?덉뼱??/div>
       <p style="margin:9px auto 0;max-width:250px;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty">
-        평소처럼 유튜브를 시청해 주세요. 연구 기간 동안 시청 데이터가 기기 안에 안전하게 기록돼요.
+        ?됱냼泥섎읆 ?좏뒠釉뚮? ?쒖껌??二쇱꽭?? ?곌뎄 湲곌컙 ?숈븞 ?쒖껌 ?곗씠?곌? 湲곌린 ?덉뿉 ?덉쟾?섍쾶 湲곕줉?쇱슂.
       </p>
     `,
     })}
@@ -354,35 +357,35 @@ function screenControlHome(day, stats = {}) {
     ${vlCard({ pad: 0, children: `<div style="display:grid;grid-template-columns:1fr 1fr">${gridCells}</div>` })}
 
     <div style="display:flex;align-items:flex-start;gap:9px;padding:13px 14px;background:var(--vl-card-2);border:1px solid var(--vl-line);border-radius:13px">
-      <div style="width:18px;height:18px;border-radius:6px;background:var(--vl-accent-soft);color:var(--vl-accent);display:grid;place-items:center;flex-shrink:0;margin-top:1px">
-        ${_lockIcon(10)}
+      <div style="width:25px;height:25px;border-radius:7px;background:var(--vl-accent-soft);color:var(--vl-accent);display:grid;place-items:center;flex-shrink:0;margin-top:1px">
+        ${_lockIcon(15)}
       </div>
       <p style="margin:0;font-size:11.5px;line-height:1.55;color:var(--vl-ink-2);text-wrap:pretty">
-        실험 기간 중 피드백 제공 시점은 참여자마다 다를 수 있으며, 실험 종료 후 모든 참여자에게 결과를 공유합니다.
+        ?ㅽ뿕 湲곌컙 以??쇰뱶諛??쒓났 ?쒖젏? 李몄뿬?먮쭏???ㅻ? ???덉쑝硫? ?ㅽ뿕 醫낅즺 ??紐⑤뱺 李몄뿬?먯뿉寃?寃곌낵瑜?怨듭쑀?⑸땲??
       </p>
     </div>
   </div>`;
 }
 
-// ── Survey modal ──────────────────────────────────────────────────────────────
+// ?? Survey modal ??????????????????????????????????????????????????????????????
 
 function screenSurveyModal(week) {
   return `<div id="vl-survey-overlay" style="position:absolute;inset:0;z-index:40;background:color-mix(in oklab,var(--vl-ink) 42%,transparent);backdrop-filter:blur(2px)">
     <div style="position:absolute;left:0;right:0;bottom:0;background:var(--vl-card);border-radius:22px 22px 0 0;padding:22px 20px 20px;box-shadow:0 -16px 40px rgba(0,0,0,.18);animation:vlSheet .32s cubic-bezier(.2,.9,.2,1)">
       <div style="width:38px;height:4px;border-radius:999px;background:var(--vl-line-2);margin:0 auto 16px"></div>
-      ${vlBadge({ text: `${week}주차 설문`, tone: "accent", size: "sm" })}
-      <h3 style="margin:12px 0 0;font-size:18px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${week}주차가 끝났어요!</h3>
+      ${vlBadge({ text: `${week}二쇱감 ?ㅻЦ`, tone: "accent", size: "sm" })}
+      <h3 style="margin:12px 0 0;font-size:18px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${week}二쇱감媛 ?앸궗?댁슂!</h3>
       <p style="margin:8px 0 0;font-size:13.5px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty">
-        연구자가 개인적으로 보내드린 <b style="color:var(--vl-ink)">설문 링크</b>에 참여해 주세요.
-        여러분의 응답이 연구에 큰 도움이 돼요.
+        ?곌뎄?먭? 媛쒖씤?곸쑝濡?蹂대궡?쒕┛ <b style="color:var(--vl-ink)">?ㅻЦ 留곹겕</b>??李몄뿬??二쇱꽭??
+        ?щ윭遺꾩쓽 ?묐떟???곌뎄?????꾩????쇱슂.
       </p>
       <div style="display:flex;flex-direction:column;gap:9px;margin-top:18px">
         <button id="vl-survey-done"
-          style="width:100%;padding:13px;border:none;border-radius:13px;cursor:pointer;background:var(--vl-accent);color:var(--vl-on-accent);font-size:14px;font-weight:700;font-family:inherit">설문 완료했어요</button>
+          style="width:100%;padding:13px;border:none;border-radius:13px;cursor:pointer;background:var(--vl-accent);color:var(--vl-on-accent);font-size:14px;font-weight:700;font-family:inherit">?ㅻЦ ?꾨즺?덉뼱??/button>
         <button id="vl-survey-later"
-          style="width:100%;padding:12px;border-radius:13px;cursor:pointer;background:transparent;color:var(--vl-ink-2);border:1px solid var(--vl-line-2);font-size:13.5px;font-weight:600;font-family:inherit">아직 안 했어요</button>
+          style="width:100%;padding:12px;border-radius:13px;cursor:pointer;background:transparent;color:var(--vl-ink-2);border:1px solid var(--vl-line-2);font-size:13.5px;font-weight:600;font-family:inherit">?꾩쭅 ???덉뼱??/button>
       </div>
-      <p style="margin:12px 0 0;font-size:11px;color:var(--vl-ink-3);text-align:center;line-height:1.5">완료를 누르기 전까지 이 안내가 계속 표시돼요.</p>
+      <p style="margin:12px 0 0;font-size:11px;color:var(--vl-ink-3);text-align:center;line-height:1.5">?꾨즺瑜??꾨Ⅴ湲??꾧퉴吏 ???덈궡媛 怨꾩냽 ?쒖떆?쇱슂.</p>
     </div>
   </div>`;
 }

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -285,8 +285,8 @@ function screenFeedback(currentWeek, selWeek) {
       pad: 16,
       children: `
       <div style="display:flex;align-items:center;gap:14px">
-        <div class="vl-tip" data-tip="시청한 영상이 여러 카테고리에 고르게 퍼져 있을수록 높아지는 점수예요. 한 주제만 보면 낮고, 다양하게 볼수록 올라가요." style="text-align:center;flex-shrink:0">
-          <div style=";font-weight:700;font-size:30px;color:var(--vl-ink);line-height:1;letter-spacing:-0.02em">${w.entropy.toFixed(2)}</div>
+        <div class="vl-tip" data-tip="시청한 영상이 여러 카테고리에 고르게 퍼져 있을수록 높아지는 점수예요.&#10;한 주제만 보면 낮고, 다양하게 볼수록 올라가요." style="text-align:center;flex-shrink:0">
+          <div style="font-weight:700;font-size:30px;color:var(--vl-ink);line-height:1;letter-spacing:-0.02em">${w.entropy.toFixed(2)}</div>
           <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">다양성 점수 ⓘ</div>
         </div>
         <div style="width:1px;align-self:stretch;background:var(--vl-line)"></div>

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -19,7 +19,7 @@ function screenOnboarding() {
       </p>
     </div>
 
-    <div style="margin-top:30px">
+    <div style="margin-top:40px">
       <label style="font-size:12px; font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--vl-ink-3)">참여 코드</label>
       <input id="vl-onboard-input" value="" placeholder="연구자에게 받은 참여 코드" spellcheck="false" autocomplete="off"
         style="display:block;margin-top:9px;width:100%;box-sizing:border-box;padding:13px 15px;
@@ -35,8 +35,8 @@ function screenOnboarding() {
 
     <div style="margin-top:auto;padding-top:22px">
       <div style="display:flex;align-items:flex-start;gap:9px;padding:12px 13px;background:var(--vl-card-2);border:1px solid var(--vl-line);border-radius:12px">
-        <div style="width:16px;height:16px;border-radius:5px;background:var(--vl-accent-soft);color:var(--vl-accent);display:grid;place-items:center;flex-shrink:0;margin-top:1px">
-          ${_lockIcon(9)}
+        <div style="width:26px;height:26px;border-radius:7px;background:var(--vl-accent-soft);color:var(--vl-accent);display:grid;place-items:center;flex-shrink:0;margin-top:1px">
+          ${_lockIcon(20)}
         </div>
         <p style="margin:0;font-size:11.5px;line-height:1.55;color:var(--vl-ink-2);text-wrap:pretty">
           시청 기록은 익명으로 저장됩니다. 누가 어떤 영상을 봤는지는 특정되지 않으며, 수집된 데이터는 오직 연구 목적으로만 사용됩니다.

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -304,10 +304,10 @@ function screenFeedback(currentWeek, selWeek) {
 
 // ── Control group home ────────────────────────────────────────────────────────
 
-function screenControlHome(day) {
+function screenControlHome(day, stats = {}) {
   const cells = [
     { v: `${VL.con.todayCount}개`, l: "오늘 시청한 영상" },
-    { v: `${VL.con.totalCount}개`, l: "총 누적 시청" },
+    { v: `${stats.totalCount ?? VL.con.totalCount}개`, l: "총 누적 시청" },
     { v: `${day}일째`, l: "설치 후" },
     { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "실험 종료까지" },
   ];

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -139,7 +139,7 @@ function screenToday() {
     <div style="display:flex;align-items:center;gap:8px">
       <span style="width:8px;height:8px;border-radius:3px;background:${c.color};flex-shrink:0"></span>
       <span style="font-size:12px;color:var(--vl-ink);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${c.name}</span>
-      <span style="font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--vl-ink-2)">${Math.round(c.p * 100)}%</span>
+      <span style="font-size:12px;color:var(--vl-ink-2)">${Math.round(c.p * 100)}%</span>
     </div>
   `,
     )
@@ -177,12 +177,12 @@ function screenToday() {
       <div style="font-size:11.5px;color:var(--vl-ink-3);font-weight:600;margin-bottom:11px">직전 시청일 대비 다양성</div>
       <div style="display:flex;align-items:center;gap:13px">
         <div style="text-align:center">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:700;color:var(--vl-ink-3);line-height:1">${d.prevEntropy.toFixed(2)}</div>
+          <div style=";font-size:18px;font-weight:700;color:var(--vl-ink-3);line-height:1">${d.prevEntropy.toFixed(2)}</div>
           <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px">${d.prevDateLabel}</div>
         </div>
         <span style="font-size:15px;color:var(--vl-ink-3)">→</span>
         <div style="text-align:center">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:22px;font-weight:700;color:var(--vl-ink);line-height:1">${h.toFixed(2)}</div>
+          <div style=";font-size:22px;font-weight:700;color:var(--vl-ink);line-height:1">${h.toFixed(2)}</div>
           <div style="font-size:10.5px;color:var(--vl-accent);margin-top:4px;font-weight:700">오늘</div>
         </div>
         <div style="margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:3px">
@@ -232,7 +232,7 @@ function screenFeedback(currentWeek, selWeek) {
       <span style="display:flex;align-items:center;gap:4px">
         ${locked ? _lockIcon(10) : ""}${wk.label}
       </span>
-      <span style="font-size:9.5px;font-weight:500;color:inherit;opacity:0.8;font-family:'JetBrains Mono',monospace">
+      <span style="font-size:9.5px;font-weight:500;color:inherit;opacity:0.8;">
         ${locked ? `${wk.week}주차 공개` : wk.isBaseline ? "첫 주" : ""}
       </span>
     </button>`;
@@ -275,9 +275,9 @@ function screenFeedback(currentWeek, selWeek) {
       <div>
         <div style="font-size:16px;font-weight:800;color:var(--vl-ink)">
           ${w.label} 리포트
-          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> · 첫 주</span>' : ""}
+          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> · ViewLens와 함께한 첫 주</span>' : ""}
         </div>
-        <div style="font-family:'JetBrains Mono',monospace;font-size:11.5px;color:var(--vl-ink-3);margin-top:2px">${w.range}</div>
+        <div style=";font-size:11.5px;color:var(--vl-ink-3);margin-top:2px">${w.range}</div>
       </div>
     </div>
 
@@ -285,8 +285,8 @@ function screenFeedback(currentWeek, selWeek) {
       pad: 16,
       children: `
       <div style="display:flex;align-items:center;gap:14px">
-        <div style="text-align:center;flex-shrink:0;cursor:help" title="시청한 영상이 여러 카테고리에 고르게 퍼져 있을수록 높아지는 점수예요. 한 가지 주제만 보면 낮고, 다양하게 볼수록 올라가요.">
-          <div style="font-family:'JetBrains Mono',monospace;font-weight:700;font-size:30px;color:var(--vl-ink);line-height:1;letter-spacing:-0.02em">${w.entropy.toFixed(2)}</div>
+        <div class="vl-tip" data-tip="시청한 영상이 여러 카테고리에 고르게 퍼져 있을수록 높아지는 점수예요. 한 주제만 보면 낮고, 다양하게 볼수록 올라가요." style="text-align:center;flex-shrink:0">
+          <div style=";font-weight:700;font-size:30px;color:var(--vl-ink);line-height:1;letter-spacing:-0.02em">${w.entropy.toFixed(2)}</div>
           <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">다양성 점수 ⓘ</div>
         </div>
         <div style="width:1px;align-self:stretch;background:var(--vl-line)"></div>

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -317,8 +317,8 @@ function screenFeedback(currentWeek, selWeek) {
 function screenControlHome(day, stats = {}) {
   const cells = [
     { v: `${stats.todayCount ?? VL.con.todayCount}개`, l: "오늘 시청한 영상" },
-    { v: `${stats.totalCount ?? VL.con.totalCount}개`, l: "총 누적 시청" },
-    { v: `${day}일째`, l: "설치 후" },
+    { v: `${stats.totalCount ?? VL.con.totalCount}개`, l: "지금까지 시청한 영상" },
+    { v: `${day}일째`, l: "ViewLens와 함께한 지" },
     { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "실험 종료까지" },
   ];
   const gridCells = cells

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -5,7 +5,7 @@ function _lockIcon(size = 12) {
   </svg>`;
 }
 
-// ?? Onboarding ????????????????????????????????????????????????????????????????
+// ── Onboarding ────────────────────────────────────────────────────────────────
 
 function screenOnboarding() {
   return `<div style="padding:34px 22px 26px;display:flex;flex-direction:column;min-height:100%;box-sizing:border-box">
@@ -15,13 +15,13 @@ function screenOnboarding() {
         View<span style="color:var(--vl-accent)">Lens</span>
       </div>
       <p style="margin:10px 0 0;font-size:13.5px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;word-break:keep-all">
-        異붿쿇 ?뚭퀬由ъ쬁???섏뼱 ?뱀떊???쒖껌 ?듦????뚯븘遊낅땲??<br />?곌뎄?먯뿉寃?諛쏆? 李몄뿬 肄붾뱶瑜??낅젰?섏뿬 ?쒖옉??二쇱꽭??
+        추천 알고리즘을 넘어 당신의 시청 습관을 돌아봅니다.<br />연구자에게 받은 참여 코드를 입력하여 시작해 주세요.
       </p>
     </div>
 
     <div style="margin-top:40px">
-      <label style="font-size:12px; font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--vl-ink-3)">李몄뿬 肄붾뱶</label>
-      <input id="vl-onboard-input" value="" placeholder="?곌뎄?먯뿉寃?諛쏆? 李몄뿬 肄붾뱶" spellcheck="false" autocomplete="off"
+      <label style="font-size:12px; font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--vl-ink-3)">참여 코드</label>
+      <input id="vl-onboard-input" value="" placeholder="연구자에게 받은 참여 코드" spellcheck="false" autocomplete="off"
         style="display:block;margin-top:9px;width:100%;box-sizing:border-box;padding:13px 15px;
           border:1.5px solid var(--vl-line-2);border-radius:13px;background:var(--vl-card-2);
           color:var(--vl-ink);outline:none;
@@ -30,7 +30,7 @@ function screenOnboarding() {
       <button id="vl-onboard-btn"
         style="margin-top:14px;width:100%;padding:13px;border:none;border-radius:13px;
           background:var(--vl-accent);color:var(--vl-on-accent);font-size:14.5px;
-          font-weight:700;cursor:pointer;font-family:inherit">?쒖옉?섍린</button>
+          font-weight:700;cursor:pointer;font-family:inherit">시작하기</button>
     </div>
 
     <div style="margin-top:auto;padding-top:22px">
@@ -39,7 +39,7 @@ function screenOnboarding() {
           ${_lockIcon(15)}
         </div>
         <p style="margin:0;font-size:11.5px;line-height:1.55;color:var(--vl-ink-2);text-wrap:pretty">
-          ?쒖껌 湲곕줉? ?듬챸?쇰줈 ??λ맗?덈떎. ?꾧? ?대뼡 ?곸긽??遊ㅻ뒗吏???뱀젙?섏? ?딆쑝硫? ?섏쭛???곗씠?곕뒗 ?ㅼ쭅 ?곌뎄 紐⑹쟻?쇰줈留??ъ슜?⑸땲??
+          시청 기록은 익명으로 저장됩니다. 누가 어떤 영상을 봤는지는 특정되지 않으며, 수집된 데이터는 오직 연구 목적으로만 사용됩니다.
         </p>
       </div>
     </div>
@@ -54,11 +54,11 @@ function bindOnboarding(root, onSubmit) {
   function submit() {
     const c = input.value.trim().toUpperCase();
     if (!c) {
-      showErr("肄붾뱶瑜??낅젰??二쇱꽭??");
+      showErr("코드를 입력해 주세요.");
       return;
     }
     if (!VL.GROUPS[c]) {
-      showErr("?좏슚?섏? ?딆? 肄붾뱶?덉슂. ?곌뎄?먯뿉寃?諛쏆? 肄붾뱶瑜??뺤씤??二쇱꽭??");
+      showErr("유효하지 않은 코드예요. 연구자에게 받은 코드를 확인해 주세요.");
       return;
     }
     onSubmit(c);
@@ -78,7 +78,7 @@ function bindOnboarding(root, onSubmit) {
   btn.addEventListener("click", submit);
 }
 
-// ?? Today ?????????????????????????????????????????????????????????????????????
+// ── Today ─────────────────────────────────────────────────────────────────────
 
 function _collectingBanner(count) {
   if (!count) return "";
@@ -86,8 +86,8 @@ function _collectingBanner(count) {
   return `<div id="vl-collecting-banner" style="display:flex;align-items:center;gap:9px;padding:10px 16px;background:var(--vl-accent-soft);border-bottom:1px solid var(--vl-line)">
     <span style="width:7px;height:7px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
     <div style="flex:1;min-width:0">
-      <div id="vl-collecting-count" style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">?곸긽 ${count}媛??섏쭛 以?/div>
-      <div style="font-size:11px;color:var(--vl-accent);opacity:0.75;margin-top:1px">???쒓컙 ?덉뿉 ???쒖껌?섏? ?딆쑝硫??쇰뱶諛깆씠 ?앹꽦?쇱슂</div>
+      <div id="vl-collecting-count" style="font-size:12.5px;font-weight:600;color:var(--vl-accent)">영상 ${count}개 수집 중</div>
+      <div style="font-size:11px;color:var(--vl-accent);opacity:0.75;margin-top:1px">이 시간 안에 더 시청하지 않으면 피드백이 생성돼요</div>
     </div>
     <span id="vl-collecting-timer" style="font-size:11px;font-weight:600;color:var(--vl-accent);opacity:0.8;white-space:nowrap;flex-shrink:0">${timerText}</span>
   </div>`;
@@ -97,9 +97,9 @@ function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
   return `<div style="display:flex;flex-direction:column;min-height:100%">
     ${_collectingBanner(collectingCount)}
     <div style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px 0">
-      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">??/button>
-      <div style="font-size:13px;font-weight:700;color:var(--vl-ink-2)">${isToday ? "?ㅻ뒛" : dateLabel}</div>
-      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>??/button>
+      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
+      <div style="font-size:13px;font-weight:700;color:var(--vl-ink-2)">${isToday ? "오늘" : dateLabel}</div>
+      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
     </div>
     <div style="flex:1;padding:24px 24px 40px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:10px">
       <div style="position:relative;width:80px;height:80px">
@@ -110,11 +110,11 @@ function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
         </span>
       </div>
       <div>
-        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "?꾩쭅 ?ㅻ뒛 ?쒖껌 湲곕줉???놁뼱?? : "?????쒖껌 湲곕줉???놁뼱??}</div>
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "아직 오늘 시청 기록이 없어요" : "이 날 시청 기록이 없어요"}</div>
         ${
           isToday
             ? `<p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty;max-width:240px">
-          ?좏뒠釉뚮? ?쒖껌?섎㈃ ?먮룞?쇰줈 ?섏쭛???쒖옉?쇱슂.<br>?쒖껌 醫낅즺 10遺???遺꾩꽍 寃곌낵媛 ?섑??섏슂.
+          유튜브를 시청하면 자동으로 수집이 시작돼요.<br>시청 종료 10분 후 분석 결과가 나타나요.
         </p>`
             : ""
         }
@@ -152,7 +152,7 @@ function screenToday() {
     <div style="display:flex;align-items:center;gap:6px">
       <span style="width:6px;height:6px;border-radius:50%;background:var(--vl-accent);flex-shrink:0;animation:vlBlink 1.6s ease-in-out infinite"></span>
       <div style="display:flex;flex-direction:column;gap:1px">
-        <span id="vl-collecting-count" style="font-size:11.5px;font-weight:600;color:var(--vl-accent)">${d.collectingCount > 0 ? `?곸긽 ${d.collectingCount}媛??섏쭛 以? : "遺꾩꽍 以?.."}</span>
+        <span id="vl-collecting-count" style="font-size:11.5px;font-weight:600;color:var(--vl-accent)">${d.collectingCount > 0 ? `영상 ${d.collectingCount}개 수집 중` : "분석 중..."}</span>
         <span id="vl-collecting-timer" style="font-size:10.5px;color:var(--vl-accent);opacity:0.8">${d.collectingTimer || ""}</span>
       </div>
     </div>`
@@ -160,34 +160,34 @@ function screenToday() {
   return `<div style="display:flex;flex-direction:column">
     <div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
     <div style="display:flex;align-items:center;justify-content:space-between">
-      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">??/button>
+      <button id="vl-date-prev" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:var(--vl-ink-2);cursor:pointer;font-size:15px;display:grid;place-items:center">‹</button>
       <div style="text-align:center">
-        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "?ㅻ뒛" : d.dateLabel}</div>
+        <div style="font-size:16px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${isToday ? "오늘" : d.dateLabel}</div>
       </div>
-      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>??/button>
+      <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
     </div>
     <div style="display:flex;align-items:center;justify-content:space-between">
       <div>${collectingRow}</div>
-      ${vlBadge({ text: `${d.videoCount}媛??곸긽 쨌 ${d.dist.length}媛?遺꾩빞`, tone: "neutral" })}
+      ${vlBadge({ text: `${d.videoCount}개 영상 · ${d.dist.length}개 분야`, tone: "neutral" })}
     </div>
 
     ${vlCard({
       pad: 16,
       children: `
-      <div style="font-size:11.5px;color:var(--vl-ink-3);font-weight:600;margin-bottom:11px">吏곸쟾 ?쒖껌???鍮??ㅼ뼇??/div>
+      <div style="font-size:11.5px;color:var(--vl-ink-3);font-weight:600;margin-bottom:11px">직전 시청일 대비 다양성</div>
       <div style="display:flex;align-items:center;gap:13px">
         <div style="text-align:center">
           <div style=";font-size:18px;font-weight:700;color:var(--vl-ink-3);line-height:1">${d.prevEntropy.toFixed(2)}</div>
           <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px">${d.prevDateLabel}</div>
         </div>
-        <span style="font-size:15px;color:var(--vl-ink-3)">??/span>
+        <span style="font-size:15px;color:var(--vl-ink-3)">→</span>
         <div style="text-align:center">
           <div style=";font-size:22px;font-weight:700;color:var(--vl-ink);line-height:1">${h.toFixed(2)}</div>
-          <div style="font-size:10.5px;color:var(--vl-accent);margin-top:4px;font-weight:700">?ㅻ뒛</div>
+          <div style="font-size:10.5px;color:var(--vl-accent);margin-top:4px;font-weight:700">오늘</div>
         </div>
         <div style="margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:3px">
           ${vlDeltaChip({ value: delta })}
-          <span style="font-size:11px;font-weight:700;color:${delta >= 0 ? "var(--vl-good)" : "var(--vl-warn)"}">${delta >= 0 ? "???ㅼ뼇?댁죱?댁슂" : "???몄쨷?먯뼱??}</span>
+          <span style="font-size:11px;font-weight:700;color:${delta >= 0 ? "var(--vl-good)" : "var(--vl-warn)"}">${delta >= 0 ? "더 다양해졌어요" : "더 편중됐어요"}</span>
         </div>
       </div>
     `,
@@ -196,7 +196,7 @@ function screenToday() {
     ${vlCard({
       pad: 16,
       children: `
-      ${vlSectionLabel({ text: "移댄뀒怨좊━ 遺꾪룷", right: `<span style="font-size:11px;color:var(--vl-ink-3)">?ㅻ뒛 ${d.videoCount}媛?/span>` })}
+      ${vlSectionLabel({ text: "카테고리 분포", right: `<span style="font-size:11px;color:var(--vl-ink-3)">오늘 ${d.videoCount}개</span>` })}
       <div style="display:flex;align-items:center;gap:16px;margin-top:6px">
         ${vlDonut({ data: d.dist, size: 124 })}
         <div style="flex:1;display:flex;flex-direction:column;gap:8px">${catRows}</div>
@@ -209,14 +209,14 @@ function screenToday() {
   </div>`;
 }
 
-// ?? Feedback ??????????????????????????????????????????????????????????????????
+// ── Feedback ──────────────────────────────────────────────────────────────────
 
 function screenFeedback(currentWeek, selWeek) {
   const w = VL.weeks[selWeek - 1];
   const vsBase = w.entropy - VL.baselineH;
   const prevW = selWeek >= 2 ? VL.weeks[selWeek - 2] : null;
   const vsPrev = prevW ? w.entropy - prevW.entropy : 0;
-  const showPrev = selWeek >= 3; // 吏곸쟾 二쇨? 泥?二쇱? ?ㅻ? ?뚮쭔 蹂꾨룄 ?쒖떆
+  const showPrev = selWeek >= 3; // 직전 주가 첫 주와 다를 때만 별도 표시
 
   const weekBtns = VL.weeks
     .map((wk) => {
@@ -233,27 +233,27 @@ function screenFeedback(currentWeek, selWeek) {
         ${locked ? _lockIcon(10) : ""}${wk.label}
       </span>
       <span style="font-size:9.5px;font-weight:500;color:inherit;opacity:0.8;">
-        ${locked ? `${wk.week}二쇱감 怨듦컻` : wk.isBaseline ? "泥?二? : ""}
+        ${locked ? `${wk.week}주차 공개` : wk.isBaseline ? "첫 주" : ""}
       </span>
     </button>`;
     })
     .join("");
 
   const vsBaseContent = w.isBaseline
-    ? `<p style="margin:0;font-size:12px;line-height:1.55;color:var(--vl-ink-2)">泥?二쇰씪 ?꾩쭅 鍮꾧탳???댁쟾 二쇨? ?놁뼱??</p>`
+    ? `<p style="margin:0;font-size:12px;line-height:1.55;color:var(--vl-ink-2)">첫 주라 아직 비교할 이전 주가 없어요.</p>`
     : `<div>
-        <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">泥?二??鍮?/div>
+        <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">첫 주 대비</div>
         <div style="display:flex;align-items:center;gap:7px">
           ${vlDeltaChip({ value: vsBase })}
-          <span style="font-size:12px;color:var(--vl-ink-2)">${vsBase >= 0 ? "???ㅼ뼇?댁슂" : "???ㅼ뼇?댁슂"}</span>
+          <span style="font-size:12px;color:var(--vl-ink-2)">${vsBase >= 0 ? "더 다양해요" : "덜 다양해요"}</span>
         </div>
         ${
           showPrev
             ? `<div style="margin-top:8px">
-          <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">吏곸쟾 二?${prevW.label}) ?鍮?/div>
+          <div style="font-size:11.5px;color:var(--vl-ink-3);margin-bottom:4px">직전 주(${prevW.label}) 대비</div>
           <div style="display:flex;align-items:center;gap:7px">
             ${vlDeltaChip({ value: vsPrev })}
-            <span style="font-size:12px;color:var(--vl-ink-2)">${vsPrev >= 0 ? "???ㅼ뼇?댁슂" : "???ㅼ뼇?댁슂"}</span>
+            <span style="font-size:12px;color:var(--vl-ink-2)">${vsPrev >= 0 ? "더 다양해요" : "덜 다양해요"}</span>
           </div>
         </div>`
             : ""
@@ -264,7 +264,7 @@ function screenFeedback(currentWeek, selWeek) {
     ? `
     <div style="display:flex;align-items:center;gap:5px;margin-top:7px">
       <span style="width:14px;height:0;border-top:1px dashed var(--vl-ink-3)"></span>
-      <span style="font-size:10.5px;color:var(--vl-ink-3)">?먯꽑 = 泥?二?${VL.baselineH.toFixed(2)}</span>
+      <span style="font-size:10.5px;color:var(--vl-ink-3)">점선 = 첫 주 ${VL.baselineH.toFixed(2)}</span>
     </div>`
     : "";
 
@@ -274,8 +274,8 @@ function screenFeedback(currentWeek, selWeek) {
     <div style="display:flex;align-items:center;justify-content:space-between">
       <div>
         <div style="font-size:16px;font-weight:800;color:var(--vl-ink)">
-          ${w.label} 由ы룷??
-          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> 쨌 ViewLens? ?④퍡??泥?二?/span>' : ""}
+          ${w.label} 리포트
+          ${w.isBaseline ? '<span style="font-size:11px;color:var(--vl-ink-3);font-weight:600"> · ViewLens와 함께한 첫 주</span>' : ""}
         </div>
         <div style=";font-size:11.5px;color:var(--vl-ink-3);margin-top:2px">${w.range}</div>
       </div>
@@ -285,15 +285,15 @@ function screenFeedback(currentWeek, selWeek) {
       pad: 16,
       children: `
       <div style="display:flex;align-items:center;gap:14px">
-        <div class="vl-tip" data-tip="?쒖껌???곸긽???щ윭 移댄뀒怨좊━??怨좊Ⅴ寃??쇱졇 ?덉쓣?섎줉 ?믪븘吏???먯닔?덉슂.&#10;??二쇱젣留?蹂대㈃ ??퀬, ?ㅼ뼇?섍쾶 蹂쇱닔濡??щ씪媛??" style="text-align:center;flex-shrink:0">
+        <div class="vl-tip" data-tip="시청한 영상이 여러 카테고리에 고르게 퍼져 있을수록 높아지는 점수예요.&#10;한 주제만 보면 낮고, 다양하게 볼수록 올라가요." style="text-align:center;flex-shrink:0">
           <div style="font-weight:700;font-size:30px;color:var(--vl-ink);line-height:1;letter-spacing:-0.02em">${w.entropy.toFixed(2)}</div>
-          <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">?ㅼ뼇???먯닔 ??/div>
+          <div style="font-size:10.5px;color:var(--vl-ink-3);margin-top:4px;font-weight:600">다양성 점수 ⓘ</div>
         </div>
         <div style="width:1px;align-self:stretch;background:var(--vl-line)"></div>
         <div style="flex:1">${vsBaseContent}</div>
       </div>
       <div style="margin-top:14px;padding-top:14px;border-top:1px solid var(--vl-line)">
-        ${vlSectionLabel({ text: "?쇰퀎 ?ㅼ뼇??異붿씠" })}
+        ${vlSectionLabel({ text: "일별 다양성 추이" })}
         ${vlMiniLine({ data: w.daily, baseline: w.isBaseline ? null : VL.baselineH })}
         ${baselineLegend}
       </div>
@@ -303,26 +303,23 @@ function screenFeedback(currentWeek, selWeek) {
     ${vlCard({
       pad: 16,
       children: `
-      ${vlSectionLabel({ text: "二쇨컙 移댄뀒怨좊━ 遺꾪룷" })}
+      ${vlSectionLabel({ text: "주간 카테고리 분포" })}
       ${vlBarChart({ data: w.dist })}
     `,
     })}
 
-    ${vlReview({ text: w.review, title: `${w.label} ?뚯븘蹂닿린` })}
+    ${vlReview({ text: w.review, title: `${w.label} 돌아보기` })}
   </div>`;
 }
 
-// ?? Control group home ????????????????????????????????????????????????????????
+// ── Control group home ────────────────────────────────────────────────────────
 
 function screenControlHome(day, stats = {}) {
   const cells = [
-    { v: `${stats.todayCount ?? VL.con.todayCount}媛?, l: "?ㅻ뒛 ?쒖껌???곸긽" },
-    {
-      v: `${stats.totalCount ?? VL.con.totalCount}媛?,
-      l: "吏湲덇퉴吏 ?꾩쟻 ?쒖껌???곸긽",
-    },
-    { v: `${day}?쇱㎏`, l: "ViewLens? ?④퍡??吏" },
-    { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "?ㅽ뿕 醫낅즺源뚯?" },
+    { v: `${stats.todayCount ?? VL.con.todayCount}개`, l: "오늘 시청한 영상" },
+    { v: `${stats.totalCount ?? VL.con.totalCount}개`, l: "총 누적 시청" },
+    { v: `${day}일째`, l: "설치 후" },
+    { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "실험 종료까지" },
   ];
   const gridCells = cells
     .map(
@@ -347,9 +344,9 @@ function screenControlHome(day, stats = {}) {
           ${markSVG({ size: 36, filled: false, accent: "var(--vl-accent)" })}
         </span>
       </div>
-      <div style="margin-top:16px;font-size:16.5px;font-weight:800;color:var(--vl-ink)">?쒖껌 湲곕줉???섏쭛?섍퀬 ?덉뼱??/div>
+      <div style="margin-top:16px;font-size:16.5px;font-weight:800;color:var(--vl-ink)">시청 기록을 수집하고 있어요</div>
       <p style="margin:9px auto 0;max-width:250px;font-size:13px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty">
-        ?됱냼泥섎읆 ?좏뒠釉뚮? ?쒖껌??二쇱꽭?? ?곌뎄 湲곌컙 ?숈븞 ?쒖껌 ?곗씠?곌? 湲곌린 ?덉뿉 ?덉쟾?섍쾶 湲곕줉?쇱슂.
+        평소처럼 유튜브를 시청해 주세요. 연구 기간 동안 시청 데이터가 기기 안에 안전하게 기록돼요.
       </p>
     `,
     })}
@@ -361,31 +358,31 @@ function screenControlHome(day, stats = {}) {
         ${_lockIcon(15)}
       </div>
       <p style="margin:0;font-size:11.5px;line-height:1.55;color:var(--vl-ink-2);text-wrap:pretty">
-        ?ㅽ뿕 湲곌컙 以??쇰뱶諛??쒓났 ?쒖젏? 李몄뿬?먮쭏???ㅻ? ???덉쑝硫? ?ㅽ뿕 醫낅즺 ??紐⑤뱺 李몄뿬?먯뿉寃?寃곌낵瑜?怨듭쑀?⑸땲??
+        실험 기간 중 피드백 제공 시점은 참여자마다 다를 수 있으며, 실험 종료 후 모든 참여자에게 결과를 공유합니다.
       </p>
     </div>
   </div>`;
 }
 
-// ?? Survey modal ??????????????????????????????????????????????????????????????
+// ── Survey modal ──────────────────────────────────────────────────────────────
 
 function screenSurveyModal(week) {
   return `<div id="vl-survey-overlay" style="position:absolute;inset:0;z-index:40;background:color-mix(in oklab,var(--vl-ink) 42%,transparent);backdrop-filter:blur(2px)">
     <div style="position:absolute;left:0;right:0;bottom:0;background:var(--vl-card);border-radius:22px 22px 0 0;padding:22px 20px 20px;box-shadow:0 -16px 40px rgba(0,0,0,.18);animation:vlSheet .32s cubic-bezier(.2,.9,.2,1)">
       <div style="width:38px;height:4px;border-radius:999px;background:var(--vl-line-2);margin:0 auto 16px"></div>
-      ${vlBadge({ text: `${week}二쇱감 ?ㅻЦ`, tone: "accent", size: "sm" })}
-      <h3 style="margin:12px 0 0;font-size:18px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${week}二쇱감媛 ?앸궗?댁슂!</h3>
+      ${vlBadge({ text: `${week}주차 설문`, tone: "accent", size: "sm" })}
+      <h3 style="margin:12px 0 0;font-size:18px;font-weight:800;color:var(--vl-ink);letter-spacing:-0.02em">${week}주차가 끝났어요!</h3>
       <p style="margin:8px 0 0;font-size:13.5px;line-height:1.6;color:var(--vl-ink-2);text-wrap:pretty">
-        ?곌뎄?먭? 媛쒖씤?곸쑝濡?蹂대궡?쒕┛ <b style="color:var(--vl-ink)">?ㅻЦ 留곹겕</b>??李몄뿬??二쇱꽭??
-        ?щ윭遺꾩쓽 ?묐떟???곌뎄?????꾩????쇱슂.
+        연구자가 개인적으로 보내드린 <b style="color:var(--vl-ink)">설문 링크</b>에 참여해 주세요.
+        여러분의 응답이 연구에 큰 도움이 돼요.
       </p>
       <div style="display:flex;flex-direction:column;gap:9px;margin-top:18px">
         <button id="vl-survey-done"
-          style="width:100%;padding:13px;border:none;border-radius:13px;cursor:pointer;background:var(--vl-accent);color:var(--vl-on-accent);font-size:14px;font-weight:700;font-family:inherit">?ㅻЦ ?꾨즺?덉뼱??/button>
+          style="width:100%;padding:13px;border:none;border-radius:13px;cursor:pointer;background:var(--vl-accent);color:var(--vl-on-accent);font-size:14px;font-weight:700;font-family:inherit">설문 완료했어요</button>
         <button id="vl-survey-later"
-          style="width:100%;padding:12px;border-radius:13px;cursor:pointer;background:transparent;color:var(--vl-ink-2);border:1px solid var(--vl-line-2);font-size:13.5px;font-weight:600;font-family:inherit">?꾩쭅 ???덉뼱??/button>
+          style="width:100%;padding:12px;border-radius:13px;cursor:pointer;background:transparent;color:var(--vl-ink-2);border:1px solid var(--vl-line-2);font-size:13.5px;font-weight:600;font-family:inherit">아직 안 했어요</button>
       </div>
-      <p style="margin:12px 0 0;font-size:11px;color:var(--vl-ink-3);text-align:center;line-height:1.5">?꾨즺瑜??꾨Ⅴ湲??꾧퉴吏 ???덈궡媛 怨꾩냽 ?쒖떆?쇱슂.</p>
+      <p style="margin:12px 0 0;font-size:11px;color:var(--vl-ink-3);text-align:center;line-height:1.5">완료를 누르기 전까지 이 안내가 계속 표시돼요.</p>
     </div>
   </div>`;
 }

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -101,7 +101,7 @@ function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
       <div style="font-size:13px;font-weight:700;color:var(--vl-ink-2)">${isToday ? "오늘" : dateLabel}</div>
       <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
     </div>
-    <div style="flex:1;padding:24px 24px 40px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:20px">
+    <div style="flex:1;padding:24px 24px 40px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:10px">
       <div style="position:relative;width:80px;height:80px">
         <span style="position:absolute;inset:0;border-radius:50%;background:var(--vl-accent-soft);animation:vlPulse 2.4s ease-out infinite"></span>
         <span style="position:absolute;inset:0;border-radius:50%;border:2px solid var(--vl-accent);opacity:0.4;animation:vlPulse 2.4s ease-out infinite 0.6s"></span>
@@ -119,7 +119,7 @@ function screenTodayEmpty(dateLabel, collectingCount, isToday = true) {
             : ""
         }
       </div>
-      <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--vl-ink-3)">${dateLabel}</div>
+      <div style="font-size:11px;color:var(--vl-ink-3)">${dateLabel}</div>
     </div>
   </div>`;
 }
@@ -213,10 +213,7 @@ function screenToday() {
 
 function screenFeedback(currentWeek, selWeek) {
   const w = VL.weeks[selWeek - 1];
-  const b = VL.band(w.entropy);
   const vsBase = w.entropy - VL.baselineH;
-  const badgeTone =
-    b.tone === "good" ? "good" : b.tone === "warn" ? "warn" : "accent";
 
   const weekBtns = VL.weeks
     .map((wk) => {
@@ -268,7 +265,6 @@ function screenFeedback(currentWeek, selWeek) {
         </div>
         <div style="font-family:'JetBrains Mono',monospace;font-size:11.5px;color:var(--vl-ink-3);margin-top:2px">${w.range}</div>
       </div>
-      ${vlBadge({ text: b.label, tone: badgeTone })}
     </div>
 
     ${vlCard({
@@ -315,7 +311,7 @@ function screenControlHome(day, stats = {}) {
     .map(
       (cell, i) => `
     <div style="padding:16px 18px;border-right:${i % 2 === 0 ? "1px solid var(--vl-line)" : "none"};border-bottom:${i < 2 ? "1px solid var(--vl-line)" : "none"}">
-      <div style="font-family:'JetBrains Mono',monospace;font-weight:700;font-size:24px;color:var(--vl-ink);letter-spacing:-0.02em;line-height:1">${cell.v}</div>
+      <div style="font-weight:700;font-size:24px;color:var(--vl-ink);letter-spacing:-0.02em;line-height:1">${cell.v}</div>
       <div style="font-size:11.5px;color:var(--vl-ink-3);margin-top:6px;font-weight:500">${cell.l}</div>
     </div>
   `,

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -309,7 +309,7 @@ function screenControlHome(day) {
     { v: `${VL.con.todayCount}개`, l: "오늘 시청한 영상" },
     { v: `${VL.con.totalCount}개`, l: "총 누적 시청" },
     { v: `${day}일째`, l: "설치 후" },
-    { v: `D-${VL.TOTAL_DAYS - day}`, l: "실험 종료까지" },
+    { v: `D-${Math.max(0, VL.TOTAL_DAYS - day)}`, l: "실험 종료까지" },
   ];
   const gridCells = cells
     .map(

--- a/extension/popup/viewlens-tokens.css
+++ b/extension/popup/viewlens-tokens.css
@@ -138,3 +138,41 @@ body {
 .vl-vid-link:hover {
   background: color-mix(in oklab, var(--vl-accent) 10%, transparent) !important;
 }
+
+/* 호버 툴팁 (data-tip 속성 사용) */
+.vl-tip {
+  position: relative;
+  cursor: help;
+}
+.vl-tip::after {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: max-content;
+  max-width: 200px;
+  padding: 8px 11px;
+  border-radius: 10px;
+  background: var(--vl-ink);
+  color: var(--vl-card);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: left;
+  white-space: normal;
+  letter-spacing: normal;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+  z-index: 100;
+  pointer-events: none;
+}
+.vl-tip:hover::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}

--- a/extension/popup/viewlens-tokens.css
+++ b/extension/popup/viewlens-tokens.css
@@ -142,7 +142,6 @@ body {
 /* 호버 툴팁 (data-tip 속성 사용) */
 .vl-tip {
   position: relative;
-  cursor: help;
 }
 .vl-tip::after {
   content: attr(data-tip);

--- a/extension/popup/viewlens-tokens.css
+++ b/extension/popup/viewlens-tokens.css
@@ -158,7 +158,7 @@ body {
   font-weight: 500;
   line-height: 1.5;
   text-align: left;
-  white-space: normal;
+  white-space: pre-line;
   letter-spacing: normal;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
   opacity: 0;

--- a/extension/popup/viewlens-ui.js
+++ b/extension/popup/viewlens-ui.js
@@ -4,7 +4,7 @@ function vlCard({ children = "", pad = 16, soft = false, style = "" } = {}) {
 
 function vlSectionLabel({ text = "", right = "" } = {}) {
   return `<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
-    <span style="font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:var(--vl-ink-3);white-space:nowrap">${text}</span>
+    <span style=";font-size:11px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:var(--vl-ink-3);white-space:nowrap">${text}</span>
     ${right}
   </div>`;
 }
@@ -31,7 +31,7 @@ function vlDeltaChip({ value = 0, unit = "", invertColor = false } = {}) {
         ? "var(--vl-good)"
         : "var(--vl-warn)";
   const arrow = value === 0 ? "·" : up ? "▲" : "▼";
-  return `<span style="display:inline-flex;align-items:center;gap:4px;color:${col};font-family:'JetBrains Mono',monospace;font-weight:600;font-size:12px">
+  return `<span style="display:inline-flex;align-items:center;gap:4px;color:${col};;font-weight:600;font-size:12px">
     <span style="font-size:9px">${arrow}</span>${up ? "+" : ""}${value.toFixed(2)}${unit}
   </span>`;
 }
@@ -48,7 +48,7 @@ function vlBarChart({ data = [], maxVal, animate = true } = {}) {
         <div style="flex:1;height:8px;background:var(--vl-line);border-radius:999px;overflow:hidden">
           <div style="width:${(d.p / top) * 100}%;height:100%;background:${d.color};border-radius:999px;${animate ? "transition:width .7s cubic-bezier(.2,.8,.2,1)" : ""}"></div>
         </div>
-        <span style="width:34px;text-align:right;font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--vl-ink-2);flex-shrink:0">${Math.round(d.p * 100)}%</span>
+        <span style="width:34px;text-align:right;;font-size:12px;color:var(--vl-ink-2);flex-shrink:0">${Math.round(d.p * 100)}%</span>
       </div>
     `,
       )
@@ -82,7 +82,7 @@ function vlDonut({ data = [], size = 128, thickness = 18 } = {}) {
       <g transform="rotate(-90 ${cx} ${cy})">${segments}</g>
     </svg>
     <div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center">
-      <span style="font-family:'JetBrains Mono',monospace;font-weight:700;font-size:22px;color:var(--vl-ink);line-height:1">${Math.round(top.p * 100)}%</span>
+      <span style=";font-weight:700;font-size:22px;color:var(--vl-ink);line-height:1">${Math.round(top.p * 100)}%</span>
       <span style="font-size:10.5px;color:var(--vl-ink-3);margin-top:3px;font-weight:600">${top.name}</span>
     </div>
   </div>`;
@@ -146,7 +146,7 @@ function vlReview({
           <span class="vl-vid-chevron" style="font-size:9px;line-height:1">▸</span>
           분석한 영상
         </span>
-        <span style="font-size:11px;font-family:'JetBrains Mono',monospace;color:var(--vl-ink-3)">${videos.length}개</span>
+        <span style="font-size:11px;;color:var(--vl-ink-3)">${videos.length}개</span>
       </summary>
       <div style="margin-top:9px;display:flex;flex-direction:column;gap:6px">
         ${videos

--- a/extension/popup/viewlens-ui.js
+++ b/extension/popup/viewlens-ui.js
@@ -88,66 +88,6 @@ function vlDonut({ data = [], size = 128, thickness = 18 } = {}) {
   </div>`;
 }
 
-function vlDiversityMeter({
-  value = 0,
-  max = 3.17,
-  lowAt = 1.9,
-  highAt = 2.5,
-} = {}) {
-  const zones = [
-    {
-      key: "편중",
-      lo: 0,
-      hi: lowAt,
-      col: "var(--vl-warn)",
-      desc: `0–${lowAt}`,
-    },
-    {
-      key: "보통",
-      lo: lowAt,
-      hi: highAt,
-      col: "var(--vl-ink-2)",
-      desc: `${lowAt}–${highAt}`,
-    },
-    {
-      key: "다양",
-      lo: highAt,
-      hi: max,
-      col: "var(--vl-good)",
-      desc: `${highAt}+`,
-    },
-  ];
-  const ai = value < lowAt ? 0 : value < highAt ? 1 : 2;
-  const z = zones[ai];
-  const local = Math.max(0, Math.min(1, (value - z.lo) / (z.hi - z.lo)));
-  const markP = ((ai + local) / 3) * 100;
-  const zoneBars = zones
-    .map(
-      (zn, i) =>
-        `<div style="flex:1;border-right:${i < 2 ? "2px solid var(--vl-card)" : "none"};background:${i === ai ? zn.col : `color-mix(in oklab,${zn.col} 24%,var(--vl-line))`}"></div>`,
-    )
-    .join("");
-  const zoneLabels = zones
-    .map(
-      (zn, i) =>
-        `<div style="flex:1;text-align:center">
-      <div style="font-size:12px;font-weight:${i === ai ? 800 : 600};color:${i === ai ? zn.col : "var(--vl-ink-3)"}">${zn.key}</div>
-      <div style="font-size:9.5px;font-family:'JetBrains Mono',monospace;color:var(--vl-ink-3);margin-top:2px">${zn.desc}</div>
-    </div>`,
-    )
-    .join("");
-  return `<div style="width:100%">
-    <div style="position:relative;height:24px">
-      <div style="position:absolute;left:${markP}%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center">
-        <span style="background:var(--vl-ink);color:var(--vl-card);font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:700;padding:2px 7px;border-radius:7px;white-space:nowrap;line-height:1.3">오늘 ${value.toFixed(2)}</span>
-        <span style="width:0;height:0;border-left:4px solid transparent;border-right:4px solid transparent;border-top:5px solid var(--vl-ink)"></span>
-      </div>
-    </div>
-    <div style="display:flex;height:13px;border-radius:999px;overflow:hidden">${zoneBars}</div>
-    <div style="display:flex;margin-top:7px">${zoneLabels}</div>
-  </div>`;
-}
-
 function vlMiniLine({ data = [], baseline = null, height = 64 } = {}) {
   const W = 300,
     H = height,
@@ -247,6 +187,5 @@ window.vlBadge = vlBadge;
 window.vlDeltaChip = vlDeltaChip;
 window.vlBarChart = vlBarChart;
 window.vlDonut = vlDonut;
-window.vlDiversityMeter = vlDiversityMeter;
 window.vlMiniLine = vlMiniLine;
 window.vlReview = vlReview;


### PR DESCRIPTION
## 개요

팝업 헤더의 "설치 N일째" 표시가 목업 값으로 인해 항상 "4일째"로 고정되던 문제를 수정  
실제 설치일(installDate) 기준으로 경과일을 계산하도록 변경하고, 스토어 업데이트를 위해 버전을 1.0.1로 올림  

## 변경 사항

- `_elapsedDay()` 헬퍼 추가:`VL._installDate` 기준 실제 경과일 계산 (installDate 없으면 기존 목업값 폴백)  
- 헤더 및 대조군 홈의 `tl.day`(항상 4) → 실제 경과일로 교체  
- "종료 D-" 음수 방지 클램프 추가 (`Math.max(0, …)`)  
- 온보딩 직후 첫 렌더부터 정확히 표시되도록 `VL._installDate` 즉시 세팅  
- `manifest.json` 버전 1.0.0 → 1.0.1  
- 대조군 홈 '총 누적 시청'을 실제 세션 데이터로 표시 (VL.con 목업 제거)  
- 주차 리포트의 편중/보통/다양 가치판단 라벨 제거
- '다양성 점수(bits)' → '다양성 점수' + 호버 설명 추가
- 주차 비교를 '첫 주 대비'+'직전 주 대비'로 개선, 용어 정리

## 테스트 확인

- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 신규 온보딩 시 "설치 1일째"로 표시되는지 확인

## 참고 사항

- 데이터 수집·분석·서버 전송에는 영향 없는 표시(UI) 수정    
