### PR TITLE
feat: 세션 분석 완료 알림·배지 및 피드백 열람 기록

### DIFF
--- a/docs/05-작업3.md
+++ b/docs/05-작업3.md
@@ -154,10 +154,10 @@
 
 #### Tasks
 
-- [ ] `manifest.json`에 `notifications` 권한 추가
-- [ ] 분석 완료 시 `chrome.notifications` + 배지 표시 (EXP·베이스라인 종료 후 게이트 — 10-8)
-- [ ] 알림/버튼 클릭 → 피드백 탭 오픈 + 열람 기록, 배지 클리어
-- [ ] 스키마 확장(`sessions.feedbackNotifiedAt`/`feedbackViewedAt`) 및 서버 수신·저장
+- [x] `manifest.json`에 `notifications` 권한 추가
+- [x] 분석 완료 시 `chrome.notifications` + 배지 표시 (EXP·베이스라인 종료 후 게이트 — 10-8)
+- [x] 알림/버튼 클릭 → 피드백 탭 오픈 + 열람 기록, 배지 클리어
+- [x] 스키마 확장(`sessions.feedbackNotifiedAt`/`feedbackViewedAt`) 및 서버 수신·저장
 
 ### Story 10-7: 세밀 다양성 신호(토픽·채널·발견 경로) — 후속 스토리
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -33,6 +33,51 @@ function isFeedbackNotificationEligible(group, _installDate) {
   return FEEDBACK_ELIGIBLE_GROUPS.has(group);
 }
 
+const BASE_ICON_PATHS = {
+  16: "assets/icons/icon16.png",
+  32: "assets/icons/icon32.png",
+  48: "assets/icons/icon48.png",
+  128: "assets/icons/icon128.png",
+};
+
+// 미열람 표시를 배지 텍스트("•") 대신 아이콘 자체에 그려 넣는다 — 배지 글리프는
+// OS·Chrome 버전마다 렌더링이 달라질 수 있지만, 이렇게 그리면 픽셀이 고정되어 항상 동일하게 보인다.
+async function setUnviewedIconDot() {
+  try {
+    const imageData = {};
+    for (const size of Object.keys(BASE_ICON_PATHS).map(Number)) {
+      imageData[size] = await drawIconWithDot(size);
+    }
+    chrome.action.setIcon({ imageData });
+  } catch (error) {
+    // 아이콘 그리기가 실패해도(예: OffscreenCanvas 미지원) 알림 자체는 이미 떴으므로 무시.
+    console.warn("[background] 미열람 아이콘 표시 실패:", error.message);
+  }
+}
+
+function clearUnviewedIconDot() {
+  chrome.action.setIcon({ path: BASE_ICON_PATHS });
+}
+
+async function drawIconWithDot(size) {
+  const response = await fetch(chrome.runtime.getURL(BASE_ICON_PATHS[size]));
+  const bitmap = await createImageBitmap(await response.blob());
+
+  const canvas = new OffscreenCanvas(size, size);
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(bitmap, 0, 0, size, size);
+
+  const radius = Math.max(2, Math.round(size * 0.22));
+  const cx = size - radius - 1;
+  const cy = radius + 1;
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.fillStyle = "#E11D2E";
+  ctx.fill();
+
+  return ctx.getImageData(0, 0, size, size);
+}
+
 // service worker가 깨어날 때마다 실행 — 같은 이름의 alarm은 자동으로 교체됨
 chrome.alarms.create(ALARM_NAME, { periodInMinutes: 1 });
 
@@ -59,7 +104,7 @@ chrome.notifications.onClicked.addListener(handleNotificationOpen);
 
 async function handleNotificationOpen(sessionId) {
   chrome.notifications.clear(sessionId);
-  chrome.action.setBadgeText({ text: "" });
+  clearUnviewedIconDot();
   chrome.tabs.create({ url: chrome.runtime.getURL("popup/popup.html") });
   await markFeedbackViewed(sessionId);
 }
@@ -238,9 +283,7 @@ function notifyFeedbackReady(session, onboarding) {
     buttons: [{ title: "피드백 보러 가기" }],
   });
   // 개수 대신 있음/없음만 표시 — 정확한 미열람 개수는 연구 지표가 아니다.
-  // 배경색을 지정하지 않으면 Chrome 기본값(테마별 회색 등)이 쓰여 눈에 잘 안 띄므로 명시한다.
-  chrome.action.setBadgeBackgroundColor({ color: "#E11D2E" });
-  chrome.action.setBadgeText({ text: "•" });
+  setUnviewedIconDot();
   return true;
 }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -22,6 +22,17 @@ import { SERVER_URL } from "./config.js";
 const ALARM_NAME = "SESSION_TIMEOUT_CHECK";
 const TIMEOUT_MS = 10 * 60 * 1000;
 
+// 분석 완료 알림 대상 판정 (). 현재는 EXP 여부만 본다 — 10-8(2주 베이스라인 게이트)이
+// 끝나면 이 함수 안에 installDate 기준 베이스라인 종료 조건만 추가하면 되고, 알림·배지·
+// 서버 코드는 건드릴 필요가 없도록 판정 로직을 이 한 곳에 모아둔다.
+// extension/popup/viewlens-data.js의 GROUPS 중 feedback:true인 그룹(EXP/TEST-EXP)과
+// 반드시 동일하게 유지해야 한다 — background.js는 popup 쪽 데이터 파일을 import할 수 없어(모듈 경계) 중복 정의한다.
+const FEEDBACK_ELIGIBLE_GROUPS = new Set(["EXP", "TEST-EXP"]);
+
+function isFeedbackNotificationEligible(group, _installDate) {
+  return FEEDBACK_ELIGIBLE_GROUPS.has(group);
+}
+
 // service worker가 깨어날 때마다 실행 — 같은 이름의 alarm은 자동으로 교체됨
 chrome.alarms.create(ALARM_NAME, { periodInMinutes: 1 });
 
@@ -150,12 +161,20 @@ async function analyzeSession(session) {
   });
   console.log("[background] 리뷰 저장 완료:", result);
 
+  // 알림·전송 모두 온보딩 정보(그룹·anonymousId)가 필요해 한 번만 조회해 공유한다.
+  const onboarding = await getOnboarding();
+
+  const feedbackNotifiedAt = notifyFeedbackReady(session, onboarding)
+    ? new Date().toISOString()
+    : null;
+
   const totalMs = Date.now() - t0;
   await postSessionToServer(
     session,
     categoryDistribution,
     entropy,
     videoCount,
+    onboarding,
     {
       totalMs,
       youtubeMs,
@@ -164,8 +183,27 @@ async function analyzeSession(session) {
       failureReason,
       httpStatus,
       timedOut,
+      feedbackNotifiedAt,
     },
   );
+}
+
+// 분석 완료 알림 + 배지 표시 (). 대상이면 true를 반환해 호출부가 feedbackNotifiedAt을 기록하게 한다.
+// notificationId로 session.sessionId를 그대로 사용 — 버튼 클릭 시 별도 매핑 없이 세션을 역추적한다.
+function notifyFeedbackReady(session, onboarding) {
+  if (!isFeedbackNotificationEligible(onboarding?.group, onboarding?.installDate)) {
+    return false;
+  }
+  chrome.notifications.create(session.sessionId, {
+    type: "basic",
+    iconUrl: chrome.runtime.getURL("assets/icons/icon128.png"),
+    title: "ViewLens",
+    message: "이번 세션 분석이 준비됐어요.",
+    buttons: [{ title: "피드백 보러 가기" }],
+  });
+  // 개수 대신 있음/없음만 표시 — 정확한 미열람 개수는 연구 지표가 아니다.
+  chrome.action.setBadgeText({ text: "•" });
+  return true;
 }
 
 async function postSessionToServer(
@@ -173,6 +211,7 @@ async function postSessionToServer(
   categoryDistribution,
   entropy,
   videoCount,
+  onboarding,
   metrics = {},
 ) {
   if (!SERVER_URL || SERVER_URL.startsWith("YOUR_")) {
@@ -182,7 +221,6 @@ async function postSessionToServer(
     return;
   }
 
-  const onboarding = await getOnboarding();
   if (!onboarding?.anonymousId) {
     console.warn("[background] anonymousId 없음, 서버 전송 건너뜀");
     return;
@@ -212,6 +250,7 @@ async function postSessionToServer(
         failureReason: metrics.failureReason,
         httpStatus: metrics.httpStatus,
         timedOut: metrics.timedOut,
+        feedbackNotifiedAt: metrics.feedbackNotifiedAt,
       }),
     });
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -238,6 +238,8 @@ function notifyFeedbackReady(session, onboarding) {
     buttons: [{ title: "피드백 보러 가기" }],
   });
   // 개수 대신 있음/없음만 표시 — 정확한 미열람 개수는 연구 지표가 아니다.
+  // 배경색을 지정하지 않으면 Chrome 기본값(테마별 회색 등)이 쓰여 눈에 잘 안 띄므로 명시한다.
+  chrome.action.setBadgeBackgroundColor({ color: "#E11D2E" });
   chrome.action.setBadgeText({ text: "•" });
   return true;
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -53,6 +53,42 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   checkSessionTimeout();
 });
 
+// 알림 본문/버튼 클릭 모두 같은 동작 — notificationId가 곧 sessionId이므로 별도 매핑 없이 역추적한다.
+chrome.notifications.onButtonClicked.addListener(handleNotificationOpen);
+chrome.notifications.onClicked.addListener(handleNotificationOpen);
+
+async function handleNotificationOpen(sessionId) {
+  chrome.notifications.clear(sessionId);
+  chrome.action.setBadgeText({ text: "" });
+  chrome.tabs.create({ url: chrome.runtime.getURL("popup/popup.html") });
+  await markFeedbackViewed(sessionId);
+}
+
+// 알림 클릭을 "실제 열람 시작"으로 서버에 기록 (). 팝업 표시 기반 feedbackViewed(10-5)보다
+// 엄격한 신호 — 알림을 거치지 않고 그냥 팝업을 연 경우는 여기서 기록하지 않는다.
+async function markFeedbackViewed(sessionId) {
+  if (!SERVER_URL || SERVER_URL.startsWith("YOUR_")) return;
+  const onboarding = await getOnboarding();
+  if (!onboarding?.anonymousId) return;
+
+  const cleanUrl = SERVER_URL.replace(/\/$/, "");
+  try {
+    const response = await fetch(
+      `${cleanUrl}/api/sessions/${encodeURIComponent(sessionId)}/feedback-viewed`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ anonymousId: onboarding.anonymousId }),
+      },
+    );
+    if (!response.ok) {
+      console.warn("[background] 피드백 열람 기록 실패:", response.status);
+    }
+  } catch (error) {
+    console.warn("[background] 피드백 열람 기록 오류:", error);
+  }
+}
+
 async function handleVideoDetected(message) {
   const { videoId, title } = message;
   await addVideo(videoId, title);

--- a/extension/background.js
+++ b/extension/background.js
@@ -56,7 +56,16 @@ async function setUnviewedIconDot() {
 }
 
 function clearUnviewedIconDot() {
-  chrome.action.setIcon({ path: BASE_ICON_PATHS });
+  // setIcon의 상대 경로는 "확장 루트"가 아니라 "호출한 스크립트의 위치" 기준으로 풀린다.
+  // background.js는 루트에 있어 상대 경로가 우연히 맞았을 뿐이므로, getURL로 명시적인
+  // 절대 경로를 만들어 어디서 호출되든(팝업 등) 항상 정확하게 만든다.
+  const path = Object.fromEntries(
+    Object.entries(BASE_ICON_PATHS).map(([size, p]) => [
+      size,
+      chrome.runtime.getURL(p),
+    ]),
+  );
+  chrome.action.setIcon({ path });
 }
 
 async function drawIconWithDot(size) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -50,35 +50,50 @@ let writeQueue = Promise.resolve();
 
 function recordVideo(videoId, title) {
   writeQueue = writeQueue.then(async () => {
-    const now = new Date().toISOString();
-    const { currentSession, anonymousId, serverUrl } = await chrome.storage.local.get([
-      "currentSession",
-      "anonymousId",
-      "serverUrl",
-    ]);
+    // 확장을 리로드/업데이트하면 이미 열려있던 유튜브 탭의 content script는 페이지를
+    // 새로고침하기 전까지 무효화된 컨텍스트로 남는다 — 이 상태에서 chrome.* 호출은 전부
+    // 예외를 던진다. 미리 감지해 조용히 실패하지 말고 콘솔에 남겨서 원인을 알 수 있게 한다.
+    if (!chrome.runtime?.id) {
+      console.warn(
+        "[content] 확장 컨텍스트 무효화됨(리로드/업데이트) — 이 탭을 새로고침해야 기록이 재개됩니다.",
+      );
+      return;
+    }
 
-    const session = currentSession ?? {
-      sessionId: String(Date.now()),
-      startTime: now,
-      videos: [],
-    };
+    try {
+      const now = new Date().toISOString();
+      const { currentSession, anonymousId, serverUrl } = await chrome.storage.local.get([
+        "currentSession",
+        "anonymousId",
+        "serverUrl",
+      ]);
 
-    await chrome.storage.local.set({ lastWatchedAt: now });
+      const session = currentSession ?? {
+        sessionId: String(Date.now()),
+        startTime: now,
+        videos: [],
+      };
 
-    const lastSaved = session.videos.at(-1);
-    if (lastSaved?.videoId === videoId) return;
+      await chrome.storage.local.set({ lastWatchedAt: now });
 
-    session.videos.push({ videoId, title, watchedAt: now });
-    await chrome.storage.local.set({ currentSession: session });
-    console.log("[content] recorded:", { videoId, title });
+      const lastSaved = session.videos.at(-1);
+      if (lastSaved?.videoId === videoId) return;
 
-    // 서버에 즉시 전송
-    if (anonymousId && serverUrl && !serverUrl.startsWith("YOUR_")) {
-      fetch(`${serverUrl.replace(/\/$/, "")}/api/video-events`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ anonymousId, videoId, title: title ?? null, watchedAt: now }),
-      }).catch(() => {});
+      session.videos.push({ videoId, title, watchedAt: now });
+      await chrome.storage.local.set({ currentSession: session });
+      console.log("[content] recorded:", { videoId, title });
+
+      // 서버에 즉시 전송
+      if (anonymousId && serverUrl && !serverUrl.startsWith("YOUR_")) {
+        fetch(`${serverUrl.replace(/\/$/, "")}/api/video-events`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ anonymousId, videoId, title: title ?? null, watchedAt: now }),
+        }).catch(() => {});
+      }
+    } catch (error) {
+      // 컨텍스트가 호출 도중 무효화된 경우 등 — 조용히 삼키지 않고 원인을 남긴다.
+      console.warn("[content] 영상 기록 실패:", error.message);
     }
   });
   return writeQueue;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "ViewLens: YouTube Bias Feedback",
   "version": "1.0.1",
-  "permissions": ["storage", "alarms"],
+  "permissions": ["storage", "alarms", "notifications"],
   "icons": {
     "16": "assets/icons/icon16.png",
     "32": "assets/icons/icon32.png",

--- a/extension/popup/viewlens-app.js
+++ b/extension/popup/viewlens-app.js
@@ -155,6 +155,8 @@ class ViewLensPopup {
         this._selectedDate.toDateString() === new Date().toDateString();
       d.collectingCount = isToday ? (VL.today?.collectingCount ?? 0) : 0;
       d.collectingTimer = isToday ? _collectingTimerText() : "";
+      // 지난 날짜 조회 시엔 블러 대상이 아니므로 항상 확인된 것으로 취급한다.
+      d.confirmed = isToday ? !!VL.today?.confirmed : true;
       VL.today = d;
     }
 

--- a/extension/popup/viewlens-app.js
+++ b/extension/popup/viewlens-app.js
@@ -67,7 +67,7 @@ function _popupHeader(groupCfg, day) {
   </div>`;
 }
 
-function _tabs(activeTab) {
+function _tabs(activeTab, needsConfirmNudge = false) {
   const list = [
     { id: "today", label: "오늘" },
     { id: "feedback", label: "주차별 피드백" },
@@ -76,7 +76,12 @@ function _tabs(activeTab) {
     ${list
       .map((t) => {
         const on = t.id === activeTab;
-        return `<button data-tab="${t.id}" style="flex:1;padding:9px 6px 11px;border:none;background:transparent;cursor:pointer;font-family:inherit;font-size:13px;font-weight:700;color:${on ? "var(--vl-accent)" : "var(--vl-ink-3)"};border-bottom:2px solid ${on ? "var(--vl-accent)" : "transparent"};transition:color .15s">${t.label}</button>`;
+        // 오늘 탭에 미확인 피드백이 있는데 지금 다른 탭을 보고 있으면 살짝 깜빡이는 점으로 알린다.
+        const nudge =
+          t.id === "today" && !on && needsConfirmNudge
+            ? `<span style="display:inline-block;width:6px;height:6px;margin-left:5px;border-radius:50%;background:var(--vl-accent);vertical-align:middle;animation:vlBlink 1.4s ease-in-out infinite"></span>`
+            : "";
+        return `<button data-tab="${t.id}" style="flex:1;padding:9px 6px 11px;border:none;background:transparent;cursor:pointer;font-family:inherit;font-size:13px;font-weight:700;color:${on ? "var(--vl-accent)" : "var(--vl-ink-3)"};border-bottom:2px solid ${on ? "var(--vl-accent)" : "transparent"};transition:color .15s">${t.label}${nudge}</button>`;
       })
       .join("")}
   </div>`;
@@ -156,7 +161,9 @@ class ViewLensPopup {
       d.collectingCount = isToday ? (VL.today?.collectingCount ?? 0) : 0;
       d.collectingTimer = isToday ? _collectingTimerText() : "";
       // 지난 날짜 조회 시엔 블러 대상이 아니므로 항상 확인된 것으로 취급한다.
-      d.confirmed = isToday ? !!VL.today?.confirmed : true;
+      // VL.today가 아니라 VL._todayConfirmed(날짜 이동에 영향받지 않는 별도 키)에서 읽는다 —
+      // VL.today에 두면 어제를 봤다가 오늘로 돌아올 때 "확인됨"으로 잘못 남는 버그가 있었다.
+      d.confirmed = isToday ? !!VL._todayConfirmed : true;
       VL.today = d;
     }
 
@@ -176,7 +183,7 @@ class ViewLensPopup {
     this.container.innerHTML = `<div style="position:relative;height:100%;display:flex;flex-direction:column;background:var(--vl-bg)">
       ${_popupHeader(groupCfg, day)}
       ${surveyPending && this._snoozed ? _surveyBanner(surveyWeek) : ""}
-      ${groupCfg.feedback ? _tabs(this._tab) : ""}
+      ${groupCfg.feedback ? _tabs(this._tab, !VL._todayConfirmed) : ""}
       <div style="flex:1;overflow-y:auto;overflow-x:hidden">${bodyHTML}</div>
       ${showModal ? screenSurveyModal(surveyWeek) : ""}
     </div>`;

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -450,6 +450,10 @@ async function handleFeedbackConfirmClick(popup, sessionId) {
   }
   clearUnviewedIconDot();
   popup.render();
+  // render()가 innerHTML을 통째로 교체하면서 스크롤이 맨 위로 리셋되므로 즉시 복원한다.
+  requestAnimationFrame(() => {
+    document.getElementById("vl-review-card")?.scrollIntoView({ block: "start" });
+  });
   postFeedbackConfirmed(sessionId);
 }
 

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -445,9 +445,7 @@ async function postFeedbackConfirmed(sessionId) {
 async function handleFeedbackConfirmClick(popup, sessionId) {
   if (!sessionId) return;
   await markFeedbackConfirmedLocally(sessionId);
-  if (VL.today?.sessionId === sessionId) {
-    VL.today = { ...VL.today, confirmed: true };
-  }
+  VL._todayConfirmed = true;
   clearUnviewedIconDot();
   popup.render();
   // render()가 innerHTML을 통째로 교체하면서 스크롤이 맨 위로 리셋되므로 즉시 복원한다.
@@ -592,11 +590,13 @@ async function boot() {
   const isExp = !!VL.GROUPS[stored.group]?.feedback;
   const needsConfirm = isExp && isRealReview(realToday.review);
   // "피드백 확인하기" 블러 해제 버튼을 눌러야만 확인된 것으로 친다(단순히 팝업을 연 것만으로는 아님).
-  realToday.confirmed = needsConfirm
+  // 날짜 이동(어제/그제 보기)에 영향받지 않도록 VL.today가 아니라 별도 키에 둔다 — VL.today는
+  // 날짜를 옮길 때마다 통째로 재생성돼서, 여기 두면 어제를 봤다 오늘로 돌아올 때 상태가 오염된다.
+  VL._todayConfirmed = needsConfirm
     ? await isFeedbackConfirmed(realToday.sessionId)
     : true;
   // 미열람 아이콘 표시도 "열기"가 아니라 "확인" 기준으로 지운다 — feedbackConfirmedAt과 의미를 맞춘다.
-  if (needsConfirm && realToday.confirmed) {
+  if (needsConfirm && VL._todayConfirmed) {
     clearUnviewedIconDot();
   }
 
@@ -653,7 +653,7 @@ async function boot() {
   });
 
   // 확인 안 된 리뷰가 있으면 열자마자 그 카드로 부드럽게 스크롤해 놓치지 않게 한다.
-  if (needsConfirm && !realToday.confirmed) {
+  if (needsConfirm && !VL._todayConfirmed) {
     requestAnimationFrame(() => {
       document
         .getElementById("vl-review-card")
@@ -732,11 +732,12 @@ async function boot() {
     freshToday.collectingTimer = _computeTimerText(localLastWatchedAt);
     const freshNeedsConfirm = isExp && isRealReview(freshToday.review);
     // 새로 완료된 세션은 아직 로컬에 확인 기록이 없을 테니 다시 블러 처리된다(의도된 동작).
-    freshToday.confirmed = freshNeedsConfirm
+    // 날짜 이동에 오염되지 않도록 VL.today가 아니라 VL._todayConfirmed에 둔다(위 boot()와 동일 이유).
+    VL._todayConfirmed = freshNeedsConfirm
       ? await isFeedbackConfirmed(freshToday.sessionId)
       : true;
     VL.today = freshToday;
-    if (freshNeedsConfirm && freshToday.confirmed) {
+    if (freshNeedsConfirm && VL._todayConfirmed) {
       clearUnviewedIconDot();
     }
     if (installDate) {

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -520,13 +520,16 @@ async function flushPendingPopupEvents(serverUrl) {
 
 // 미열람 아이콘 표시 해제 — background.js의 setUnviewedIconDot()과 짝을 이룬다.
 // 배경 스크립트(ESM)와 팝업 스크립트(클래식) 경계 때문에 경로 상수를 공유할 수 없어 중복 정의한다.
+// setIcon의 상대 경로는 "확장 루트"가 아니라 "호출한 스크립트의 위치"(여기선 popup/) 기준으로
+// 풀리므로, 반드시 chrome.runtime.getURL로 절대 경로를 만들어 넘겨야 한다(상대 경로로 두면
+// popup/assets/icons/...로 잘못 풀려 "Could not load action icon" 에러가 난다 — 실제 재현됨).
 function clearUnviewedIconDot() {
   chrome.action.setIcon({
     path: {
-      16: "assets/icons/icon16.png",
-      32: "assets/icons/icon32.png",
-      48: "assets/icons/icon48.png",
-      128: "assets/icons/icon128.png",
+      16: chrome.runtime.getURL("assets/icons/icon16.png"),
+      32: chrome.runtime.getURL("assets/icons/icon32.png"),
+      48: chrome.runtime.getURL("assets/icons/icon48.png"),
+      128: chrome.runtime.getURL("assets/icons/icon128.png"),
     },
   });
 }

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -125,6 +125,8 @@ function buildDataForDate(allSessions, targetDate) {
     sourceSessions.at(-1)?.review ||
     "시청 패턴을 분석하고 있어요. 잠시 후 시청 분석이 업데이트돼요.";
   const reviewTopic = sourceSessions.at(-1)?.reviewTopic || "";
+  // "피드백 확인하기" 블러 해제 버튼이 어느 세션을 확인 처리할지 알아야 해서 함께 넘긴다.
+  const sessionId = sourceSessions.at(-1)?.sessionId ?? null;
 
   const videos = sourceSessions
     .flatMap((sess) => {
@@ -172,6 +174,7 @@ function buildDataForDate(allSessions, targetDate) {
     videos,
     review,
     reviewTopic,
+    sessionId,
   };
 }
 
@@ -394,6 +397,62 @@ function isRealReview(text) {
   );
 }
 
+// "피드백 확인하기" 블러 해제 여부 () — 한 번 확인한 세션은 로컬에 기억해 다음에
+// 다시 팝업을 열어도 또 가리지 않는다. feedbackViewedAt(알림 클릭)보다 엄격한 별도 신호.
+async function isFeedbackConfirmed(sessionId) {
+  if (!sessionId) return false;
+  const { confirmedFeedbackSessionIds = [] } = await chrome.storage.local.get(
+    "confirmedFeedbackSessionIds",
+  );
+  return confirmedFeedbackSessionIds.includes(sessionId);
+}
+
+async function markFeedbackConfirmedLocally(sessionId) {
+  const { confirmedFeedbackSessionIds = [] } = await chrome.storage.local.get(
+    "confirmedFeedbackSessionIds",
+  );
+  if (confirmedFeedbackSessionIds.includes(sessionId)) return;
+  await chrome.storage.local.set({
+    confirmedFeedbackSessionIds: [...confirmedFeedbackSessionIds, sessionId],
+  });
+}
+
+// 서버에 feedbackConfirmedAt 기록 — 실패해도 로컬 확인 상태(위)는 이미 반영돼 있어
+// 사용자 경험에는 영향 없고, 연구 데이터 쪽만 유실될 수 있다(다른 서버 전송들과 동일한 정책).
+async function postFeedbackConfirmed(sessionId) {
+  const { serverUrl, anonymousId } = await chrome.storage.local.get([
+    "serverUrl",
+    "anonymousId",
+  ]);
+  if (!serverUrl || serverUrl.startsWith("YOUR_") || !anonymousId) return;
+  try {
+    const res = await fetch(
+      `${serverUrl.replace(/\/$/, "")}/api/sessions/${encodeURIComponent(sessionId)}/feedback-confirmed`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ anonymousId }),
+      },
+    );
+    if (!res.ok) console.warn("[popup] 피드백 확인 기록 실패:", res.status);
+  } catch (error) {
+    console.warn("[popup] 피드백 확인 기록 오류:", error.message);
+  }
+}
+
+// "피드백 확인하기" 버튼 클릭 처리 — 로컬 확인 상태 저장, 블러 해제 재렌더링,
+// 아이콘 점 제거, 서버 기록을 한 번에 묶는다.
+async function handleFeedbackConfirmClick(popup, sessionId) {
+  if (!sessionId) return;
+  await markFeedbackConfirmedLocally(sessionId);
+  if (VL.today?.sessionId === sessionId) {
+    VL.today = { ...VL.today, confirmed: true };
+  }
+  clearUnviewedIconDot();
+  popup.render();
+  postFeedbackConfirmed(sessionId);
+}
+
 function buildPopupEventPayload(m) {
   return {
     eventId: m.eventId,
@@ -457,6 +516,19 @@ async function flushPendingPopupEvents(serverUrl) {
   }
 }
 
+// 미열람 아이콘 표시 해제 — background.js의 setUnviewedIconDot()과 짝을 이룬다.
+// 배경 스크립트(ESM)와 팝업 스크립트(클래식) 경계 때문에 경로 상수를 공유할 수 없어 중복 정의한다.
+function clearUnviewedIconDot() {
+  chrome.action.setIcon({
+    path: {
+      16: "assets/icons/icon16.png",
+      32: "assets/icons/icon32.png",
+      48: "assets/icons/icon48.png",
+      128: "assets/icons/icon128.png",
+    },
+  });
+}
+
 // ── Main boot ─────────────────────────────────────────────────────────────────
 
 async function boot() {
@@ -513,11 +585,15 @@ async function boot() {
   realToday.collectingTimer = _computeTimerText(stored.lastWatchedAt);
   VL.today = realToday;
 
-  // EXP가 실제 리뷰를 보고 있으면(알림 클릭 여부와 무관) 미열람 배지를 지운다.
-  // sessions.feedbackViewedAt(알림 클릭 기준)과 별개로, 배지는 UX용이라 더 느슨한 기준을 쓴다.
   const isExp = !!VL.GROUPS[stored.group]?.feedback;
-  if (isExp && isRealReview(realToday.review)) {
-    chrome.action.setBadgeText({ text: "" });
+  const needsConfirm = isExp && isRealReview(realToday.review);
+  // "피드백 확인하기" 블러 해제 버튼을 눌러야만 확인된 것으로 친다(단순히 팝업을 연 것만으로는 아님).
+  realToday.confirmed = needsConfirm
+    ? await isFeedbackConfirmed(realToday.sessionId)
+    : true;
+  // 미열람 아이콘 표시도 "열기"가 아니라 "확인" 기준으로 지운다 — feedbackConfirmedAt과 의미를 맞춘다.
+  if (needsConfirm && realToday.confirmed) {
+    clearUnviewedIconDot();
   }
 
   if (installDate) {
@@ -572,6 +648,15 @@ async function boot() {
     },
   });
 
+  // 확인 안 된 리뷰가 있으면 열자마자 그 카드로 부드럽게 스크롤해 놓치지 않게 한다.
+  if (needsConfirm && !realToday.confirmed) {
+    requestAnimationFrame(() => {
+      document
+        .getElementById("vl-review-card")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }
+
   // ── 팝업 상호작용 로그 — 온보딩 완료 사용자만 ─────────────────────────
   let popupMetrics = null;
   if (stored.group && stored.anonymousId) {
@@ -593,17 +678,26 @@ async function boot() {
     };
     persistLivePopupEvent(popupMetrics);
 
-    // 탭 클릭 계측 — popEl은 re-render(innerHTML 교체) 후에도 유지되므로 위임 리스너로 한 번만 바인딩
+    // 탭 클릭 계측 + 피드백 확인 버튼 — popEl은 re-render(innerHTML 교체) 후에도 유지되므로
+    // 위임 리스너로 한 번만 바인딩
     popEl.addEventListener("click", (e) => {
       const tabBtn = e.target.closest && e.target.closest("[data-tab]");
-      if (!tabBtn) return;
-      if (tabBtn.dataset.tab === "today") {
-        popupMetrics.tabTodayClicks++;
-      } else if (tabBtn.dataset.tab === "feedback") {
-        popupMetrics.tabWeekClicks++;
-        popupMetrics.feedbackViewed = 1; // 주차별 피드백 탭 열람 = 개입 전달
+      if (tabBtn) {
+        if (tabBtn.dataset.tab === "today") {
+          popupMetrics.tabTodayClicks++;
+        } else if (tabBtn.dataset.tab === "feedback") {
+          popupMetrics.tabWeekClicks++;
+          popupMetrics.feedbackViewed = 1; // 주차별 피드백 탭 열람 = 개입 전달
+        }
+        persistLivePopupEvent(popupMetrics);
+        return;
       }
-      persistLivePopupEvent(popupMetrics);
+
+      const confirmBtn =
+        e.target.closest && e.target.closest("#vl-feedback-confirm-btn");
+      if (confirmBtn) {
+        handleFeedbackConfirmClick(popup, confirmBtn.dataset.sessionId);
+      }
     });
 
     // 팝업 종료 감지 — dwellMs 최종 반영(단일 set, teardown에 상대적으로 안전).
@@ -620,7 +714,7 @@ async function boot() {
   let localLastWatchedAt = stored.lastWatchedAt || null;
 
   // sessions가 바뀌면(분석 완료, 리뷰 저장 등) 즉시 today 데이터를 갱신하고 re-render
-  chrome.storage.onChanged.addListener((changes, area) => {
+  chrome.storage.onChanged.addListener(async (changes, area) => {
     if (area !== "local") return;
     if (changes.currentSession)
       localCurrentSession = changes.currentSession.newValue || null;
@@ -632,9 +726,14 @@ async function boot() {
     const freshToday = buildDataForDate(updatedSessions, new Date());
     freshToday.collectingCount = localCurrentSession?.videos?.length ?? 0;
     freshToday.collectingTimer = _computeTimerText(localLastWatchedAt);
+    const freshNeedsConfirm = isExp && isRealReview(freshToday.review);
+    // 새로 완료된 세션은 아직 로컬에 확인 기록이 없을 테니 다시 블러 처리된다(의도된 동작).
+    freshToday.confirmed = freshNeedsConfirm
+      ? await isFeedbackConfirmed(freshToday.sessionId)
+      : true;
     VL.today = freshToday;
-    if (isExp && isRealReview(freshToday.review)) {
-      chrome.action.setBadgeText({ text: "" });
+    if (freshNeedsConfirm && freshToday.confirmed) {
+      clearUnviewedIconDot();
     }
     if (installDate) {
       VL.weeks = buildWeeksData(updatedSessions, installDate);

--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -513,6 +513,13 @@ async function boot() {
   realToday.collectingTimer = _computeTimerText(stored.lastWatchedAt);
   VL.today = realToday;
 
+  // EXP가 실제 리뷰를 보고 있으면(알림 클릭 여부와 무관) 미열람 배지를 지운다.
+  // sessions.feedbackViewedAt(알림 클릭 기준)과 별개로, 배지는 UX용이라 더 느슨한 기준을 쓴다.
+  const isExp = !!VL.GROUPS[stored.group]?.feedback;
+  if (isExp && isRealReview(realToday.review)) {
+    chrome.action.setBadgeText({ text: "" });
+  }
+
   if (installDate) {
     VL.weeks = buildWeeksData(sessions, installDate);
     VL.baselineH = VL.weeks[0]?.entropy ?? 0;
@@ -573,7 +580,6 @@ async function boot() {
     // 큐 전송은 백그라운드 — 렌더/상호작용을 막지 않음. 실패분은 큐에 남아 다음 open에서 재시도.
     flushPendingPopupEvents(stored.serverUrl);
 
-    const isExp = !!VL.GROUPS[stored.group]?.feedback;
     popupMetrics = {
       anonymousId: stored.anonymousId,
       // 팝업 오픈당 1회 발급 — 재전송돼도 서버가 이 id로 중복을 무시(멱등)
@@ -627,6 +633,9 @@ async function boot() {
     freshToday.collectingCount = localCurrentSession?.videos?.length ?? 0;
     freshToday.collectingTimer = _computeTimerText(localLastWatchedAt);
     VL.today = freshToday;
+    if (isExp && isRealReview(freshToday.review)) {
+      chrome.action.setBadgeText({ text: "" });
+    }
     if (installDate) {
       VL.weeks = buildWeeksData(updatedSessions, installDate);
       VL.baselineH = VL.weeks[0]?.entropy ?? 0;

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -176,6 +176,8 @@ function screenToday() {
     .join("");
 
   const isToday = d.dateLabel === koreanDateLabel(new Date());
+  // 오늘의 실제 리뷰인데 아직 "확인하기"를 안 눌렀으면 블러 처리 — 지난 날짜는 대상 아님.
+  const reviewLocked = isToday && !d.confirmed && isRealReview(d.review);
   const isCollecting = d.collectingCount > 0 || !!d.collectingTimer;
   const collectingRow = isCollecting
     ? `
@@ -234,7 +236,7 @@ function screenToday() {
     `,
     })}
 
-    ${vlReview({ text: d.review, topic: d.reviewTopic, videos: d.videos })}
+    ${vlReview({ text: d.review, topic: d.reviewTopic, videos: d.videos, locked: reviewLocked, sessionId: d.sessionId })}
   </div>
   </div>`;
 }

--- a/extension/popup/viewlens-screens.js
+++ b/extension/popup/viewlens-screens.js
@@ -189,6 +189,14 @@ function screenToday() {
       </div>
     </div>`
     : "";
+  // 오늘 탭 안에 들어와 있어도 스크롤 안 하면 확인 카드가 안 보이니, 스크롤하지 않아도
+  // 보이는 상단 영역에 내려가 보라는 안내를 띄운다(수집 중 표시와 자리를 공유).
+  const scrollNudgeRow = reviewLocked
+    ? `<div style="display:flex;align-items:center;gap:6px">
+      <span style="display:inline-block;font-size:13px;line-height:1;color:var(--vl-accent);animation:vlBounceDown 1.2s ease-in-out infinite">↓</span>
+      <span style="font-size:11.5px;font-weight:600;color:var(--vl-accent)">아래로 스크롤해서 피드백 확인하세요!</span>
+    </div>`
+    : "";
   return `<div style="display:flex;flex-direction:column">
     <div style="padding:16px 16px 22px;display:flex;flex-direction:column;gap:14px">
     <div style="display:flex;align-items:center;justify-content:space-between">
@@ -199,7 +207,7 @@ function screenToday() {
       <button id="vl-date-next" style="width:32px;height:32px;border:1px solid var(--vl-line);border-radius:9px;background:var(--vl-card);color:${isToday ? "var(--vl-ink-3)" : "var(--vl-ink-2)"};cursor:${isToday ? "default" : "pointer"};font-size:15px;display:grid;place-items:center;opacity:${isToday ? 0.35 : 1}" ${isToday ? "disabled" : ""}>›</button>
     </div>
     <div style="display:flex;align-items:center;justify-content:space-between">
-      <div>${collectingRow}</div>
+      <div>${isCollecting ? collectingRow : scrollNudgeRow}</div>
       ${vlBadge({ text: `${d.videoCount}개 영상 · ${d.dist.length}개 분야`, tone: "neutral" })}
     </div>
 

--- a/extension/popup/viewlens-tokens.css
+++ b/extension/popup/viewlens-tokens.css
@@ -98,6 +98,28 @@ body {
     transform: none;
   }
 }
+@keyframes vlGlow {
+  0%,
+  100% {
+    box-shadow:
+      0 2px 10px color-mix(in oklab, var(--vl-ink) 14%, transparent),
+      0 0 0 0 color-mix(in oklab, var(--vl-accent) 35%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 2px 10px color-mix(in oklab, var(--vl-ink) 14%, transparent),
+      0 0 12px 3px color-mix(in oklab, var(--vl-accent) 28%, transparent);
+  }
+}
+@keyframes vlBounceDown {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(3px);
+  }
+}
 
 .vl-vid-details > summary {
   list-style: none;

--- a/extension/popup/viewlens-ui.js
+++ b/extension/popup/viewlens-ui.js
@@ -176,14 +176,10 @@ function vlReview({
   //  backdrop-filter 미지원 환경에서도 filter:blur만으로 판독 불가능하도록 이중 처리).
   const revealOverlay = locked
     ? `<div style="position:absolute;inset:0;border-radius:16px;display:flex;align-items:center;justify-content:center;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);background:color-mix(in oklab,var(--vl-accent-soft) 60%,transparent)">
-        <div style="position:relative;display:inline-flex">
-          <span style="position:absolute;inset:-6px;border-radius:999px;border:2px solid var(--vl-accent);opacity:0.5;pointer-events:none;animation:vlPulse 2.2s ease-out infinite"></span>
-          <span style="position:absolute;inset:-6px;border-radius:999px;border:2px solid var(--vl-accent);opacity:0.5;pointer-events:none;animation:vlPulse 2.2s ease-out infinite 0.7s"></span>
-          <button id="vl-feedback-confirm-btn" data-session-id="${sessionId ?? ""}" style="position:relative;display:flex;align-items:center;gap:7px;padding:11px 20px;border:1px solid color-mix(in oklab,var(--vl-accent) 35%,transparent);border-radius:999px;background:var(--vl-card);color:var(--vl-accent);font-size:13px;font-weight:700;cursor:pointer;box-shadow:0 2px 10px color-mix(in oklab,var(--vl-ink) 14%,transparent)">
-            ${markSVG({ size: 15, filled: false, accent: "var(--vl-accent)" })}
-            피드백 확인하기
-          </button>
-        </div>
+        <button id="vl-feedback-confirm-btn" data-session-id="${sessionId ?? ""}" style="display:flex;align-items:center;gap:7px;padding:11px 20px;border:1px solid color-mix(in oklab,var(--vl-accent) 35%,transparent);border-radius:999px;background:var(--vl-card);color:var(--vl-accent);font-size:13px;font-weight:700;cursor:pointer;animation:vlGlow 2.4s ease-in-out infinite">
+          ${markSVG({ size: 15, filled: false, accent: "var(--vl-accent)" })}
+          피드백 확인하기
+        </button>
       </div>`
     : "";
 

--- a/extension/popup/viewlens-ui.js
+++ b/extension/popup/viewlens-ui.js
@@ -128,6 +128,8 @@ function vlReview({
   topic = "",
   title = "오늘 돌아보기",
   videos = [],
+  locked = false,
+  sessionId = null,
 } = {}) {
   const cats = VL.CATS;
 
@@ -170,14 +172,29 @@ function vlReview({
   `
       : "";
 
-  return `<div style="background:var(--vl-accent-soft);border:1px solid color-mix(in oklab,var(--vl-accent) 22%,transparent);border-radius:16px;padding:15px">
-    <div style="display:flex;align-items:center;gap:7px;margin-bottom:9px">
-      ${markSVG({ size: 18, filled: false, accent: "var(--vl-accent)" })}
-      <span style="font-size:12.5px;font-weight:700;color:var(--vl-accent)">${title}</span>
+  // "피드백 확인하기"로 블러를 해제하기 전까지는 내용을 실제로 읽을 수 없게 만든다
+  // (glassmorphism: 콘텐츠 자체 blur + 반투명 backdrop-filter 오버레이를 함께 써서
+  //  backdrop-filter 미지원 환경에서도 filter:blur만으로 판독 불가능하도록 이중 처리).
+  const revealOverlay = locked
+    ? `<div style="position:absolute;inset:0;border-radius:16px;display:flex;align-items:center;justify-content:center;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);background:color-mix(in oklab,var(--vl-accent-soft) 60%,transparent)">
+        <button id="vl-feedback-confirm-btn" data-session-id="${sessionId ?? ""}" style="display:flex;align-items:center;gap:7px;padding:11px 20px;border:1px solid color-mix(in oklab,var(--vl-accent) 35%,transparent);border-radius:999px;background:var(--vl-card);color:var(--vl-accent);font-size:13px;font-weight:700;cursor:pointer;box-shadow:0 2px 10px color-mix(in oklab,var(--vl-ink) 14%,transparent)">
+          ${markSVG({ size: 15, filled: false, accent: "var(--vl-accent)" })}
+          피드백 확인하기
+        </button>
+      </div>`
+    : "";
+
+  return `<div id="vl-review-card" style="position:relative;overflow:hidden;background:var(--vl-accent-soft);border:1px solid color-mix(in oklab,var(--vl-accent) 22%,transparent);border-radius:16px;padding:15px">
+    <div style="${locked ? "filter:blur(6px);user-select:none;pointer-events:none" : ""}">
+      <div style="display:flex;align-items:center;gap:7px;margin-bottom:9px">
+        ${markSVG({ size: 18, filled: false, accent: "var(--vl-accent)" })}
+        <span style="font-size:12.5px;font-weight:700;color:var(--vl-accent)">${title}</span>
+      </div>
+      ${topicBlock}
+      <p style="margin:0;font-size:13.5px;line-height:1.65;color:var(--vl-ink);text-wrap:pretty">${text}</p>
+      ${videoList}
     </div>
-    ${topicBlock}
-    <p style="margin:0;font-size:13.5px;line-height:1.65;color:var(--vl-ink);text-wrap:pretty">${text}</p>
-    ${videoList}
+    ${revealOverlay}
   </div>`;
 }
 

--- a/extension/popup/viewlens-ui.js
+++ b/extension/popup/viewlens-ui.js
@@ -173,14 +173,17 @@ function vlReview({
       : "";
 
   // "피드백 확인하기"로 블러를 해제하기 전까지는 내용을 실제로 읽을 수 없게 만든다
-  // (glassmorphism: 콘텐츠 자체 blur + 반투명 backdrop-filter 오버레이를 함께 써서
   //  backdrop-filter 미지원 환경에서도 filter:blur만으로 판독 불가능하도록 이중 처리).
   const revealOverlay = locked
     ? `<div style="position:absolute;inset:0;border-radius:16px;display:flex;align-items:center;justify-content:center;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);background:color-mix(in oklab,var(--vl-accent-soft) 60%,transparent)">
-        <button id="vl-feedback-confirm-btn" data-session-id="${sessionId ?? ""}" style="display:flex;align-items:center;gap:7px;padding:11px 20px;border:1px solid color-mix(in oklab,var(--vl-accent) 35%,transparent);border-radius:999px;background:var(--vl-card);color:var(--vl-accent);font-size:13px;font-weight:700;cursor:pointer;box-shadow:0 2px 10px color-mix(in oklab,var(--vl-ink) 14%,transparent)">
-          ${markSVG({ size: 15, filled: false, accent: "var(--vl-accent)" })}
-          피드백 확인하기
-        </button>
+        <div style="position:relative;display:inline-flex">
+          <span style="position:absolute;inset:-6px;border-radius:999px;border:2px solid var(--vl-accent);opacity:0.5;pointer-events:none;animation:vlPulse 2.2s ease-out infinite"></span>
+          <span style="position:absolute;inset:-6px;border-radius:999px;border:2px solid var(--vl-accent);opacity:0.5;pointer-events:none;animation:vlPulse 2.2s ease-out infinite 0.7s"></span>
+          <button id="vl-feedback-confirm-btn" data-session-id="${sessionId ?? ""}" style="position:relative;display:flex;align-items:center;gap:7px;padding:11px 20px;border:1px solid color-mix(in oklab,var(--vl-accent) 35%,transparent);border-radius:999px;background:var(--vl-card);color:var(--vl-accent);font-size:13px;font-weight:700;cursor:pointer;box-shadow:0 2px 10px color-mix(in oklab,var(--vl-ink) 14%,transparent)">
+            ${markSVG({ size: 15, filled: false, accent: "var(--vl-accent)" })}
+            피드백 확인하기
+          </button>
+        </div>
       </div>`
     : "";
 

--- a/server/db.js
+++ b/server/db.js
@@ -44,9 +44,11 @@ function initializeDB() {
       failureReason        TEXT,     -- timeout | http_error | empty_response | parse_error | network_error (성공 시 NULL)
       httpStatus           INTEGER,  -- failureReason='http_error'일 때만 (429 쿼터 vs 5xx 장애 구분)
       timedOut             INTEGER,  -- 타임아웃으로 실패한 경우 1
-      -- 피드백 알림·열람 시점 (Story 10-6) — 측정 퍼널: 생성 → 알림(feedbackNotifiedAt) → 열람(feedbackViewedAt)
+      -- 피드백 알림·열람·확인 시점 (Story 10-6) — 측정 퍼널: 생성 → 알림(feedbackNotifiedAt)
+      -- → 클릭(feedbackViewedAt, 알림 클릭 기준) → 확인(feedbackConfirmedAt, 블러 해제 버튼 클릭 기준 — 가장 엄격한 신호)
       feedbackNotifiedAt   TEXT,     -- 분석 완료 알림을 표시한 시각 (미대상/미전달이면 NULL)
       feedbackViewedAt     TEXT,     -- 알림 클릭 등으로 피드백을 실제로 연 시각 (NULL이면 아직 미열람)
+      feedbackConfirmedAt  TEXT,     -- "피드백 확인하기" 버튼으로 블러를 해제한 시각 (NULL이면 아직 미확인)
       createdAt            TEXT    DEFAULT (datetime('now'))
     );
 
@@ -97,6 +99,7 @@ function initializeDB() {
   // 서버 기동 시 "no column named feedbackNotifiedAt" 에러 재현 확인) addColumn 패턴을 도입한다.
   addColumn("sessions", "feedbackNotifiedAt", "TEXT");
   addColumn("sessions", "feedbackViewedAt", "TEXT");
+  addColumn("sessions", "feedbackConfirmedAt", "TEXT");
 }
 
 // 이미 컬럼이 있으면(신규 DB) 조용히 넘어가고, 없으면(기존 DB) 추가한다.

--- a/server/db.js
+++ b/server/db.js
@@ -89,12 +89,23 @@ function initializeDB() {
   `);
 
   // 스키마의 단일 진실 원천(single source of truth)은 위 CREATE TABLE 하나다.
-  // 런칭 전이라 세상에 마이그레이션할 '옛 스키마 DB'가 없으므로, ALTER 기반
-  // 점진 마이그레이션은 두지 않는다(넣어봤자 새 DB에선 전부 no-op인 죽은 코드).
-  // 운영 중 스키마를 바꿔야 하는 첫 순간이 오면, 그때 duplicate column name만
-  // 무시하고 나머지는 재던지는 addColumn 패턴을 도입한다.
   // (eventId의 UNIQUE도 위 CREATE TABLE에 인라인으로 선언 — 별도 인덱스로 분리하던
   //  이유였던 'ALTER는 UNIQUE 컬럼을 못 만든다' 제약이 ALTER를 걷어내며 사라졌다.)
+  //
+  // 다만 이미 만들어진 DB 파일(로컬 개발용·이미 배포된 서버)에는 CREATE TABLE IF NOT EXISTS가
+  // no-op이라 새 컬럼이 반영되지 않는다 — Story 10-6에서 처음 이 문제가 실제로 발생해(로컬
+  // 서버 기동 시 "no column named feedbackNotifiedAt" 에러 재현 확인) addColumn 패턴을 도입한다.
+  addColumn("sessions", "feedbackNotifiedAt", "TEXT");
+  addColumn("sessions", "feedbackViewedAt", "TEXT");
+}
+
+// 이미 컬럼이 있으면(신규 DB) 조용히 넘어가고, 없으면(기존 DB) 추가한다.
+function addColumn(table, name, type) {
+  try {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${name} ${type}`);
+  } catch (err) {
+    if (!/duplicate column name/i.test(err.message)) throw err;
+  }
 }
 
 module.exports = { db, initializeDB };

--- a/server/db.js
+++ b/server/db.js
@@ -44,6 +44,9 @@ function initializeDB() {
       failureReason        TEXT,     -- timeout | http_error | empty_response | parse_error | network_error (성공 시 NULL)
       httpStatus           INTEGER,  -- failureReason='http_error'일 때만 (429 쿼터 vs 5xx 장애 구분)
       timedOut             INTEGER,  -- 타임아웃으로 실패한 경우 1
+      -- 피드백 알림·열람 시점 (Story 10-6) — 측정 퍼널: 생성 → 알림(feedbackNotifiedAt) → 열람(feedbackViewedAt)
+      feedbackNotifiedAt   TEXT,     -- 분석 완료 알림을 표시한 시각 (미대상/미전달이면 NULL)
+      feedbackViewedAt     TEXT,     -- 알림 클릭 등으로 피드백을 실제로 연 시각 (NULL이면 아직 미열람)
       createdAt            TEXT    DEFAULT (datetime('now'))
     );
 

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -175,48 +175,54 @@ router.post("/", (req, res, next) => {
   return success(res);
 });
 
-// 피드백 열람 시각 갱신 () — 알림 클릭 등으로 실제 열람이 확인된 시점에
-// background.js가 아닌 popup.js가 나중에(세션 생성 POST와 별도 시점에) 호출한다.
-// anonymousId로 소유권을 확인해 다른 참여자의 세션을 갱신하지 못하도록 막는다.
-const updateFeedbackViewedAt = db.prepare(`
-  UPDATE sessions SET feedbackViewedAt = @feedbackViewedAt
-  WHERE sessionId = @sessionId AND anonymousId = @anonymousId
-`);
+// 피드백 열람/확인 시각 갱신 () — 세션 생성 POST와 별도 시점에(알림 클릭, 확인 버튼 클릭 등)
+// 호출된다. anonymousId로 소유권을 확인해 다른 참여자의 세션을 갱신하지 못하도록 막는다.
+// column은 요청 값이 아니라 아래 두 router.patch 호출부에서만 하드코딩으로 주어지므로
+// SQL 인젝션 경로가 없다(server/db.js의 addColumn(table, name, type) 패턴과 동일한 근거).
+function makeFeedbackTimestampHandler(column) {
+  const update = db.prepare(
+    `UPDATE sessions SET ${column} = @value WHERE sessionId = @sessionId AND anonymousId = @anonymousId`,
+  );
+  return (req, res, next) => {
+    const { sessionId } = req.params;
+    const { anonymousId } = req.body;
 
-router.patch("/:sessionId/feedback-viewed", (req, res, next) => {
-  const { sessionId } = req.params;
-  const { anonymousId } = req.body;
-
-  if (typeof anonymousId !== "string" || !anonymousId.trim()) {
-    return fail(
-      res,
-      400,
-      ERROR_CODES.MISSING_REQUIRED_FIELD,
-      "anonymousId 필드가 올바르지 않습니다.",
-      "anonymousId",
-    );
-  }
-
-  try {
-    const result = updateFeedbackViewedAt.run({
-      sessionId,
-      anonymousId,
-      feedbackViewedAt: new Date().toISOString(),
-    });
-    if (result.changes === 0) {
+    if (typeof anonymousId !== "string" || !anonymousId.trim()) {
       return fail(
         res,
-        404,
-        ERROR_CODES.NOT_FOUND,
-        "세션을 찾을 수 없습니다.",
-        sessionId,
+        400,
+        ERROR_CODES.MISSING_REQUIRED_FIELD,
+        "anonymousId 필드가 올바르지 않습니다.",
+        "anonymousId",
       );
     }
-  } catch (err) {
-    return next(err);
-  }
 
-  return success(res);
-});
+    try {
+      const result = update.run({
+        sessionId,
+        anonymousId,
+        value: new Date().toISOString(),
+      });
+      if (result.changes === 0) {
+        return fail(
+          res,
+          404,
+          ERROR_CODES.NOT_FOUND,
+          "세션을 찾을 수 없습니다.",
+          sessionId,
+        );
+      }
+    } catch (err) {
+      return next(err);
+    }
+
+    return success(res);
+  };
+}
+
+// 알림 클릭 기준 — background.js가 호출 (느슨한 신호)
+router.patch("/:sessionId/feedback-viewed", makeFeedbackTimestampHandler("feedbackViewedAt"));
+// "피드백 확인하기" 블러 해제 버튼 클릭 기준 — popup.js가 호출 (가장 엄격한 신호)
+router.patch("/:sessionId/feedback-confirmed", makeFeedbackTimestampHandler("feedbackConfirmedAt"));
 
 module.exports = router;

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -5,8 +5,8 @@ const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
 const router = express.Router();
 
 const insertSession = db.prepare(`
-  INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs, llmStatus, failureReason, httpStatus, timedOut)
-  VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy, @totalMs, @youtubeMs, @geminiMs, @llmStatus, @failureReason, @httpStatus, @timedOut)
+  INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, videoCount, categoryDistribution, entropy, totalMs, youtubeMs, geminiMs, llmStatus, failureReason, httpStatus, timedOut, feedbackNotifiedAt)
+  VALUES (@anonymousId, @sessionId, @startTime, @endTime, @videoCount, @categoryDistribution, @entropy, @totalMs, @youtubeMs, @geminiMs, @llmStatus, @failureReason, @httpStatus, @timedOut, @feedbackNotifiedAt)
 `);
 
 //  지연시간 필드 — 확장이 측정해 전송. 선택 항목이며, 있으면 음수 아닌 정수여야 한다.
@@ -95,6 +95,16 @@ function validateSession(body) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "timedOut" };
   }
 
+  // 피드백 알림 시각 () — 분석 완료 알림을 표시한 경우에만 확장이 함께 전송
+  const { feedbackNotifiedAt } = body;
+  if (
+    feedbackNotifiedAt !== undefined &&
+    feedbackNotifiedAt !== null &&
+    isNaN(Date.parse(feedbackNotifiedAt))
+  ) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "feedbackNotifiedAt" };
+  }
+
   return null;
 }
 
@@ -125,6 +135,7 @@ router.post("/", (req, res, next) => {
     failureReason,
     httpStatus,
     timedOut,
+    feedbackNotifiedAt,
   } = req.body;
 
   try {
@@ -146,6 +157,7 @@ router.post("/", (req, res, next) => {
       failureReason: failureReason ?? null,
       httpStatus: httpStatus ?? null,
       timedOut: timedOut ?? null,
+      feedbackNotifiedAt: feedbackNotifiedAt ?? null,
     });
   } catch (err) {
     if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {
@@ -157,6 +169,50 @@ router.post("/", (req, res, next) => {
         sessionId,
       );
     }
+    return next(err);
+  }
+
+  return success(res);
+});
+
+// 피드백 열람 시각 갱신 () — 알림 클릭 등으로 실제 열람이 확인된 시점에
+// background.js가 아닌 popup.js가 나중에(세션 생성 POST와 별도 시점에) 호출한다.
+// anonymousId로 소유권을 확인해 다른 참여자의 세션을 갱신하지 못하도록 막는다.
+const updateFeedbackViewedAt = db.prepare(`
+  UPDATE sessions SET feedbackViewedAt = @feedbackViewedAt
+  WHERE sessionId = @sessionId AND anonymousId = @anonymousId
+`);
+
+router.patch("/:sessionId/feedback-viewed", (req, res, next) => {
+  const { sessionId } = req.params;
+  const { anonymousId } = req.body;
+
+  if (typeof anonymousId !== "string" || !anonymousId.trim()) {
+    return fail(
+      res,
+      400,
+      ERROR_CODES.MISSING_REQUIRED_FIELD,
+      "anonymousId 필드가 올바르지 않습니다.",
+      "anonymousId",
+    );
+  }
+
+  try {
+    const result = updateFeedbackViewedAt.run({
+      sessionId,
+      anonymousId,
+      feedbackViewedAt: new Date().toISOString(),
+    });
+    if (result.changes === 0) {
+      return fail(
+        res,
+        404,
+        ERROR_CODES.NOT_FOUND,
+        "세션을 찾을 수 없습니다.",
+        sessionId,
+      );
+    }
+  } catch (err) {
     return next(err);
   }
 


### PR DESCRIPTION
## 개요

세션 분석 완료 시 Chrome 알림·아이콘 표시로 알리고, 열람을 두 단계로 측정한다: 알림 클릭(`feedbackViewedAt`, 느슨한 신호)과 "피드백 확인하기" 버튼 클릭(`feedbackConfirmedAt`, 블러를 직접 해제해야만 기록되는 가장 엄격한 신호)  
10-5의 `feedbackViewed`(팝업 표시 기준)보다 정밀한 열람 신호를 추가해 측정 퍼널(생성 → 알림 → 클릭 → 확인)을 완성한다.  

## 변경 사항

### 알림 · 아이콘 표시
- `extension/manifest.json`: `notifications` 권한 추가
- `extension/background.js`:
  - `isFeedbackNotificationEligible(group, installDate)` 게이트 함수 도입 (현재는 EXP 여부만 확인하고, 10-8 완료 시 이 함수에만 조건을 추가하면 되도록 분리)
  - 분석 완료 시 `chrome.notifications.create`(id=sessionId)로 알림 표시 + `feedbackNotifiedAt` 서버 전송
  - 미열람 표시는 배지 텍스트가 아니라 **아이콘 자체에 점을 그려 넣는 방식**(`OffscreenCanvas`로 기존 아이콘 위에 빨간 점 합성)으로 구현 (배지 글리프가 OS·Chrome 버전마다 다르게 렌더링되는 문제를 회피)  
  - 알림/버튼 클릭 시 피드백 탭 오픈 + `PATCH .../feedback-viewed` 호출 + 아이콘 원복
  - `chrome.action.setIcon`의 상대 경로가 "확장 루트"가 아니라 "호출한 스크립트의 위치" 기준으로 풀리는 문제를 발견해 `chrome.runtime.getURL`로 절대 경로를 명시하도록 수정(팝업 쪽에서 호출 시 `Could not load action icon` 에러로 실제 재현됨)

### 서버 스키마 · API
- `server/db.js`: `sessions`에 `feedbackNotifiedAt`/`feedbackViewedAt`/`feedbackConfirmedAt` 컬럼 추가 + 기존 DB에도 반영되도록 `addColumn`(멱등 `ALTER TABLE`) 패턴 도입
- `server/routes/sessions.js`:
  - `POST /`에 `feedbackNotifiedAt` 선택 필드 추가(날짜 형식 검증, 하위호환)
  - `PATCH /:sessionId/feedback-viewed`, `PATCH /:sessionId/feedback-confirmed` 신규 (공통 핸들러로 구현, `anonymousId`로 소유권 확인 후 해당 시각을 서버 시각으로 기록, 대상 없으면 404)

### "피드백 확인하기" 블러/확인 UI  
- `extension/popup/viewlens-ui.js`: 오늘 탭의 리뷰 카드를 블러로 가리고, 그 위에 "피드백 확인하기" 버튼(부드러운 글로우 애니메이션)을 띄운다. 버튼을 눌러야만 블러가 해제된다.
- `extension/popup/viewlens-screens.js`: 오늘 탭 상단(스크롤 없이 보이는 영역)에 "아래로 스크롤해서 피드백 확인하세요!" 안내 + 바운스 화살표 추가
- `extension/popup/viewlens-app.js`: 다른 탭(주차별 피드백 등)을 보고 있을 때 오늘 탭에 미확인 피드백이 있으면 탭에 깜빡이는 점 표시
- `extension/popup/viewlens-popup.js`:
  - `buildDataForDate`에 `sessionId` 노출, 로컬 확인 상태 추적 헬퍼(`isFeedbackConfirmed`/`markFeedbackConfirmedLocally`) 추가 (한 번 확인한 세션은 다시 열어도 안 가려짐)
  - 확인 버튼 클릭 시 로컬 기록 + `feedbackConfirmedAt` 서버 전송 + 아이콘 원복(아이콘 원복 기준을 "열기"가 아니라 "확인"으로 변경)
  - 미확인 리뷰가 있으면 팝업을 열자마자 그 카드로 자동 스크롤
  - **버그 수정**: 확인 상태를 `VL.today`(날짜 이동 시 통째로 재생성되는 객체)에 뒀더니, 어제 기록을 봤다가 오늘로 돌아오면 미확인 상태가 "확인됨"으로 오염되는 문제 → 날짜 이동에 영향받지 않는 별도 키(`VL._todayConfirmed`)로 분리해 수정
  - **버그 수정**: 확인 버튼 클릭 후 재렌더(`innerHTML` 교체)로 스크롤이 맨 위로 리셋되던 문제 수정
- `extension/popup/viewlens-tokens.css`: `vlGlow`(버튼 글로우), `vlBounceDown`(스크롤 안내 화살표) 키프레임 추가

### 기타
- `extension/content.js`: 확장 리로드/업데이트로 이미 열려있던 유튜브 탭의 컨텍스트가 무효화되면 `chrome.*` 호출이 전부 예외를 던지는데, 이걸 잡는 코드가 없어 새 영상 기록이 조용히 실패했다. `chrome.runtime.id` 사전 체크 + `try/catch`로 감싸 실패 시 콘솔에 경고를 남기도록 수정  


## 관련 이슈

- closes #132

## 테스트 확인

- [x] 서버 재기동 회귀 테스트: **기존(사전 존재) 로컬 개발 DB**로 서버를 실제로 기동해 재현 확인 (`addColumn` 패턴 적용 전에는 `SqliteError: table sessions has no column named feedbackNotifiedAt`로 기동 자체가 실패했고, 적용 후 정상 기동됨을 확인)
- [x] `POST /api/sessions`에 `feedbackNotifiedAt` 포함 전송 → 저장값 직접 조회로 일치 확인
- [x] `PATCH /api/sessions/:sessionId/feedback-viewed`: 정상 케이스(200, `feedbackViewedAt` 서버 시각 기록), `anonymousId` 누락(400), 소유권 불일치(404), 존재하지 않는 세션(404) 4가지 모두 curl로 직접 호출해 확인
- [x] 기존 `DUPLICATE_SESSION`(409) 등 회귀 없음 확인
- [x] 변경된 서버·확장 JS 파일 전체 구문 검사(`node --check`) 통과
- [x] 콘솔 에러 없음 / 실제 브라우저 동작 확인  
- [x] `chrome.storage.local.get`로 실제 저장값을 직접 조회해 "피드백까지 ~분 ~초"가 안 뜬 원인이 UI 버그가 아니라 확장 리로드로 인한 content script 컨텍스트 무효화(영상 기록 자체가 안 됨)임을 재현·확인  


## 스크린샷 (UI 변경 시)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/bb5d7fb4-c553-446d-90b2-5849a39da443" />

<img  width="500" alt="image" src="https://github.com/user-attachments/assets/ad872c16-d61d-40d0-98e6-080af2edd63a" />

<img  width="500" alt="image" src="https://github.com/user-attachments/assets/80667351-2d24-41dd-98b5-d15e9825ed81" />

<img  width="500" alt="image" src="https://github.com/user-attachments/assets/80359e7a-ff39-42b1-bf41-5369b736dce6" />

## 참고 사항

- 10-8이 완료되면 `isFeedbackNotificationEligible`의 `installDate` 조건만 채우면 되도록 설계해 둠(알림·배지·서버 코드는 변경 불필요)  
- 배지는 미열람 개수 대신 단순 dot(있음/없음)만 표시 (정확한 개수는 연구 지표가 아니므로 상태 관리를 단순화하는 쪽을 선택)
- `feedbackViewedAt`은 알림 클릭 경유로만 기록되며, 10-5의 `popup_events.feedbackViewed`(팝업 표시 기준)와는 의도적으로 별개 신호  
- content.js 수정은 Story 10-6 범위 밖의 기존 견고성 문제지만, 이번 테스트 중 직접 재현되어 같은 PR에 포함    

