### PR TITLE
release: SQLite 오프사이트 백업 기능 추가

### DIFF
--- a/docs/05-작업3.md
+++ b/docs/05-작업3.md
@@ -71,9 +71,10 @@
 
 #### 남은 운영 작업 (배포 후, 후속 처리)
 
-- [ ] A1 서버 crontab에 백업 등록(밤 23시·아침 8시 KST, 2회/일). 스크립트가 `main` 배포에 포함된 뒤 등록·수동 테스트.
-- [ ] `pm2 install pm2-logrotate` — 6주간 운영 로그 로테이션(유실·디스크 방지).
-- [ ] 오프사이트 백업 대상 확정 시 [backup-db.js](../server/scripts/backup-db.js)의 TODO(rclone/scp 원격 1부) 채우기. (단일 A1 디스크 장애 대비)
+- [x] A1 서버 crontab에 백업 등록(밤 23시·아침 8시 KST, 2회/일) + 수동 실행 테스트 완료. 서버 타임존 `Asia/Seoul` 설정, 로그 `~/db-backups/backup.log`.
+- [x] `pm2 install pm2-logrotate` — 6주간 운영 로그 로테이션(유실·디스크 방지). `pm2 startup`/`pm2 save`로 재부팅 시 자동 복원까지 설정.
+- [x] 오프사이트 백업 구현 — A1 → e1 서버로 백업 자동 복사. [backup-db.js](../server/scripts/backup-db.js)가 `E1_BACKUP_HOST` 환경변수 설정 시에만 scp 전송(무압축, 원격 14일 보관, best-effort). 원격 주소·키는 코드 미포함(A1 crontab의 env로만 주입). A1→e1 무암호 SSH 키(`~/.ssh/e1_backup`) 설정 완료.
+  - [ ] 남은 것: A1 crontab 두 줄에 `E1_BACKUP_HOST=<e1 IP>` 추가 + 배포 후 전송 1회 검증.
 
 ---
 

--- a/server/scripts/backup-db.js
+++ b/server/scripts/backup-db.js
@@ -91,6 +91,18 @@ function offsitePush(dest) {
   const key = process.env.E1_BACKUP_KEY || path.join(os.homedir(), ".ssh", "e1_backup");
   const remoteDir = process.env.E1_BACKUP_DIR || "db-backups";
   const remoteRetention = Number(process.env.E1_RETENTION_DAYS || 14);
+
+  // remoteDir/remoteRetention은 원격 쉘 명령(mkdir/find)에 삽입되므로 검증한다.
+  // 쉘 메타문자·공백 유입 시 원격에서 의도치 않은 실행/구문 오류 방지. (실패해도 로컬 백업은 유효)
+  if (!/^[a-zA-Z0-9_/-]+$/.test(remoteDir)) {
+    console.warn("[backup] 오프사이트 건너뜀: E1_BACKUP_DIR에 허용되지 않는 문자가 있습니다.");
+    return;
+  }
+  if (!Number.isInteger(remoteRetention) || remoteRetention < 0) {
+    console.warn("[backup] 오프사이트 건너뜀: E1_RETENTION_DAYS가 0 이상의 정수가 아닙니다.");
+    return;
+  }
+
   const target = `${user}@${host}`;
   // BatchMode=yes: 프롬프트 없이 즉시 실패(자동화용). known_hosts는 최초 수동 접속 시 등록됨.
   const sshOpts = ["-i", key, "-o", "BatchMode=yes", "-o", "ConnectTimeout=10"];

--- a/server/scripts/backup-db.js
+++ b/server/scripts/backup-db.js
@@ -10,13 +10,24 @@
  * - 파일명    : youtube_bias-YYYYMMDD-HHMMSS.db
  * - 로테이션  : RETENTION_DAYS(기본 30일) 지난 백업 자동 삭제
  *
+ * 오프사이트 복사(선택): E1_BACKUP_HOST가 설정된 경우에만, 백업 후 원격 서버로 scp 전송한다.
+ * 단일 디스크 장애 대비. best-effort라 전송 실패해도 로컬 백업은 유효(스크립트 성공).
+ * 원격 주소·키는 코드에 두지 않고 환경변수로만 받는다(레포·이력에 노출 방지).
+ *   E1_BACKUP_HOST      원격 호스트(IP). 설정 시 오프사이트 활성화
+ *   E1_BACKUP_USER      원격 사용자 (기본 ubuntu)
+ *   E1_BACKUP_KEY       개인키 경로 (기본 ~/.ssh/e1_backup)
+ *   E1_BACKUP_DIR       원격 저장 디렉터리 (기본 db-backups, 홈 기준 상대경로)
+ *   E1_RETENTION_DAYS   원격 보관 일수 (기본 14)
+ *
  * 사용:
  *   node server/scripts/backup-db.js
  *   BACKUP_DIR=/mnt/backups RETENTION_DAYS=60 node server/scripts/backup-db.js
+ *   E1_BACKUP_HOST=203.0.113.9 node server/scripts/backup-db.js
  */
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { execFileSync } = require("child_process");
 const Database = require("better-sqlite3");
 
 const DB_PATH = path.join(__dirname, "..", "youtube_bias.db");
@@ -67,9 +78,36 @@ async function main() {
   }
   if (removed) console.log(`[backup] 로테이션: 오래된 백업 ${removed}개 삭제 (>${RETENTION_DAYS}일)`);
 
-  // TODO(오프사이트): 단일 서버 디스크 장애 대비 원격 1부 복사 권장.
-  //   예) rclone copy "${dest}" remote:youtube-bias-backups/
-  //       또는 scp "${dest}" user@host:/backups/
+  offsitePush(dest);
+}
+
+// 오프사이트 복사 — E1_BACKUP_HOST가 설정된 경우에만 동작.
+// best-effort: 전송/원격정리 실패해도 로컬 백업은 이미 성공했으므로 경고만 남기고 넘어간다.
+function offsitePush(dest) {
+  const host = process.env.E1_BACKUP_HOST;
+  if (!host) return; // 미설정 → 오프사이트 비활성화
+
+  const user = process.env.E1_BACKUP_USER || "ubuntu";
+  const key = process.env.E1_BACKUP_KEY || path.join(os.homedir(), ".ssh", "e1_backup");
+  const remoteDir = process.env.E1_BACKUP_DIR || "db-backups";
+  const remoteRetention = Number(process.env.E1_RETENTION_DAYS || 14);
+  const target = `${user}@${host}`;
+  // BatchMode=yes: 프롬프트 없이 즉시 실패(자동화용). known_hosts는 최초 수동 접속 시 등록됨.
+  const sshOpts = ["-i", key, "-o", "BatchMode=yes", "-o", "ConnectTimeout=10"];
+
+  try {
+    execFileSync("ssh", [...sshOpts, target, `mkdir -p ${remoteDir}`], { stdio: "pipe" });
+    execFileSync("scp", [...sshOpts, dest, `${target}:${remoteDir}/`], { stdio: "pipe" });
+    // 원격 로테이션 — remoteRetention일 지난 백업 삭제
+    execFileSync(
+      "ssh",
+      [...sshOpts, target, `find ${remoteDir} -maxdepth 1 -name 'youtube_bias-*.db' -mtime +${remoteRetention} -delete`],
+      { stdio: "pipe" },
+    );
+    console.log(`[backup] 오프사이트 전송 완료: ${target}:${remoteDir}/ (보관 ${remoteRetention}일)`);
+  } catch (err) {
+    console.warn("[backup] 오프사이트 전송 실패(로컬 백업은 정상):", err.message);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
이번 PR에서는 백업 안정성과 운영 환경을 개선했습니다. SQLite 백업 파일을 환경변수 기반으로 원격 서버에 자동 복사하는 오프사이트 백업 기능을 추가하고, 전송 실패 시에도 로컬 백업은 정상 유지되도록 처리했습니다. 또한 백업 관련 환경변수 검증을 추가해 원격 명령 인젝션 가능성을 방지했으며, 운영 문서를 갱신하여 로그 로테이션, 재부팅 자동 복원, 오프사이트 백업 적용 현황을 반영했습니다.
