### PR TITLE
fix: 기간 리뷰 배치가 쌓이지 않던 문제 수정 (env 키 배포 누락 + Gemini 모델 만료)

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -31,4 +31,5 @@ jobs:
             echo "PORT=3000" > server/.env
             echo "NODE_ENV=production" >> server/.env
             echo "DB_ENCRYPTION_KEY=${{ secrets.DB_ENCRYPTION_KEY }}" >> server/.env
+            echo "PERIOD_REVIEW_GEMINI_API_KEY=${{ secrets.PERIOD_REVIEW_GEMINI_API_KEY }}" >> server/.env
             pm2 restart youtube-bias-server

--- a/server/pipeline/period-review-llm.js
+++ b/server/pipeline/period-review-llm.js
@@ -1,7 +1,7 @@
 // 기간 단위 리뷰 생성 파이프라인
 
 const GEMINI_API_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent";
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent";
 const TIMEOUT_MS = 10000;
 
 // 단일 카테고리 편중 경고 임계 비율

--- a/server/pipeline/period-review-llm.js
+++ b/server/pipeline/period-review-llm.js
@@ -1,7 +1,7 @@
 // 기간 단위 리뷰 생성 파이프라인
 
 const GEMINI_API_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent";
 const TIMEOUT_MS = 10000;
 
 // 단일 카테고리 편중 경고 임계 비율


### PR DESCRIPTION
- deploy-server.yml이 PERIOD_REVIEW_GEMINI_API_KEY를 .env에 반영하지 않아 기간 리뷰 cron이 매번 조용히 죽고 있던 문제 수정
- gemini-2.5-flash가 신규 키에서 404 나서 gemini-3.6-flash로 교체  

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ddb2e039-1f2d-4e14-8f70-0caa6d114320" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 기간 검토 기능의 Gemini 모델을 최신 버전으로 업데이트했습니다.
  * 배포 환경에서 기간 검토 기능에 필요한 API 인증 설정이 자동으로 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->