### PR TITLE
feat: 세션 성능 및 사용자 상호작용 로깅 추가

### DIFF
--- a/docs/05-작업3.md
+++ b/docs/05-작업3.md
@@ -107,7 +107,10 @@
 - 설명: 팝업 체류 시간과 탭(오늘/주차별) 클릭 여부·횟수를 수집·전송한다. (사용자 상호작용/행동 분석용)
 - Priority: Medium / Owner: FE
 - 스키마: 10-2에서 `popup_events` 테이블 **확정 완료**(`dwellMs`, `tabTodayClicks`, `tabWeekClicks`, `feedbackViewed`, `openedAt`).
-- 핵심 고려 / 남은 구현:
-  - 팝업 close 시 전송(visibilitychange/beforeunload), 전송 실패 대비 버퍼/재시도, baseline 기간 수집 여부를 실험 설계와 일치.
-  - 신규 엔드포인트 `POST /api/popup-events` 추가 필요(현재 미구현).
-  - **`feedbackViewed`(피드백 실제 열람 여부)** 는 "개입이 전달되었는가"를 가르는 핵심 지표라 우선 수집 권장. engagement 최근성 분석을 위해 `openedAt` 병행.
+
+#### 완료 작업
+
+- [x] **신규 엔드포인트** ([server/routes/popup-events.js](../server/routes/popup-events.js), [server/app.js](../server/app.js)): `POST /api/popup-events` 추가. `anonymousId` 필수, 카운트/`dwellMs` 음수 아닌 정수·`feedbackViewed` 0/1·`openedAt` 날짜 형식 검증(모두 선택). in-memory 스모크 테스트로 저장 확인.
+- [x] **FE 수집·전송** ([extension/popup/viewlens-popup.js](../extension/popup/viewlens-popup.js)): 온보딩 완료 사용자만 계측. `openedAt`, 탭 클릭(위임 리스너로 `today`/`feedback` 탭 카운트), `feedbackViewed`(EXP가 열자마자 실제 리뷰 노출 또는 주차별 탭 열람 시 1, CON은 0) 수집.
+- [x] **전송/재시도 전략**: 팝업 close 시 `storage.set`은 teardown에 잘릴 수 있어, 세션 중 `livePopupEvent` 스냅샷을 상호작용·1초 간격으로 갱신하고 **다음 open(boot)에서 이전 스냅샷을 확정 큐(`pendingPopupEvents`)로 승격→전송, 실패분은 재시도**. 팝업 싱글턴 특성으로 이전/현재 구분이 단순. `sendBeacon` 미사용 → **중복 전송 없음**. `dwellMs`는 최종 쓰기가 잘려도 ±1초 오차로 보존.
+- baseline 기간 수집 여부는 실험 설계에 따르며, 현재는 온보딩 이후 상시 수집.

--- a/docs/05-작업3.md
+++ b/docs/05-작업3.md
@@ -7,7 +7,7 @@
 ## Epic 10: 데이터·개인정보 보강
 
 - 설명: 실험 규모·기간 확대(참여자 80명 목표, 총 6주)에 필요한 데이터·개인정보 요건을 충족하도록 시스템을 보강한다.
-- 작업 순서(효율): 10-1(개인정보·IRB) → 10-2(DB·스키마) → 10-3(latency) → 10-4(폴백) → 10-5(마이크로 로그)
+- 작업 순서(효율): 10-1(개인정보·IRB) → 10-2(DB·스키마) → 10-3(latency) → 10-4(폴백) → 10-5(마이크로 로그) → 10-6(완료 알림) → 10-7(세밀 다양성 신호) → 10-8(2주 베이스라인·그룹 분기)
 
 ---
 
@@ -114,3 +114,94 @@
 - [x] **FE 수집·전송** ([extension/popup/viewlens-popup.js](../extension/popup/viewlens-popup.js)): 온보딩 완료 사용자만 계측. `openedAt`, 탭 클릭(위임 리스너로 `today`/`feedback` 탭 카운트), `feedbackViewed`(EXP가 열자마자 실제 리뷰 노출 또는 주차별 탭 열람 시 1, CON은 0) 수집.
 - [x] **전송/재시도 전략**: 팝업 close 시 `storage.set`은 teardown에 잘릴 수 있어, 세션 중 `livePopupEvent` 스냅샷을 상호작용·1초 간격으로 갱신하고 **다음 open(boot)에서 이전 스냅샷을 확정 큐(`pendingPopupEvents`)로 승격→전송, 실패분은 재시도**. 팝업 싱글턴 특성으로 이전/현재 구분이 단순. `sendBeacon` 미사용 → **중복 전송 없음**. `dwellMs`는 최종 쓰기가 잘려도 ±1초 오차로 보존.
 - baseline 기간 수집 여부는 실험 설계에 따르며, 현재는 온보딩 이후 상시 수집.
+
+> `feedbackViewed`의 정확도 한계: 현재는 "리뷰가 화면에 표시됨" 수준(팝업을 즉시 닫아도 1로 집계). "실제 열람"에 가까운 측정은 10-6에서 **분석 완료 알림 → 능동 클릭**을 열람 트리거로 삼아 보강한다.
+
+### Story 10-6: 세션 분석 완료 알림 및 피드백 열람 유도 — 후속 스토리
+
+- 설명: 세션 분석(피드백 생성)이 완료되면 Chrome 알림·아이콘 배지로 사용자에게 알리고, "피드백 보러 가기" 클릭을 **피드백 열람 시작 시점**으로 기록한다.
+- Priority: Medium / Owner: FE(확장) + BE(저장)
+- Dependencies: 10-5(팝업 로그)·10-3/10-4(세션 저장 경로). 그룹·타이밍 게이트는 10-8과 연동.
+
+#### 설계 결정 (배경)
+
+- **문제**: 피드백 생성은 세션 종료(10분 비활성) 후에야 시작되므로, 완성 시점엔 사용자가 이미 팝업을 닫고 이탈한 상태다. 따라서 "표시됨" 기반 `feedbackViewed`(10-5)는 개입 전달을 정확히 못 잡는다.
+- **팝업 상시 노출 불가**: Chrome action 팝업은 포커스 상실 시 강제로 닫히고, 프로그램적 유지·재오픈 API가 없다(`chrome.action.openPopup()`도 사용자 제스처·포커스 창 요구, 플랫폼별 불안정) → 알림 방식 채택.
+- **알림 강도 병행**: `chrome.notifications`(배너+버튼, `notifications` 권한 필요) + `chrome.action.setBadgeText`(권한 불필요, 은은·지속). 알림을 놓쳐도 배지가 남는다.
+- **완료 시점**: [extension/background.js](../extension/background.js) `analyzeSession`의 리뷰 저장 직후(알람 핸들러라 SW 활성).
+- **열람 트리거**: `notifications.onButtonClicked` → 피드백 화면을 **탭으로 오픈**(`popup.html?src=notification`; `action.openPopup`보다 신뢰성↑). 진입 시 열람 기록.
+- **측정 퍼널**: 생성 → 알림(전달 시도) → 클릭(열람 시작) → 열람. 알림~클릭 시간차 = time-to-view(engagement 최근성, 기존 `openedAt`이 근사하려던 값).
+
+#### 미해결 / 결정 필요
+
+- **연구 설계**: 능동 알림은 개입을 강화하는 추가 nudge → EXP군에만, **베이스라인 종료(10-8) 이후에만** 활성. 순수 관찰 대비 열람률↑/자발성 측정 저하 트레이드오프를 연구 가설과 합치할 것.
+- **스키마**: 피드백 열람은 세션 단위이므로 `sessions`에 `feedbackNotifiedAt`/`feedbackViewedAt` 컬럼을 비파괴 `ALTER`로 추가 검토(현 `popup_events`는 세션 링크·source 없음).
+
+#### Tasks
+
+- [ ] `manifest.json`에 `notifications` 권한 추가
+- [ ] 분석 완료 시 `chrome.notifications` + 배지 표시 (EXP·베이스라인 종료 후 게이트 — 10-8)
+- [ ] 알림/버튼 클릭 → 피드백 탭 오픈 + 열람 기록, 배지 클리어
+- [ ] 스키마 확장(`sessions.feedbackNotifiedAt`/`feedbackViewedAt`) 및 서버 수신·저장
+
+### Story 10-7: 세밀 다양성 신호(토픽·채널·발견 경로) — 후속 스토리
+
+- 설명: YouTube 기본 카테고리(~15개 버킷)만으로는 추천 알고리즘이 만든 필터버블이 드러나지 않는다. 같은 API 호출로 얻을 수 있는 세부 토픽·채널 집중도(및 별도로 발견 경로)를 수집해 다양성 측정을 세밀화한다.
+- Priority: Medium / Owner: FE(측정) + BE(저장) + Research
+- Dependencies: 10-2(스키마 확장)·기존 [extension/pipeline/youtube.js](../extension/pipeline/youtube.js)/[analysis.js](../extension/pipeline/analysis.js)
+
+#### 배경 (리뷰 반영)
+
+- 지시형 → **거울형** 전환은 유지. **이념·논조 라벨링은 배제** — LLM 판단 의존이라 신뢰성 낮고, "정치 성향·이념 추론 금지"를 못박은 거울형 원칙([llm.js](../extension/pipeline/llm.js) 프롬프트)과 충돌.
+- **`categoryId` 한계**: (1) 카테고리 **내부** 집중(같은 사건·논조), (2) **채널/창작자** 집중, (3) **발견 경로**(추천 vs 검색·구독)를 못 잡음 → "다양한 척하지만 소수 채널·추천에 갇힘"이 안 보인다. 현재 [youtube.js](../extension/pipeline/youtube.js)는 `part=snippet`으로 `categoryId` 하나만 사용.
+- **측정 ≠ 피드백**: 세밀 신호는 우선 연구 분석용으로 수집하고, 거울에 무엇을 비출지는 별도 결정(예: "이번 주 78%가 3개 채널에서" 같은 사실 반영은 거울형과 정합).
+
+#### 개선안 (효과 × 실현성)
+
+- **A. `topicDetails.topicCategories`**: `videos.list`를 `part=snippet,topicDetails`로 확장(같은 1 quota). Wikipedia 기반 세부 토픽 → 15버킷보다 세밀. 저비용.
+- **B. 채널 집중도**: 이미 오는 `snippet.channelId`/`channelTitle` 저장 → **채널 엔트로피** 계산. 필터버블 직접 지표, 저비용·최고 가성비.
+- **C. 발견 경로 계측(별도 스파이크)**: content script로 홈피드/추천 사이드바/자동재생 vs 검색·구독 구분 → "알고리즘 주도 시청 비율". 우려의 정곡이나 DOM/URL 기반이라 brittle·검증 필요.
+- **D. 의미 기반 세분(분석 단계 옵션)**: 제목·설명 임베딩/LLM 서브토픽으로 카테고리 내부 집중 포착. 신뢰성 주의, 이념 판정은 배제.
+
+#### 우선순위
+
+- **바로**: A + B — 같은 호출에 거의 공짜로 얹혀 필터버블 데이터 확보.
+- **별도 스파이크**: C(발견 경로).
+- **옵션**: D(분석 단계).
+
+#### 미해결 / 결정 필요
+
+- **스키마**: `channelId`/`topicCategories` 저장 위치·형태(`video_events` vs `sessions`, 정규화 vs JSON) 확정.
+- **거울 반영**: 채널 집중 등을 사용자 피드백에 노출할지, 연구 수집만 할지 결정.
+
+#### Tasks
+
+- [ ] [youtube.js](../extension/pipeline/youtube.js) `part=snippet,topicDetails`로 확장, `channelId`/`channelTitle`/`topicCategories` 수집
+- [ ] 스키마 확장 — `video_events`(또는 `sessions`)에 채널·토픽 저장 (비파괴 `ALTER`)
+- [ ] [analysis.js](../extension/pipeline/analysis.js)에 채널 엔트로피(및 토픽 기반 분포) 추가
+- [ ] (별도 스파이크) 발견 경로 계측 PoC
+- [ ] 세밀 신호의 거울 반영 여부·문구 결정
+
+### Story 10-8: 2주 베이스라인 이후 그룹(CON/EXP) 분기 전달 — 후속 스토리
+
+- 설명: 실험 첫 **2주는 베이스라인 기간**으로 모든 참여자를 동일 처리(그룹 무관, 차별적 피드백 미전달)하고, 2주 경과 후부터 CON/EXP를 나눠 **EXP에만 분석·피드백을 전달**한다.
+- Priority: High / Owner: FE + Research
+- Dependencies: 10-1(그룹 배정)·10-6(알림 게이트)
+
+#### 설계 결정 (배경)
+
+- **베이스라인 목적**: 개입 전 자연 시청 패턴을 두 군 공통으로 확보 → 개입 효과 측정의 기준선. 2주로 확장해 기준을 안정화.
+- **분기 타이밍**: `installDate` 기준 경과일 **≥ 14일(2주)**부터 EXP에 피드백 UI·알림(10-6) 활성. 그 전에는 EXP/CON 모두 피드백 비노출(데이터 수집만).
+- **현재 코드와의 차이**: 지금은 `groupCfg.feedback`로 1일째부터 즉시 그룹 분기(EXP는 바로 피드백 노출). **시간 게이트(<14일 전원 baseline)를 추가**해야 하며, 주차·타임라인 상수([extension/popup/viewlens-popup.js](../extension/popup/viewlens-popup.js) `EXPERIMENT_DAYS`, `VL.TIMELINE`, 현 `w===1` baseline)도 2주 기준으로 재정의 필요.
+
+#### 미해결 / 결정 필요
+
+- **베이스라인 중 화면**: 이 기간 팝업이 무엇을 보여줄지(수집 현황만? 안내 문구만?) — EXP/CON 동일 화면 정의.
+- **전체 일정 정합**: 문서 상단의 "총 6주"와 "2주 baseline + 이후 개입"의 주차/타임라인 상수(현 `EXPERIMENT_DAYS=21`=3주)를 재조정.
+
+#### Tasks
+
+- [ ] `installDate` 기준 14일 게이트 도입 — <14일 전원 baseline(피드백·알림 미전달)
+- [ ] 14일 이후 EXP 피드백/알림 활성, CON 대조 유지
+- [ ] baseline 2주 정의에 맞춰 주차·타임라인 상수 재조정
+- [ ] 개인정보/IRB 문서(10-1)에 baseline·분기 일정 반영

--- a/docs/05-작업3.md
+++ b/docs/05-작업3.md
@@ -78,26 +78,31 @@
 
 ---
 
-### Story 10-3: 세션 처리 지연시간(Latency) 로깅 — 후속 스토리
+### Story 10-3: 세션 처리 지연시간(Latency) 로깅
 
 - 설명: 세션 종료 후 YouTube API 호출 ~ Gemini 피드백 생성까지 처리 시간(ms)을 측정·저장한다. (실시간 시스템 성능 지표)
-- Priority: Medium / Owner: BE(저장) + **FE 선행 필요**
-- 스키마: 10-2에서 `sessions.totalMs/youtubeMs/geminiMs`로 **확정 완료**. 데이터 수집 로직만 후속 구현.
-- 핵심 고려 / 남은 구현:
-  - **FE 선행**: LLM·YouTube 호출은 확장에서 일어나므로([extension/background.js](../extension/background.js), [extension/pipeline/llm.js](../extension/pipeline/llm.js)) 확장에서 `youtubeMs`/`geminiMs`/`totalMs`를 측정해 `postSessionToServer` payload에 실어 전송해야 함.
-  - **BE**: [server/routes/sessions.js](../server/routes/sessions.js)가 이 필드들을 받아 저장하도록 확장(현재 미수신).
-  - total 및 단계별 분리 저장. 실패(타임아웃) 소요 시간도 `timedOut`으로 구분 기록.
+- Priority: Medium / Owner: BE(저장) + FE(측정)
+- 스키마: 10-2에서 `sessions.totalMs/youtubeMs/geminiMs`로 **확정 완료**.
 
-### Story 10-4: LLM 실패·폴백 작동 로깅 — 후속 스토리
+#### 완료 작업
+
+- [x] **FE 측정** ([extension/background.js](../extension/background.js)): `analyzeSession`에서 구간별 `Date.now()` 측정 — `youtubeMs`(카테고리 조회), `geminiMs`(리뷰 생성, 성공/폴백 무관·타임아웃 대기 포함), `totalMs`(분석 시작~피드백 완료 전체). `postSessionToServer`에 `metrics`로 전달·전송.
+- [x] **BE 저장** ([server/routes/sessions.js](../server/routes/sessions.js)): INSERT에 3필드 추가, 음수 아닌 정수 검증(선택값, 미전송 시 `null` → 구버전 확장 하위호환).
+- 실패(타임아웃) 소요 시간은 `geminiMs`(폴백까지 걸린 시간)로 기록됨. 타임아웃 여부 자체(`timedOut`)와 실패 분류는 10-4에서 처리.
+
+### Story 10-4: LLM 실패·폴백 작동 로깅
 
 - 설명: Gemini 호출 실패로 규칙 기반 폴백이 작동한 경우와 사유를 기록한다. (시스템 견고성 지표)
-- Priority: Medium / Owner: BE(저장) + **FE 선행 필요**
+- Priority: Medium / Owner: BE(저장) + FE(분류)
 - 스키마: 10-2에서 `sessions.llmStatus/failureReason/httpStatus/timedOut`로 **확정 완료**.
-- 핵심 고려 / 남은 구현:
-  - **FE 선행**: [extension/background.js](../extension/background.js)의 단일 `catch`(현재 모든 에러를 폴백 처리, 분류 없음)를 **분류 로직으로 교체** — 실제 throw 지점(타임아웃/HTTP status/빈 응답/parse/network)에 에러 태깅 후 `failureReason`+`httpStatus`로 전송.
-  - **BE**: sessions.js가 필드 수신·저장(10-3과 같은 경로에 담으면 효율적). 개인정보 아님.
 
-### Story 10-5: 팝업 상호작용(체류시간·탭 클릭) 마이크로 로그 — 후속 스토리
+#### 완료 작업
+
+- [x] **실패 사유 태깅** ([extension/pipeline/llm.js](../extension/pipeline/llm.js)): `generateReview`의 각 throw 지점을 `failureReason` 분류값으로 태깅하는 `llmError()` 도입 — `timeout`(abort 플래그로 네트워크 장애와 구분, `timedOut:true`), `http_error`(`httpStatus` 병기: 429 쿼터 vs 5xx 구분), `empty_response`, `parse_error`(응답 본문/피드백 JSON 파싱 실패), `network_error`(fetch 예외). 타임아웃은 헤더 수신 후 해제해 본문 읽기를 끊지 않음.
+- [x] **FE 분류·전송** ([extension/background.js](../extension/background.js)): 단일 `catch`를 분류 로직으로 교체 — 성공 시 `llmStatus='success'`, 폴백 시 태깅된 `failureReason`/`httpStatus`/`timedOut`(1/0)을 기록해 `postSessionToServer`로 전송. 태깅 안 된 예상 밖 에러는 `network_error`로 수렴.
+- [x] **BE 수신·저장** ([server/routes/sessions.js](../server/routes/sessions.js)): 10-3과 같은 경로에 4필드 추가. `llmStatus`/`failureReason`은 허용값 enum 검증, `httpStatus`(정수)·`timedOut`(0/1) 형식 검증. 모두 선택값(구버전 확장 하위호환). in-memory 스모크 테스트로 success/http_error/timeout 저장 확인.
+
+### Story 10-5: 팝업 상호작용(체류시간·탭 클릭) 마이크로 로그
 
 - 설명: 팝업 체류 시간과 탭(오늘/주차별) 클릭 여부·횟수를 수집·전송한다. (사용자 상호작용/행동 분석용)
 - Priority: Medium / Owner: FE

--- a/docs/05-작업3.md
+++ b/docs/05-작업3.md
@@ -74,7 +74,7 @@
 - [x] A1 서버 crontab에 백업 등록(밤 23시·아침 8시 KST, 2회/일) + 수동 실행 테스트 완료. 서버 타임존 `Asia/Seoul` 설정, 로그 `~/db-backups/backup.log`.
 - [x] `pm2 install pm2-logrotate` — 6주간 운영 로그 로테이션(유실·디스크 방지). `pm2 startup`/`pm2 save`로 재부팅 시 자동 복원까지 설정.
 - [x] 오프사이트 백업 구현 — A1 → e1 서버로 백업 자동 복사. [backup-db.js](../server/scripts/backup-db.js)가 `E1_BACKUP_HOST` 환경변수 설정 시에만 scp 전송(무압축, 원격 14일 보관, best-effort). 원격 주소·키는 코드 미포함(A1 crontab의 env로만 주입). A1→e1 무암호 SSH 키(`~/.ssh/e1_backup`) 설정 완료.
-  - [ ] 남은 것: A1 crontab 두 줄에 `E1_BACKUP_HOST=<e1 IP>` 추가 + 배포 후 전송 1회 검증.
+  - [x] 남은 것: A1 crontab 두 줄에 `E1_BACKUP_HOST=<e1 IP>` 추가 + 배포 후 전송 1회 검증.
 
 ---
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -8,8 +8,15 @@ import {
   getOnboarding,
 } from "./storage.js";
 import { fetchVideoCategories } from "./pipeline/youtube.js";
-import { calculateDistribution, calculateEntropy } from "./pipeline/analysis.js";
-import { buildPrompt, generateReview, generateFallbackReview } from "./pipeline/llm.js";
+import {
+  calculateDistribution,
+  calculateEntropy,
+} from "./pipeline/analysis.js";
+import {
+  buildPrompt,
+  generateReview,
+  generateFallbackReview,
+} from "./pipeline/llm.js";
 import { SERVER_URL } from "./config.js";
 
 const ALARM_NAME = "SESSION_TIMEOUT_CHECK";
@@ -73,8 +80,13 @@ function findPrevEntropy(sessions, currentSessionId) {
 }
 
 async function analyzeSession(session) {
+  // 지연시간 측정 — 세션 종료 후 처리 파이프라인 전체를 t0로 감싼다.
+  const t0 = Date.now();
   const videoIds = session.videos.map((v) => v.videoId);
+
+  const ytStart = Date.now();
   const categoryMap = await fetchVideoCategories(videoIds);
+  const youtubeMs = Date.now() - ytStart;
   const categoryIds = videoIds.map((id) => categoryMap[id]);
 
   const categoryDistribution = calculateDistribution(categoryIds);
@@ -91,7 +103,11 @@ async function analyzeSession(session) {
     entropy,
     videoCount,
   });
-  console.log("[background] 분석 완료:", { entropy, prevEntropy, categoryDistribution });
+  console.log("[background] 분석 완료:", {
+    entropy,
+    prevEntropy,
+    categoryDistribution,
+  });
 
   const analysisData = {
     categoryDistribution,
@@ -103,6 +119,8 @@ async function analyzeSession(session) {
   const prompt = buildPrompt(analysisData);
 
   let result;
+  // 성공/폴백 무관하게 Gemini 호출(및 타임아웃까지의 대기) 소요를 기록한다.
+  const geminiStart = Date.now();
   try {
     result = await generateReview(prompt);
     console.log("[background] 리뷰 생성 완료");
@@ -110,6 +128,7 @@ async function analyzeSession(session) {
     console.warn("[background] 리뷰 생성 실패, 폴백 사용:", error.message);
     result = generateFallbackReview(analysisData);
   }
+  const geminiMs = Date.now() - geminiStart;
 
   await saveAnalysis(session.sessionId, {
     review: result.feedback,
@@ -117,7 +136,18 @@ async function analyzeSession(session) {
   });
   console.log("[background] 리뷰 저장 완료:", result);
 
-  await postSessionToServer(session, categoryDistribution, entropy, videoCount);
+  const totalMs = Date.now() - t0;
+  await postSessionToServer(
+    session,
+    categoryDistribution,
+    entropy,
+    videoCount,
+    {
+      totalMs,
+      youtubeMs,
+      geminiMs,
+    },
+  );
 }
 
 async function postSessionToServer(
@@ -125,6 +155,7 @@ async function postSessionToServer(
   categoryDistribution,
   entropy,
   videoCount,
+  metrics = {},
 ) {
   if (!SERVER_URL || SERVER_URL.startsWith("YOUR_")) {
     console.warn(
@@ -156,6 +187,9 @@ async function postSessionToServer(
           typeof entropy === "number" && Number.isFinite(entropy)
             ? entropy
             : undefined,
+        totalMs: metrics.totalMs,
+        youtubeMs: metrics.youtubeMs,
+        geminiMs: metrics.geminiMs,
       }),
     });
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -119,7 +119,7 @@ async function analyzeSession(session) {
   const prompt = buildPrompt(analysisData);
 
   let result;
-  // LLM 성공/폴백 로깅 (10-4). generateReview가 실패 사유를 태깅해 던지므로 분류해 기록한다.
+  // LLM 성공/폴백 로깅 (). generateReview가 실패 사유를 태깅해 던지므로 분류해 기록한다.
   let llmStatus = "success";
   let failureReason = null;
   let httpStatus = null;

--- a/extension/background.js
+++ b/extension/background.js
@@ -119,13 +119,27 @@ async function analyzeSession(session) {
   const prompt = buildPrompt(analysisData);
 
   let result;
+  // LLM 성공/폴백 로깅 (10-4). generateReview가 실패 사유를 태깅해 던지므로 분류해 기록한다.
+  let llmStatus = "success";
+  let failureReason = null;
+  let httpStatus = null;
+  let timedOut = 0; // SQLite INTEGER — 1/0
   // 성공/폴백 무관하게 Gemini 호출(및 타임아웃까지의 대기) 소요를 기록한다.
   const geminiStart = Date.now();
   try {
     result = await generateReview(prompt);
     console.log("[background] 리뷰 생성 완료");
   } catch (error) {
-    console.warn("[background] 리뷰 생성 실패, 폴백 사용:", error.message);
+    llmStatus = "fallback";
+    // 태깅 안 된 예상 밖 에러는 network_error로 수렴(죽은 카테고리 방지)
+    failureReason = error.failureReason || "network_error";
+    httpStatus = error.httpStatus ?? null;
+    timedOut = error.timedOut === true ? 1 : 0;
+    console.warn(
+      "[background] 리뷰 생성 실패, 폴백 사용:",
+      failureReason,
+      error.message,
+    );
     result = generateFallbackReview(analysisData);
   }
   const geminiMs = Date.now() - geminiStart;
@@ -146,6 +160,10 @@ async function analyzeSession(session) {
       totalMs,
       youtubeMs,
       geminiMs,
+      llmStatus,
+      failureReason,
+      httpStatus,
+      timedOut,
     },
   );
 }
@@ -190,6 +208,10 @@ async function postSessionToServer(
         totalMs: metrics.totalMs,
         youtubeMs: metrics.youtubeMs,
         geminiMs: metrics.geminiMs,
+        llmStatus: metrics.llmStatus,
+        failureReason: metrics.failureReason,
+        httpStatus: metrics.httpStatus,
+        timedOut: metrics.timedOut,
       }),
     });
 

--- a/extension/pipeline/llm.js
+++ b/extension/pipeline/llm.js
@@ -1,7 +1,7 @@
-import { GEMINI_API_KEY } from '../config.js';
+import { GEMINI_API_KEY } from "../config.js";
 
 const GEMINI_API_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
 const TIMEOUT_MS = 10000;
 
 // 다양성 변화로 인정할 최소 entropy 변화량(bits) — 노이즈 무시
@@ -20,7 +20,7 @@ function roundedDelta(entropy, prevEntropy) {
 // prevEntropy 및 편중 비율을 LLM에게 줄 자연어 지시로 번역
 function buildTrendGuidance({ entropy, prevEntropy, topRatio, videoCount }) {
   if (videoCount < MIN_VIDEOS_FOR_TREND) {
-    return '- 이번 세션은 시청한 영상 수가 적어 패턴을 단정하기 어렵습니다. 무엇을 봤는지 가볍게 비추는 정도로만 언급해 주세요.';
+    return "- 이번 세션은 시청한 영상 수가 적어 패턴을 단정하기 어렵습니다. 무엇을 봤는지 가볍게 비추는 정도로만 언급해 주세요.";
   }
 
   const lines = [];
@@ -28,42 +28,70 @@ function buildTrendGuidance({ entropy, prevEntropy, topRatio, videoCount }) {
   if (Number.isFinite(prevEntropy)) {
     const delta = roundedDelta(entropy, prevEntropy);
     if (delta >= ENTROPY_DELTA_EPS) {
-      lines.push('- 직전 세션보다 시청이 여러 주제로 다양해졌습니다. 이 변화를 담담한 사실로 비춰 주세요.');
+      lines.push(
+        "- 직전 세션보다 시청이 여러 주제로 다양해졌습니다. 이 변화를 담담한 사실로 비춰 주세요.",
+      );
     } else if (delta <= -ENTROPY_DELTA_EPS) {
-      lines.push('- 직전 세션보다 시청이 더 적은 수의 주제에 모였습니다. 이 변화를 부드럽고 또렷하게 사실로 비춰 주세요.');
+      lines.push(
+        "- 직전 세션보다 시청이 더 적은 수의 주제에 모였습니다. 이 변화를 부드럽고 또렷하게 사실로 비춰 주세요.",
+      );
     } else {
-      lines.push('- 직전 세션과 비슷한 다양성을 유지하고 있습니다. 이 사실을 중립적으로 비춰 주세요.');
+      lines.push(
+        "- 직전 세션과 비슷한 다양성을 유지하고 있습니다. 이 사실을 중립적으로 비춰 주세요.",
+      );
     }
   }
 
   if (topRatio >= BIAS_WARN_RATIO) {
-    lines.push('- 시청이 한 주제에 크게 모여 있습니다. 그 쏠림을 부드럽고 또렷하게 사실로 비춰 주세요. 다양하게 보라는 권유나 지시는 하지 마세요.');
+    lines.push(
+      "- 시청이 한 주제에 크게 모여 있습니다. 그 쏠림을 부드럽고 또렷하게 사실로 비춰 주세요. 다양하게 보라는 권유나 지시는 하지 마세요.",
+    );
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
-export function buildPrompt({ categoryDistribution, entropy, prevEntropy = null, videoCount, videoTitles = [] }) {
-  const sorted = Object.entries(categoryDistribution).sort(([, a], [, b]) => b - a);
+export function buildPrompt({
+  categoryDistribution,
+  entropy,
+  prevEntropy = null,
+  videoCount,
+  videoTitles = [],
+}) {
+  const sorted = Object.entries(categoryDistribution).sort(
+    ([, a], [, b]) => b - a,
+  );
 
   const categoryLines = sorted
     .map(([name, ratio]) => `  · ${name}: ${Math.round(ratio * 100)}%`)
-    .join('\n');
+    .join("\n");
 
   const categoryCount = sorted.length;
-  const maxEntropy = categoryCount > 1 ? Math.log2(categoryCount).toFixed(2) : null;
+  const maxEntropy =
+    categoryCount > 1 ? Math.log2(categoryCount).toFixed(2) : null;
   const entropyLine =
     maxEntropy !== null
       ? `- 다양성 지수: ${entropy} (최대 ${maxEntropy})`
       : `- 다양성 지수: ${entropy}`;
 
-  const titleLines = videoTitles.length > 0
-    ? `\n- 시청한 영상 제목:\n${videoTitles.slice(0, 10).map(t => `  · ${t}`).join('\n')}`
-    : '';
+  const titleLines =
+    videoTitles.length > 0
+      ? `\n- 시청한 영상 제목:\n${videoTitles
+          .slice(0, 10)
+          .map((t) => `  · ${t}`)
+          .join("\n")}`
+      : "";
 
   const topRatio = sorted.length > 0 ? sorted[0][1] : 0;
-  const trendGuidance = buildTrendGuidance({ entropy, prevEntropy, topRatio, videoCount });
-  const trendSection = trendGuidance ? `\n\n[피드백 작성 지침]\n${trendGuidance}` : '';
+  const trendGuidance = buildTrendGuidance({
+    entropy,
+    prevEntropy,
+    topRatio,
+    videoCount,
+  });
+  const trendSection = trendGuidance
+    ? `\n\n[피드백 작성 지침]\n${trendGuidance}`
+    : "";
 
   return `당신은 사용자가 자신의 YouTube 콘텐츠 소비 패턴을 스스로 돌아볼 수 있도록 있는 그대로 비춰 주는 거울 같은 조력자입니다.
 
@@ -88,7 +116,7 @@ ${entropyLine}${titleLines}${trendSection}
 }
 
 // 실패 사유를 sessions.failureReason 분류값으로 태깅한 에러.
-// background.js가 이 필드(failureReason/httpStatus/timedOut)를 읽어 서버로 전송한다(10-4).
+// background.js가 이 필드(failureReason/httpStatus/timedOut)를 읽어 서버로 전송한다().
 // 분류값은 server/db.js 스키마 주석과 1:1 대응: timeout | http_error | empty_response | parse_error | network_error
 function llmError(failureReason, message, extra = {}) {
   const err = new Error(message);
@@ -107,15 +135,21 @@ export async function generateReview(prompt) {
   let response;
   try {
     response = await fetch(GEMINI_API_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'x-goog-api-key': GEMINI_API_KEY },
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": GEMINI_API_KEY,
+      },
       body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
       signal: controller.signal,
     });
   } catch (error) {
     // abort는 타임아웃으로만 발생 → 실제 네트워크 장애(TypeError 등)와 구분
-    if (timedOut) throw llmError('timeout', `Gemini API 타임아웃 (${TIMEOUT_MS}ms)`, { timedOut: true });
-    throw llmError('network_error', error.message);
+    if (timedOut)
+      throw llmError("timeout", `Gemini API 타임아웃 (${TIMEOUT_MS}ms)`, {
+        timedOut: true,
+      });
+    throw llmError("network_error", error.message);
   } finally {
     // 헤더 수신 후에는 타임아웃 해제 — 본문 읽기가 abort로 끊기지 않도록
     clearTimeout(timeoutId);
@@ -123,40 +157,63 @@ export async function generateReview(prompt) {
 
   if (!response.ok) {
     const errorBody = await response.text();
-    console.error('[llm] API error body:', errorBody);
-    // httpStatus 병기 — 429 쿼터 vs 5xx 장애 구분 (10-4 분석용)
-    throw llmError('http_error', `Gemini API error: ${response.status}`, { httpStatus: response.status });
+    console.error("[llm] API error body:", errorBody);
+    // httpStatus 병기 — 429 쿼터 vs 5xx 장애 구분 ( 분석용)
+    throw llmError("http_error", `Gemini API error: ${response.status}`, {
+      httpStatus: response.status,
+    });
   }
 
   let data;
   try {
     data = await response.json();
   } catch (error) {
-    throw llmError('parse_error', `응답 본문 JSON 파싱 실패: ${error.message}`);
+    throw llmError("parse_error", `응답 본문 JSON 파싱 실패: ${error.message}`);
   }
 
   const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
-  if (!text) throw llmError('empty_response', 'Gemini API: 응답에 텍스트가 없습니다');
+  if (!text)
+    throw llmError("empty_response", "Gemini API: 응답에 텍스트가 없습니다");
 
-  const cleaned = text.trim().replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  const cleaned = text
+    .trim()
+    .replace(/^```(?:json)?\n?/, "")
+    .replace(/\n?```$/, "");
   try {
     const parsed = JSON.parse(cleaned);
-    const isObj = parsed && typeof parsed === 'object';
-    return { topic: (isObj && parsed.topic) || '', feedback: (isObj && parsed.feedback) || cleaned };
+    const isObj = parsed && typeof parsed === "object";
+    return {
+      topic: (isObj && parsed.topic) || "",
+      feedback: (isObj && parsed.feedback) || cleaned,
+    };
   } catch (error) {
-    throw llmError('parse_error', `피드백 JSON 파싱 실패: ${error.message}`);
+    throw llmError("parse_error", `피드백 JSON 파싱 실패: ${error.message}`);
   }
 }
 
-export function generateFallbackReview({ categoryDistribution, entropy, prevEntropy = null, videoCount }) {
-  const sorted = Object.entries(categoryDistribution).sort(([, a], [, b]) => b - a);
+export function generateFallbackReview({
+  categoryDistribution,
+  entropy,
+  prevEntropy = null,
+  videoCount,
+}) {
+  const sorted = Object.entries(categoryDistribution).sort(
+    ([, a], [, b]) => b - a,
+  );
 
   if (sorted.length === 0) {
-    return { topic: '', feedback: '이번 세션의 시청 데이터를 분석하지 못했습니다. 다음 세션을 기대해 주세요!' };
+    return {
+      topic: "",
+      feedback:
+        "이번 세션의 시청 데이터를 분석하지 못했습니다. 다음 세션을 기대해 주세요!",
+    };
   }
 
   const [topName, topRatio] = sorted[0];
-  const topNames = sorted.slice(0, 3).map(([name]) => name).join(', ');
+  const topNames = sorted
+    .slice(0, 3)
+    .map(([name]) => name)
+    .join(", ");
 
   // [무엇을 봤는지]
   let summary;
@@ -173,23 +230,25 @@ export function generateFallbackReview({ categoryDistribution, entropy, prevEntr
   }
 
   // [변화 추세] + [쏠림] — 거울형: 사실만 비추고 권유·처방은 하지 않음
-  let trend = '';
-  let skewNote = '';
+  let trend = "";
+  let skewNote = "";
   if (videoCount >= MIN_VIDEOS_FOR_TREND) {
     const hasPrev = Number.isFinite(prevEntropy);
     const delta = hasPrev ? roundedDelta(entropy, prevEntropy) : 0;
 
     if (hasPrev) {
-      if (delta >= ENTROPY_DELTA_EPS) trend = '직전 세션보다 여러 주제를 두루 보셨어요.';
-      else if (delta <= -ENTROPY_DELTA_EPS) trend = '직전 세션보다 더 적은 수의 주제에 모여 있었어요.';
-      else trend = '직전 세션과 비슷한 다양성이었어요.';
+      if (delta >= ENTROPY_DELTA_EPS)
+        trend = "직전 세션보다 여러 주제를 두루 보셨어요.";
+      else if (delta <= -ENTROPY_DELTA_EPS)
+        trend = "직전 세션보다 더 적은 수의 주제에 모여 있었어요.";
+      else trend = "직전 세션과 비슷한 다양성이었어요.";
     }
 
     if (topRatio >= BIAS_WARN_RATIO) {
-      skewNote = '특히 시청이 한 주제에 크게 모여 있었어요.';
+      skewNote = "특히 시청이 한 주제에 크게 모여 있었어요.";
     }
   }
 
-  const feedback = [summary, trend, skewNote].filter(Boolean).join(' ');
+  const feedback = [summary, trend, skewNote].filter(Boolean).join(" ");
   return { topic, feedback };
 }

--- a/extension/pipeline/llm.js
+++ b/extension/pipeline/llm.js
@@ -87,37 +87,64 @@ ${entropyLine}${titleLines}${trendSection}
 }`;
 }
 
+// 실패 사유를 sessions.failureReason 분류값으로 태깅한 에러.
+// background.js가 이 필드(failureReason/httpStatus/timedOut)를 읽어 서버로 전송한다(10-4).
+// 분류값은 server/db.js 스키마 주석과 1:1 대응: timeout | http_error | empty_response | parse_error | network_error
+function llmError(failureReason, message, extra = {}) {
+  const err = new Error(message);
+  err.failureReason = failureReason;
+  return Object.assign(err, extra);
+}
+
 export async function generateReview(prompt) {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, TIMEOUT_MS);
 
+  let response;
   try {
-    const response = await fetch(GEMINI_API_URL, {
+    response = await fetch(GEMINI_API_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-goog-api-key': GEMINI_API_KEY },
       body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
       signal: controller.signal,
     });
-
+  } catch (error) {
+    // abort는 타임아웃으로만 발생 → 실제 네트워크 장애(TypeError 등)와 구분
+    if (timedOut) throw llmError('timeout', `Gemini API 타임아웃 (${TIMEOUT_MS}ms)`, { timedOut: true });
+    throw llmError('network_error', error.message);
+  } finally {
+    // 헤더 수신 후에는 타임아웃 해제 — 본문 읽기가 abort로 끊기지 않도록
     clearTimeout(timeoutId);
+  }
 
-    if (!response.ok) {
-      const errorBody = await response.text();
-      console.error('[llm] API error body:', errorBody);
-      throw new Error(`Gemini API error: ${response.status}`);
-    }
+  if (!response.ok) {
+    const errorBody = await response.text();
+    console.error('[llm] API error body:', errorBody);
+    // httpStatus 병기 — 429 쿼터 vs 5xx 장애 구분 (10-4 분석용)
+    throw llmError('http_error', `Gemini API error: ${response.status}`, { httpStatus: response.status });
+  }
 
-    const data = await response.json();
-    const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
-    if (!text) throw new Error('Gemini API: 응답에 텍스트가 없습니다');
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw llmError('parse_error', `응답 본문 JSON 파싱 실패: ${error.message}`);
+  }
 
-    const cleaned = text.trim().replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!text) throw llmError('empty_response', 'Gemini API: 응답에 텍스트가 없습니다');
+
+  const cleaned = text.trim().replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  try {
     const parsed = JSON.parse(cleaned);
     const isObj = parsed && typeof parsed === 'object';
     return { topic: (isObj && parsed.topic) || '', feedback: (isObj && parsed.feedback) || cleaned };
   } catch (error) {
-    clearTimeout(timeoutId);
-    throw error;
+    throw llmError('parse_error', `피드백 JSON 파싱 실패: ${error.message}`);
   }
 }
 

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -325,14 +325,25 @@ class RealPopup extends ViewLensPopup {
 
 // participants 서버 등록 — 성공(200) 시에만 participantSynced 플래그를 저장한다.
 // 실패하면 플래그를 세우지 않으므로 다음 팝업 boot에서 재시도된다(서버는 anonymousId UNIQUE로 멱등 처리).
-async function syncParticipant(serverUrl, { anonymousId, participantCode, group_code, installDate }) {
+async function syncParticipant(
+  serverUrl,
+  { anonymousId, participantCode, group_code, installDate },
+) {
   if (!serverUrl || serverUrl.startsWith("YOUR_")) return;
   try {
-    const res = await fetch(`${serverUrl.replace(/\/$/, "")}/api/participants`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ anonymousId, participantCode, group_code, installDate }),
-    });
+    const res = await fetch(
+      `${serverUrl.replace(/\/$/, "")}/api/participants`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          anonymousId,
+          participantCode,
+          group_code,
+          installDate,
+        }),
+      },
+    );
     if (!res.ok) {
       console.warn("[popup] participants 등록 실패:", res.status);
       return;
@@ -363,6 +374,86 @@ async function validateParticipantCode(code) {
 }
 window.validateParticipantCode = validateParticipantCode;
 
+// ── 팝업 상호작용 마이크로 로그 ────────────────────────────────────────
+// 수집: openedAt, dwellMs, tabTodayClicks, tabWeekClicks, feedbackViewed.
+// 전송: 팝업 close 시점의 storage 쓰기는 teardown에 잘릴 수 있어 신뢰하지 않는다.
+//   대신 세션 중 livePopupEvent 슬롯을 상호작용·1초 간격으로 계속 갱신해 최신 스냅샷을 남기고,
+//   다음 팝업 open(boot) 때 이전 스냅샷을 확정 큐로 승격해 서버로 전송(실패분은 큐에 남겨 재시도).
+//   팝업은 싱글턴이라 boot 시점의 잔여 livePopupEvent는 곧 "닫힌 이전 팝업"의 확정 이벤트다.
+//   sendBeacon을 쓰지 않으므로 중복 전송이 없다(전송은 항상 다음 open의 flush 한 경로).
+
+// 실제 LLM 리뷰인지(플레이스홀더·빈 값 제외) — feedbackViewed 판정용
+const POPUP_PLACEHOLDER_REVIEWS = new Set([
+  "시청 패턴을 분석하고 있어요. 잠시 후 시청 분석이 업데이트돼요.",
+]);
+function isRealReview(text) {
+  return (
+    typeof text === "string" &&
+    text.trim() !== "" &&
+    !POPUP_PLACEHOLDER_REVIEWS.has(text.trim())
+  );
+}
+
+function buildPopupEventPayload(m) {
+  return {
+    anonymousId: m.anonymousId,
+    dwellMs: Math.max(0, Date.now() - m.startTs),
+    tabTodayClicks: m.tabTodayClicks,
+    tabWeekClicks: m.tabWeekClicks,
+    feedbackViewed: m.feedbackViewed,
+    openedAt: m.openedAt,
+  };
+}
+
+// teardown 대비 — 현재 세션 스냅샷을 live 슬롯에 기록(fire-and-forget)
+function persistLivePopupEvent(m) {
+  chrome.storage.local.set({ livePopupEvent: buildPopupEventPayload(m) });
+}
+
+async function postPopupEvent(serverUrl, event) {
+  if (!serverUrl || serverUrl.startsWith("YOUR_")) return false;
+  try {
+    const res = await fetch(
+      `${serverUrl.replace(/\/$/, "")}/api/popup-events`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(event),
+      },
+    );
+    return res.ok;
+  } catch (error) {
+    return false;
+  }
+}
+
+// 이전 팝업의 잔여 이벤트를 확정 큐로 승격하고 live 슬롯을 비운다.
+// 현재 세션이 live 슬롯을 새로 쓰기 전에 완료해야 하므로 반드시 await 한다.
+async function drainPreviousPopupEvents() {
+  const { pendingPopupEvents = [], livePopupEvent = null } =
+    await chrome.storage.local.get(["pendingPopupEvents", "livePopupEvent"]);
+  const queue = [...pendingPopupEvents];
+  if (livePopupEvent) queue.push(livePopupEvent);
+  await chrome.storage.local.set({
+    pendingPopupEvents: queue,
+    livePopupEvent: null,
+  });
+}
+
+// 확정 큐를 서버로 전송 — 실패분만 큐에 남겨 다음 open에서 재시도(렌더 블로킹 없이 백그라운드).
+async function flushPendingPopupEvents(serverUrl) {
+  const { pendingPopupEvents = [] } = await chrome.storage.local.get([
+    "pendingPopupEvents",
+  ]);
+  if (pendingPopupEvents.length === 0) return;
+  const stillPending = [];
+  for (const ev of pendingPopupEvents) {
+    const ok = await postPopupEvent(serverUrl, ev);
+    if (!ok) stillPending.push(ev);
+  }
+  await chrome.storage.local.set({ pendingPopupEvents: stillPending });
+}
+
 // ── Main boot ─────────────────────────────────────────────────────────────────
 
 async function boot() {
@@ -389,7 +480,12 @@ async function boot() {
 
   // 온보딩은 됐지만 서버 등록이 확인되지 않은 경우 재시도(등록 누락 복구).
   // 팝업 렌더링을 막지 않도록 await 없이 백그라운드로 실행 — 실패 시 다음 boot에서 다시 재시도된다.
-  if (stored.group && stored.anonymousId && stored.installDate && !stored.participantSynced) {
+  if (
+    stored.group &&
+    stored.anonymousId &&
+    stored.installDate &&
+    !stored.participantSynced
+  ) {
     syncParticipant(stored.serverUrl, {
       anonymousId: stored.anonymousId,
       participantCode: stored.participantCode,
@@ -446,14 +542,67 @@ async function boot() {
           participantSynced: false,
         });
 
-        await syncParticipant(serverUrl, { anonymousId, participantCode, group_code: g, installDate });
+        await syncParticipant(serverUrl, {
+          anonymousId,
+          participantCode,
+          group_code: g,
+          installDate,
+        });
       } else if (!ob) {
         // 연구자 모드 — 온보딩 초기화 (세션 데이터는 유지)
-        await chrome.storage.local.remove(['group', 'participantCode', 'installDate', 'surveyStatus', 'participantSynced']);
+        await chrome.storage.local.remove([
+          "group",
+          "participantCode",
+          "installDate",
+          "surveyStatus",
+          "participantSynced",
+        ]);
         window.location.reload();
       }
     },
   });
+
+  // ── 팝업 상호작용 로그 — 온보딩 완료 사용자만 ─────────────────────────
+  let popupMetrics = null;
+  if (stored.group && stored.anonymousId) {
+    // 이전 팝업의 잔여 이벤트를 확정 큐로 승격(현재 세션이 live 슬롯을 새로 쓰기 전에 완료).
+    await drainPreviousPopupEvents();
+    // 큐 전송은 백그라운드 — 렌더/상호작용을 막지 않음. 실패분은 큐에 남아 다음 open에서 재시도.
+    flushPendingPopupEvents(stored.serverUrl);
+
+    const isExp = !!VL.GROUPS[stored.group]?.feedback;
+    popupMetrics = {
+      anonymousId: stored.anonymousId,
+      openedAt: new Date().toISOString(),
+      startTs: Date.now(),
+      tabTodayClicks: 0,
+      tabWeekClicks: 0,
+      // EXP 사용자가 열자마자 실제 리뷰(today 탭)를 보고 있으면 개입 전달로 간주
+      feedbackViewed: isExp && isRealReview(realToday.review) ? 1 : 0,
+    };
+    persistLivePopupEvent(popupMetrics);
+
+    // 탭 클릭 계측 — popEl은 re-render(innerHTML 교체) 후에도 유지되므로 위임 리스너로 한 번만 바인딩
+    popEl.addEventListener("click", (e) => {
+      const tabBtn = e.target.closest && e.target.closest("[data-tab]");
+      if (!tabBtn) return;
+      if (tabBtn.dataset.tab === "today") {
+        popupMetrics.tabTodayClicks++;
+      } else if (tabBtn.dataset.tab === "feedback") {
+        popupMetrics.tabWeekClicks++;
+        popupMetrics.feedbackViewed = 1; // 주차별 피드백 탭 열람 = 개입 전달
+      }
+      persistLivePopupEvent(popupMetrics);
+    });
+
+    // 팝업 종료 감지 — dwellMs 최종 반영(단일 set, teardown에 상대적으로 안전).
+    // 최종 쓰기가 잘려도 세션 중 스냅샷이 남아 다음 boot에서 승격된다.
+    const finalizePopupMetrics = () => persistLivePopupEvent(popupMetrics);
+    window.addEventListener("pagehide", finalizePopupMetrics);
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) finalizePopupMetrics();
+    });
+  }
 
   // 로컬 캐시 — storage.onChanged로 갱신, setInterval에서는 캐시만 읽음
   let localCurrentSession = stored.currentSession || null;
@@ -462,8 +611,10 @@ async function boot() {
   // sessions가 바뀌면(분석 완료, 리뷰 저장 등) 즉시 today 데이터를 갱신하고 re-render
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== "local") return;
-    if (changes.currentSession) localCurrentSession = changes.currentSession.newValue || null;
-    if (changes.lastWatchedAt) localLastWatchedAt = changes.lastWatchedAt.newValue || null;
+    if (changes.currentSession)
+      localCurrentSession = changes.currentSession.newValue || null;
+    if (changes.lastWatchedAt)
+      localLastWatchedAt = changes.lastWatchedAt.newValue || null;
     if (!changes.sessions) return;
     const updatedSessions = changes.sessions.newValue || [];
     VL._allSessions = updatedSessions;
@@ -483,6 +634,9 @@ async function boot() {
 
   setInterval(() => {
     VL._lastWatchedAt = localLastWatchedAt;
+
+    // dwellMs 스냅샷 갱신 — close write가 잘려도 최근값(±1초)이 보존됨
+    if (popupMetrics) persistLivePopupEvent(popupMetrics);
 
     const count = localCurrentSession?.videos?.length ?? 0;
     const timerText = _computeTimerText(localLastWatchedAt);

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -396,6 +396,7 @@ function isRealReview(text) {
 
 function buildPopupEventPayload(m) {
   return {
+    eventId: m.eventId,
     anonymousId: m.anonymousId,
     dwellMs: Math.max(0, Date.now() - m.startTs),
     tabTodayClicks: m.tabTodayClicks,
@@ -575,6 +576,8 @@ async function boot() {
     const isExp = !!VL.GROUPS[stored.group]?.feedback;
     popupMetrics = {
       anonymousId: stored.anonymousId,
+      // 팝업 오픈당 1회 발급 — 재전송돼도 서버가 이 id로 중복을 무시(멱등)
+      eventId: crypto.randomUUID(),
       openedAt: new Date().toISOString(),
       startTs: Date.now(),
       tabTodayClicks: 0,

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -446,12 +446,14 @@ async function flushPendingPopupEvents(serverUrl) {
     "pendingPopupEvents",
   ]);
   if (pendingPopupEvents.length === 0) return;
-  const stillPending = [];
-  for (const ev of pendingPopupEvents) {
-    const ok = await postPopupEvent(serverUrl, ev);
-    if (!ok) stillPending.push(ev);
+  // 전송 성공분은 즉시 큐에서 제거 — flush 도중 팝업이 닫혀도 재전송(중복)을 막는다.
+  const queue = [...pendingPopupEvents];
+  while (queue.length > 0) {
+    const ok = await postPopupEvent(serverUrl, queue[0]);
+    if (!ok) break;
+    queue.shift();
+    await chrome.storage.local.set({ pendingPopupEvents: queue });
   }
-  await chrome.storage.local.set({ pendingPopupEvents: stillPending });
 }
 
 // ── Main boot ─────────────────────────────────────────────────────────────────

--- a/server/app.js
+++ b/server/app.js
@@ -20,6 +20,7 @@ app.use("/api/participants", require("./routes/participants"));
 app.use("/api/sessions", require("./routes/sessions"));
 app.use("/api/surveys", require("./routes/surveys"));
 app.use("/api/video-events", require("./routes/video-events"));
+app.use("/api/popup-events", require("./routes/popup-events"));
 
 app.use(errorHandler);
 

--- a/server/db.js
+++ b/server/db.js
@@ -62,7 +62,7 @@ function initializeDB() {
       createdAt  TEXT DEFAULT (datetime('now'))
     );
 
-    -- 팝업 상호작용 마이크로 로그 (10-5) — 세션과 무관해 별도 테이블
+    -- 팝업 상호작용 마이크로 로그 — 세션과 무관해 별도 테이블
     CREATE TABLE IF NOT EXISTS popup_events (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
       anonymousId    TEXT    NOT NULL,

--- a/server/db.js
+++ b/server/db.js
@@ -65,6 +65,7 @@ function initializeDB() {
     -- 팝업 상호작용 마이크로 로그 — 세션과 무관해 별도 테이블
     CREATE TABLE IF NOT EXISTS popup_events (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      eventId        TEXT,     -- 확장이 오픈당 1회 발급하는 멱등 키 (재전송 중복 방지)
       anonymousId    TEXT    NOT NULL,
       dwellMs        INTEGER,  -- 팝업 체류 시간(ms)
       tabTodayClicks INTEGER DEFAULT 0,  -- '오늘' 탭 클릭 횟수
@@ -98,6 +99,14 @@ function initializeDB() {
   addColumn("ALTER TABLE sessions ADD COLUMN failureReason TEXT");
   addColumn("ALTER TABLE sessions ADD COLUMN httpStatus INTEGER");
   addColumn("ALTER TABLE sessions ADD COLUMN timedOut INTEGER");
+
+  // 팝업 이벤트 멱등 키 — SQLite는 ALTER TABLE로 UNIQUE 컬럼을 못 만들므로
+  // 컬럼 추가 후 UNIQUE 인덱스를 별도로 생성. 기존 행(eventId=NULL)은 NULL끼리
+  // distinct 취급되어 충돌하지 않는다.
+  addColumn("ALTER TABLE popup_events ADD COLUMN eventId TEXT");
+  db.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_popup_events_eventId ON popup_events(eventId)",
+  );
 }
 
 module.exports = { db, initializeDB };

--- a/server/db.js
+++ b/server/db.js
@@ -26,11 +26,11 @@ function initializeDB() {
       videoCount           INTEGER,
       categoryDistribution TEXT,
       entropy              REAL,
-      -- 세션 처리 지연시간 (10-3) — 확장이 측정해 전송, ms 단위
+      -- 세션 처리 지연시간 () — 확장이 측정해 전송, ms 단위
       totalMs              INTEGER,
       youtubeMs            INTEGER,
       geminiMs             INTEGER,
-      -- LLM 성공/폴백 로깅 (10-4) — 확장의 폴백 분기(background.js/llm.js)와 대응
+      -- LLM 성공/폴백 로깅 () — 확장의 폴백 분기(background.js/llm.js)와 대응
       llmStatus            TEXT,     -- 'success' | 'fallback'
       failureReason        TEXT,     -- timeout | http_error | empty_response | parse_error | network_error (성공 시 NULL)
       httpStatus           INTEGER,  -- failureReason='http_error'일 때만 (429 쿼터 vs 5xx 장애 구분)
@@ -90,7 +90,7 @@ function initializeDB() {
   };
 
   addColumn("ALTER TABLE participants ADD COLUMN participantCode TEXT");
-  // 10-3 latency / 10-4 폴백 로깅 컬럼
+  //  latency /  폴백 로깅 컬럼
   addColumn("ALTER TABLE sessions ADD COLUMN totalMs INTEGER");
   addColumn("ALTER TABLE sessions ADD COLUMN youtubeMs INTEGER");
   addColumn("ALTER TABLE sessions ADD COLUMN geminiMs INTEGER");

--- a/server/routes/popup-events.js
+++ b/server/routes/popup-events.js
@@ -5,9 +5,11 @@ const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
 const router = express.Router();
 
 // 팝업 상호작용 마이크로 로그 — 세션과 무관, 확장이 팝업 종료 시점 스냅샷을 전송.
+// OR IGNORE: eventId(멱등 키) 중복 시 조용히 건너뜀 → 재전송돼도 한 행만 남는다.
+// eventId가 없는 구버전 확장 요청은 NULL로 저장되어 dedup만 생략된다(하위호환).
 const insertPopupEvent = db.prepare(`
-  INSERT INTO popup_events (anonymousId, dwellMs, tabTodayClicks, tabWeekClicks, feedbackViewed, openedAt)
-  VALUES (@anonymousId, @dwellMs, @tabTodayClicks, @tabWeekClicks, @feedbackViewed, @openedAt)
+  INSERT OR IGNORE INTO popup_events (eventId, anonymousId, dwellMs, tabTodayClicks, tabWeekClicks, feedbackViewed, openedAt)
+  VALUES (@eventId, @anonymousId, @dwellMs, @tabTodayClicks, @tabWeekClicks, @feedbackViewed, @openedAt)
 `);
 
 // 값이 있으면 음수 아닌 정수여야 하는 필드 (미전송 시 null)
@@ -61,6 +63,7 @@ router.post("/", (req, res, next) => {
   }
 
   const {
+    eventId,
     anonymousId,
     dwellMs,
     tabTodayClicks,
@@ -71,6 +74,7 @@ router.post("/", (req, res, next) => {
 
   try {
     insertPopupEvent.run({
+      eventId: eventId ?? null,
       anonymousId,
       dwellMs: dwellMs ?? null,
       tabTodayClicks: tabTodayClicks ?? null,

--- a/server/routes/popup-events.js
+++ b/server/routes/popup-events.js
@@ -1,0 +1,88 @@
+const express = require("express");
+const { db } = require("../db");
+const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
+
+const router = express.Router();
+
+// 팝업 상호작용 마이크로 로그 — 세션과 무관, 확장이 팝업 종료 시점 스냅샷을 전송.
+const insertPopupEvent = db.prepare(`
+  INSERT INTO popup_events (anonymousId, dwellMs, tabTodayClicks, tabWeekClicks, feedbackViewed, openedAt)
+  VALUES (@anonymousId, @dwellMs, @tabTodayClicks, @tabWeekClicks, @feedbackViewed, @openedAt)
+`);
+
+// 값이 있으면 음수 아닌 정수여야 하는 필드 (미전송 시 null)
+const COUNT_FIELDS = ["dwellMs", "tabTodayClicks", "tabWeekClicks"];
+
+function validatePopupEvent(body) {
+  const { anonymousId, feedbackViewed, openedAt } = body;
+
+  if (typeof anonymousId !== "string" || !anonymousId.trim()) {
+    return { code: ERROR_CODES.MISSING_REQUIRED_FIELD, field: "anonymousId" };
+  }
+  for (const field of COUNT_FIELDS) {
+    const value = body[field];
+    if (
+      value !== undefined &&
+      value !== null &&
+      (!Number.isInteger(value) || value < 0)
+    ) {
+      return { code: ERROR_CODES.INVALID_FIELD_VALUE, field };
+    }
+  }
+  if (
+    feedbackViewed !== undefined &&
+    feedbackViewed !== null &&
+    feedbackViewed !== 0 &&
+    feedbackViewed !== 1
+  ) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "feedbackViewed" };
+  }
+  if (
+    openedAt !== undefined &&
+    openedAt !== null &&
+    isNaN(Date.parse(openedAt))
+  ) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "openedAt" };
+  }
+
+  return null;
+}
+
+router.post("/", (req, res, next) => {
+  const error = validatePopupEvent(req.body);
+  if (error) {
+    return fail(
+      res,
+      400,
+      error.code,
+      `${error.field} 필드가 올바르지 않습니다.`,
+      error.field,
+    );
+  }
+
+  const {
+    anonymousId,
+    dwellMs,
+    tabTodayClicks,
+    tabWeekClicks,
+    feedbackViewed,
+    openedAt,
+  } = req.body;
+
+  try {
+    insertPopupEvent.run({
+      anonymousId,
+      dwellMs: dwellMs ?? null,
+      tabTodayClicks: tabTodayClicks ?? null,
+      tabWeekClicks: tabWeekClicks ?? null,
+      feedbackViewed: feedbackViewed ?? null,
+      openedAt: openedAt ?? null,
+    });
+  } catch (err) {
+    return next(err);
+  }
+
+  return success(res);
+});
+
+module.exports = router;

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -5,12 +5,16 @@ const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
 const router = express.Router();
 
 const insertSession = db.prepare(`
-  INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs)
-  VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy, @totalMs, @youtubeMs, @geminiMs)
+  INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs, llmStatus, failureReason, httpStatus, timedOut)
+  VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy, @totalMs, @youtubeMs, @geminiMs, @llmStatus, @failureReason, @httpStatus, @timedOut)
 `);
 
 // 10-3 지연시간 필드 — 확장이 측정해 전송. 선택 항목이며, 있으면 음수 아닌 정수여야 한다.
 const LATENCY_FIELDS = ["totalMs", "youtubeMs", "geminiMs"];
+
+// 10-4 LLM 폴백 로깅 — 확장의 실패 분류값. server/db.js·llm.js와 1:1 대응.
+const LLM_STATUSES = ["success", "fallback"];
+const FAILURE_REASONS = ["timeout", "http_error", "empty_response", "parse_error", "network_error"];
 
 function validateSession(body) {
   const { anonymousId, sessionId, startTime, endTime, videoCount, entropy } = body;
@@ -42,6 +46,21 @@ function validateSession(body) {
     }
   }
 
+  // 10-4 폴백 로깅 — 값이 있을 때만 분류값·형식 검증 (성공 시 null 허용)
+  const { llmStatus, failureReason, httpStatus, timedOut } = body;
+  if (llmStatus !== undefined && llmStatus !== null && !LLM_STATUSES.includes(llmStatus)) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "llmStatus" };
+  }
+  if (failureReason !== undefined && failureReason !== null && !FAILURE_REASONS.includes(failureReason)) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "failureReason" };
+  }
+  if (httpStatus !== undefined && httpStatus !== null && (!Number.isInteger(httpStatus) || httpStatus < 0)) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "httpStatus" };
+  }
+  if (timedOut !== undefined && timedOut !== null && timedOut !== 0 && timedOut !== 1) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "timedOut" };
+  }
+
   return null;
 }
 
@@ -51,7 +70,7 @@ router.post("/", (req, res, next) => {
     return fail(res, 400, error.code, `${error.field} 필드가 올바르지 않습니다.`, error.field);
   }
 
-  const { anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs } = req.body;
+  const { anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs, llmStatus, failureReason, httpStatus, timedOut } = req.body;
 
   try {
     insertSession.run({
@@ -65,6 +84,10 @@ router.post("/", (req, res, next) => {
       totalMs: totalMs ?? null,
       youtubeMs: youtubeMs ?? null,
       geminiMs: geminiMs ?? null,
+      llmStatus: llmStatus ?? null,
+      failureReason: failureReason ?? null,
+      httpStatus: httpStatus ?? null,
+      timedOut: timedOut ?? null,
     });
   } catch (err) {
     if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -9,15 +9,22 @@ const insertSession = db.prepare(`
   VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy, @totalMs, @youtubeMs, @geminiMs, @llmStatus, @failureReason, @httpStatus, @timedOut)
 `);
 
-// 10-3 지연시간 필드 — 확장이 측정해 전송. 선택 항목이며, 있으면 음수 아닌 정수여야 한다.
+//  지연시간 필드 — 확장이 측정해 전송. 선택 항목이며, 있으면 음수 아닌 정수여야 한다.
 const LATENCY_FIELDS = ["totalMs", "youtubeMs", "geminiMs"];
 
-// 10-4 LLM 폴백 로깅 — 확장의 실패 분류값. server/db.js·llm.js와 1:1 대응.
+//  LLM 폴백 로깅 — 확장의 실패 분류값. server/db.js·llm.js와 1:1 대응.
 const LLM_STATUSES = ["success", "fallback"];
-const FAILURE_REASONS = ["timeout", "http_error", "empty_response", "parse_error", "network_error"];
+const FAILURE_REASONS = [
+  "timeout",
+  "http_error",
+  "empty_response",
+  "parse_error",
+  "network_error",
+];
 
 function validateSession(body) {
-  const { anonymousId, sessionId, startTime, endTime, videoCount, entropy } = body;
+  const { anonymousId, sessionId, startTime, endTime, videoCount, entropy } =
+    body;
 
   const requiredFields = ["anonymousId", "sessionId", "startTime", "endTime"];
   for (const field of requiredFields) {
@@ -33,10 +40,16 @@ function validateSession(body) {
   if (isNaN(Date.parse(endTime))) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "endTime" };
   }
-  if (videoCount !== undefined && (!Number.isInteger(videoCount) || videoCount < 0)) {
+  if (
+    videoCount !== undefined &&
+    (!Number.isInteger(videoCount) || videoCount < 0)
+  ) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "videoCount" };
   }
-  if (entropy !== undefined && (typeof entropy !== "number" || !Number.isFinite(entropy) || entropy < 0)) {
+  if (
+    entropy !== undefined &&
+    (typeof entropy !== "number" || !Number.isFinite(entropy) || entropy < 0)
+  ) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "entropy" };
   }
   for (const field of LATENCY_FIELDS) {
@@ -46,18 +59,35 @@ function validateSession(body) {
     }
   }
 
-  // 10-4 폴백 로깅 — 값이 있을 때만 분류값·형식 검증 (성공 시 null 허용)
+  //  폴백 로깅 — 값이 있을 때만 분류값·형식 검증 (성공 시 null 허용)
   const { llmStatus, failureReason, httpStatus, timedOut } = body;
-  if (llmStatus !== undefined && llmStatus !== null && !LLM_STATUSES.includes(llmStatus)) {
+  if (
+    llmStatus !== undefined &&
+    llmStatus !== null &&
+    !LLM_STATUSES.includes(llmStatus)
+  ) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "llmStatus" };
   }
-  if (failureReason !== undefined && failureReason !== null && !FAILURE_REASONS.includes(failureReason)) {
+  if (
+    failureReason !== undefined &&
+    failureReason !== null &&
+    !FAILURE_REASONS.includes(failureReason)
+  ) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "failureReason" };
   }
-  if (httpStatus !== undefined && httpStatus !== null && (!Number.isInteger(httpStatus) || httpStatus < 0)) {
+  if (
+    httpStatus !== undefined &&
+    httpStatus !== null &&
+    (!Number.isInteger(httpStatus) || httpStatus < 0)
+  ) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "httpStatus" };
   }
-  if (timedOut !== undefined && timedOut !== null && timedOut !== 0 && timedOut !== 1) {
+  if (
+    timedOut !== undefined &&
+    timedOut !== null &&
+    timedOut !== 0 &&
+    timedOut !== 1
+  ) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "timedOut" };
   }
 
@@ -67,10 +97,31 @@ function validateSession(body) {
 router.post("/", (req, res, next) => {
   const error = validateSession(req.body);
   if (error) {
-    return fail(res, 400, error.code, `${error.field} 필드가 올바르지 않습니다.`, error.field);
+    return fail(
+      res,
+      400,
+      error.code,
+      `${error.field} 필드가 올바르지 않습니다.`,
+      error.field,
+    );
   }
 
-  const { anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs, llmStatus, failureReason, httpStatus, timedOut } = req.body;
+  const {
+    anonymousId,
+    sessionId,
+    startTime,
+    endTime,
+    videoCount,
+    categoryDistribution,
+    entropy,
+    totalMs,
+    youtubeMs,
+    geminiMs,
+    llmStatus,
+    failureReason,
+    httpStatus,
+    timedOut,
+  } = req.body;
 
   try {
     insertSession.run({
@@ -79,7 +130,10 @@ router.post("/", (req, res, next) => {
       startTime,
       endTime,
       videoCount: videoCount ?? null,
-      categoryDistribution: categoryDistribution != null ? JSON.stringify(categoryDistribution) : null,
+      categoryDistribution:
+        categoryDistribution != null
+          ? JSON.stringify(categoryDistribution)
+          : null,
       entropy: entropy ?? null,
       totalMs: totalMs ?? null,
       youtubeMs: youtubeMs ?? null,
@@ -91,7 +145,13 @@ router.post("/", (req, res, next) => {
     });
   } catch (err) {
     if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {
-      return fail(res, 409, ERROR_CODES.DUPLICATE_SESSION, "이미 존재하는 세션입니다.", sessionId);
+      return fail(
+        res,
+        409,
+        ERROR_CODES.DUPLICATE_SESSION,
+        "이미 존재하는 세션입니다.",
+        sessionId,
+      );
     }
     return next(err);
   }

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -54,7 +54,11 @@ function validateSession(body) {
   }
   for (const field of LATENCY_FIELDS) {
     const value = body[field];
-    if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
+    if (
+      value !== undefined &&
+      value !== null &&
+      (!Number.isInteger(value) || value < 0)
+    ) {
       return { code: ERROR_CODES.INVALID_FIELD_VALUE, field };
     }
   }

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -5,9 +5,12 @@ const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
 const router = express.Router();
 
 const insertSession = db.prepare(`
-  INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy)
-  VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy)
+  INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs)
+  VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy, @totalMs, @youtubeMs, @geminiMs)
 `);
+
+// 10-3 지연시간 필드 — 확장이 측정해 전송. 선택 항목이며, 있으면 음수 아닌 정수여야 한다.
+const LATENCY_FIELDS = ["totalMs", "youtubeMs", "geminiMs"];
 
 function validateSession(body) {
   const { anonymousId, sessionId, startTime, endTime, videoCount, entropy } = body;
@@ -32,6 +35,12 @@ function validateSession(body) {
   if (entropy !== undefined && (typeof entropy !== "number" || !Number.isFinite(entropy) || entropy < 0)) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "entropy" };
   }
+  for (const field of LATENCY_FIELDS) {
+    const value = body[field];
+    if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
+      return { code: ERROR_CODES.INVALID_FIELD_VALUE, field };
+    }
+  }
 
   return null;
 }
@@ -42,7 +51,7 @@ router.post("/", (req, res, next) => {
     return fail(res, 400, error.code, `${error.field} 필드가 올바르지 않습니다.`, error.field);
   }
 
-  const { anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy } = req.body;
+  const { anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs } = req.body;
 
   try {
     insertSession.run({
@@ -53,6 +62,9 @@ router.post("/", (req, res, next) => {
       videoCount: videoCount ?? null,
       categoryDistribution: categoryDistribution != null ? JSON.stringify(categoryDistribution) : null,
       entropy: entropy ?? null,
+      totalMs: totalMs ?? null,
+      youtubeMs: youtubeMs ?? null,
+      geminiMs: geminiMs ?? null,
     });
   } catch (err) {
     if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {

--- a/server/scripts/backup-db.js
+++ b/server/scripts/backup-db.js
@@ -107,18 +107,23 @@ function offsitePush(dest) {
   // BatchMode=yes: 프롬프트 없이 즉시 실패(자동화용). known_hosts는 최초 수동 접속 시 등록됨.
   const sshOpts = ["-i", key, "-o", "BatchMode=yes", "-o", "ConnectTimeout=10"];
 
+  // 네트워크 장애·원격 지연으로 무한 대기하면 후속 크론 작업까지 막히므로 타임아웃을 건다.
+  const execOpts = { stdio: "pipe", timeout: 30000 };
+
   try {
-    execFileSync("ssh", [...sshOpts, target, `mkdir -p ${remoteDir}`], { stdio: "pipe" });
-    execFileSync("scp", [...sshOpts, dest, `${target}:${remoteDir}/`], { stdio: "pipe" });
+    execFileSync("ssh", [...sshOpts, target, `mkdir -p ${remoteDir}`], execOpts);
+    execFileSync("scp", [...sshOpts, dest, `${target}:${remoteDir}/`], execOpts);
     // 원격 로테이션 — remoteRetention일 지난 백업 삭제
     execFileSync(
       "ssh",
       [...sshOpts, target, `find ${remoteDir} -maxdepth 1 -name 'youtube_bias-*.db' -mtime +${remoteRetention} -delete`],
-      { stdio: "pipe" },
+      execOpts,
     );
     console.log(`[backup] 오프사이트 전송 완료: ${target}:${remoteDir}/ (보관 ${remoteRetention}일)`);
   } catch (err) {
-    console.warn("[backup] 오프사이트 전송 실패(로컬 백업은 정상):", err.message);
+    // err.message에는 SSH 실패 원인이 안 담기는 경우가 많아, stderr가 있으면 함께 남긴다.
+    const detail = err.stderr ? err.stderr.toString().trim() : err.message;
+    console.warn("[backup] 오프사이트 전송 실패(로컬 백업은 정상):", detail);
   }
 }
 


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->

Epic 10의 후속 스토리 10-3~10-5를 구현  
6주 확대 실험에 대비한 **성능·견고성·상호작용 계측 3종**의 측정 및 저장.   
저장 스키마는 10-2에서 이미 확정되었고, 본 PR은 **데이터 수집·전송·검증 로직**을 추가(신규 마이그레이션 없음). 모든 신규 필드는 선택값이라 구버전 확장과 하위호환됩니다.  

## 변경 사항

<!-- 구체적으로 무엇을 변경했는지 -->

- **10-3 세션 처리 지연시간**: `background.js`에서 구간별 측정(`youtubeMs` 카테고리 조회 / `geminiMs` 리뷰 생성, 성공·폴백 무관 / `totalMs` 전체)해 세션 POST로 전송. `server/routes/sessions.js`가 수신·저장(음수 아닌 정수 검증)  
- **10-4 LLM 실패·폴백 로깅**:`pipeline/llm.js`의 `generateReview` throw 지점을 `failureReason` 분류값(`timeout`/`http_error`/`empty_response`/`parse_error`/`network_error`)으로 태깅(`llmError`, `httpStatus`·`timedOut` 병기). `background.js`가 성공/폴백을 분류해 `llmStatus`/`failureReason`/`httpStatus`/`timedOut` 전송, 서버가 enum·형식 검증 후 저장  
- **10-5 팝업 상호작용 마이크로 로그**: 신규 엔드포인트 `POST /api/popup-events`(`server/routes/popup-events.js`, `app.js` 등록). 팝업(`viewlens-popup.js`)에서 `openedAt`·탭 클릭(`today`/`feedback`)·`feedbackViewed`·`dwellMs` 수집. close teardown에 잘려도 유실되지 않도록 `livePopupEvent` 스냅샷 + 다음 open 시 확정 큐로 flush·재시도(`sendBeacon` 미사용 → 중복 없음)  
- **오프사이트 백업 코드리뷰 반영**(10-2 후속) — `backup-db.js` `execFileSync` 타임아웃 30초 + 전송 실패 시 `stderr` 로깅  
- **문서** — `docs/05-작업3.md` 10-3~10-5 완료 반영, 후속 스토리(10-6 완료 알림 / 10-7 세밀 다양성 신호 / 10-8 2주 베이스라인·그룹 분기) 추가. 코드 주석의 작업 단계 번호 표기 정리  

## 관련 이슈

- closes #117 
- closes #118 
- closes #119   
  
## 테스트 확인

- [x] 변경된 서버 라우트·확장 파일 `node --check` 구문 검사 통과  
- [x] in-memory SQLite 스모크 테스트 — `sessions`(success/http_error/timeout), `popup_events` 저장 확인  
- [ ] 로컬에서 확장 프로그램 리로드 후 세션 종료→전송 E2E 확인  
- [ ] 콘솔 에러 없음  

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

## 참고 사항

<!-- 특별히 전달할 내용 -->