### PR TITLE
docs: 10-2 스키마·백업 서술을 리팩터링 후 코드에 맞게 정정

### DIFF
--- a/docs/05-작업3.md
+++ b/docs/05-작업3.md
@@ -69,13 +69,13 @@
 #### 완료 작업
 
 - [x] **동시성·내구성 하드닝** ([server/db.js](../server/db.js)): `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`, `foreign_keys=ON`. `.gitignore`에 `*.db-wal`, `*.db-shm` 추가. (commit `632eaed`)
-- [x] **스키마 확정 + 비파괴 마이그레이션** ([server/db.js](../server/db.js)): 아래 컬럼/테이블을 `ALTER TABLE`(멱등) 패턴으로 반영. (commit `3e1928c`)
+- [x] **스키마 확정** ([server/db.js](../server/db.js)): 아래 컬럼/테이블을 반영. (commit `3e1928c`; 최초엔 `ALTER TABLE`(멱등) 패턴이었으나, 런칭 전이라 마이그레이션할 구버전 DB가 없어 이후 commit `fbd3446`에서 단일 `CREATE TABLE IF NOT EXISTS`로 통합)
   - `sessions` 추가 컬럼 (10-3/10-4용, 확장이 측정해 세션 POST로 전송):
     - `totalMs`, `youtubeMs`, `geminiMs` — 세션 처리 지연시간
     - `llmStatus`(`'success'`|`'fallback'`), `failureReason`(`timeout`|`http_error`|`empty_response`|`parse_error`|`network_error`), `httpStatus`, `timedOut`
     - `failureReason` 분류값은 [extension/pipeline/llm.js](../extension/pipeline/llm.js)의 실제 throw 지점과 1:1 대응(죽은 카테고리 없음, 429 쿼터 vs 5xx 장애 구분 위해 `httpStatus` 병기).
   - `popup_events` 신규 테이블 (10-5용, 세션 무관): `dwellMs`, `tabTodayClicks`, `tabWeekClicks`, `feedbackViewed`, `openedAt`.
-- [x] **정기 백업 스크립트** ([server/scripts/backup-db.js](../server/scripts/backup-db.js)): `better-sqlite3 db.backup()` 핫 백업(cp 대비 WAL 정합성 보장), repo 밖 `~/db-backups`에 저장, `RETENTION_DAYS`(기본 30일) 로테이션. `pnpm backup` 스크립트 추가. (commit `721f982`)
+- [x] **정기 백업 스크립트** ([server/scripts/backup-db.js](../server/scripts/backup-db.js)): `PRAGMA wal_checkpoint(TRUNCATE)`로 WAL을 메인 파일에 반영한 뒤 `fs.copyFileSync()`로 파일 전체 복사(암호화된 바이트 그대로 복제), repo 밖 `~/db-backups`에 저장, `RETENTION_DAYS`(기본 30일) 로테이션. `pnpm backup` 스크립트 추가. (commit `721f982`; 최초엔 `better-sqlite3 db.backup()` 핫 백업이었으나, 이후 DB 암호화 도입으로 독립 생성된 두 암호화 파일의 salt가 달라 `db.backup()`이 `incompatible source and target databases`로 실패하게 되어 commit `eb2b3a0`에서 현재 방식으로 교체)
 - [x] **응답 포맷 명세 준수 수정**: `DUPLICATE_SESSION` HTTP 400 → **409** ([server/routes/sessions.js](../server/routes/sessions.js), [docs/01-응답포맷.md](01-응답포맷.md) 명세와 일치).
 
 #### 남은 운영 작업 (배포 후, 후속 처리)
@@ -84,6 +84,12 @@
 - [x] `pm2 install pm2-logrotate` — 6주간 운영 로그 로테이션(유실·디스크 방지). `pm2 startup`/`pm2 save`로 재부팅 시 자동 복원까지 설정.
 - [x] 오프사이트 백업 구현 — A1 → e1 서버로 백업 자동 복사. [backup-db.js](../server/scripts/backup-db.js)가 `E1_BACKUP_HOST` 환경변수 설정 시에만 scp 전송(무압축, 원격 14일 보관, best-effort). 원격 주소·키는 코드 미포함(A1 crontab의 env로만 주입). A1→e1 무암호 SSH 키(`~/.ssh/e1_backup`) 설정 완료.
   - [x] 남은 것: A1 crontab 두 줄에 `E1_BACKUP_HOST=<e1 IP>` 추가 + 배포 후 전송 1회 검증.
+
+#### 문서 정합성 갱신 필요 (완료 작업 항목 2건, 리팩터링 후 문서 미반영)
+
+- 배경: [docs/blog/story-10-2-검증-보고서.md](blog/story-10-2-검증-보고서.md)에서 위 "완료 작업" 절 중 2개 항목의 서술이 이후 리팩터링 커밋으로 실제 구현과 달라졌음을 확인(기능 자체는 정상 동작, 서술만 outdated).
+- [x] 스키마 확정 항목의 "`ALTER TABLE`(멱등) 패턴으로 반영" → 단일 `CREATE TABLE`로 정정 (커밋 `fbd3446` "ALTER 기반 점진 마이그레이션 제거, CREATE TABLE로 스키마 단일화" 반영. 런칭 전이라 마이그레이션할 구버전 DB가 없다는 판단에 따른 리팩터링).
+- [x] 정기 백업 스크립트 항목의 "`better-sqlite3 db.backup()` 핫 백업(cp 대비 WAL 정합성 보장)" → `PRAGMA wal_checkpoint(TRUNCATE)` 후 `fs.copyFileSync()` 방식으로 정정 (커밋 `eb2b3a0` "ase-256 형식 암호화 적용 및 백업 방식 변경" 반영. 암호화된 DB 2개는 salt가 달라 `db.backup()`이 `incompatible source and target databases`로 실패해서 교체됨).
 
 ---
 


### PR DESCRIPTION
## 개요

Story 10-2(데이터 저장소 스키마 확정) 완료 작업 절 중 2개 항목의 서술이 이후 리팩터링 커밋으로 실제 구현과 달라져 있었다. 코드 변경 없이 문서 서술만 최신 구현에 맞게 정정한다.

## 변경 사항

- "`ALTER TABLE`(멱등) 패턴으로 반영" → 단일 `CREATE TABLE`로 정정 (런칭 전이라 마이그레이션할 구버전 DB가 없어 ALTER 기반 마이그레이션을 제거한 리팩터링)
- "`better-sqlite3 db.backup()` 핫 백업" → `PRAGMA wal_checkpoint(TRUNCATE)` + `fs.copyFileSync()` 방식으로 정정 (DB 암호화 도입 후 독립 생성된 두 암호화 파일의 salt가 달라 `db.backup()`이 실패하게 되어 교체된 방식)
- "문서 정합성 갱신 필요" 체크리스트 2건을 완료로 표시

## 관련 이슈

- closes #130 

## 테스트 확인

- [x] 문서 변경만 포함(코드 변경 없음) — 확장 프로그램 리로드·콘솔 에러 확인 해당 없음  
- [x] 정정 서술이 실제 코드(`server/db.js`, `server/scripts/backup-db.js`) 및 인용 커밋 해시와 일치하는지 확인  

## 스크린샷 (UI 변경 시)

해당 없음 (문서 변경만)

## 참고 사항
- 기능적 동작에는 영향 없음 — 문서 서술만 코드에 맞춰 정정
