### PR TITLE
bug: 팝업 마지막 상호작용 로그가 서버에 누락되지 않도록 sendBeacon 백업 전송 추가

### DIFF
--- a/extension/popup/viewlens-popup.js
+++ b/extension/popup/viewlens-popup.js
@@ -651,11 +651,14 @@ window.validateStudyEndCode = validateStudyEndCode;
 
 // ── 팝업 상호작용 마이크로 로그 ────────────────────────────────────────
 // 수집: openedAt, dwellMs, tabTodayClicks, tabWeekClicks, feedbackViewed.
-// 전송: 팝업 close 시점의 storage 쓰기는 teardown에 잘릴 수 있어 신뢰하지 않는다.
-//   대신 세션 중 livePopupEvent 슬롯을 상호작용·1초 간격으로 계속 갱신해 최신 스냅샷을 남기고,
-//   다음 팝업 open(boot) 때 이전 스냅샷을 확정 큐로 승격해 서버로 전송(실패분은 큐에 남겨 재시도).
-//   팝업은 싱글턴이라 boot 시점의 잔여 livePopupEvent는 곧 "닫힌 이전 팝업"의 확정 이벤트다.
-//   sendBeacon을 쓰지 않으므로 중복 전송이 없다(전송은 항상 다음 open의 flush 한 경로).
+// 전송 경로 1(기본)
+// 팝업 close 시점의 fetch는 teardown에 끊길 수 있어 신뢰하지 않는다.
+// 대신 세션 중 livePopupEvent 슬롯을 상호작용·1초 간격으로 계속 갱신해 최신 스냅샷을 남기고,
+// 다음 팝업 open(boot) 때 이전 스냅샷을 확정 큐로 승격해 서버로 전송한다.
+// 전송 경로 2(백업)
+// close 시점 sendBeacon: 참여자가 다시 팝업을 열지 않으면 경로 1이 영영 트리거되지 않아 그 팝업 몫이 서버에 도달하지 못한다.
+// sendBeacon은 문서가 파괴되는 도중에도 브라우저가 전송을 이어가도록 보장하는 API라 pagehide/visibilitychange 핸들러에서 fetch 대신 시도해볼 수 있다.
+// eventId 멱등키 + 서버의 INSERT OR IGNORE 덕분에 경로 1과 경로 2가 같은 이벤트를 둘 다 성공시켜도 서버에는 한 행만 남는다.
 
 // "피드백 확인하기" 블러 해제 여부 () — 한 번 확인한 세션은 로컬에 기억해 다음에
 // 다시 팝업을 열어도 또 가리지 않는다. feedbackViewedAt(알림 클릭)보다 엄격한 별도 신호.
@@ -755,6 +758,19 @@ function buildPopupEventPayload(m) {
 // teardown 대비 — 현재 세션 스냅샷을 live 슬롯에 기록(fire-and-forget)
 function persistLivePopupEvent(m) {
   chrome.storage.local.set({ livePopupEvent: buildPopupEventPayload(m) });
+}
+
+// 전송 경로 2(close 시점 백업)
+function sendPopupEventBeacon(serverUrl, m) {
+  if (!serverUrl || serverUrl.startsWith("YOUR_")) return;
+  if (typeof navigator.sendBeacon !== "function") return;
+  const blob = new Blob([JSON.stringify(buildPopupEventPayload(m))], {
+    type: "application/json",
+  });
+  navigator.sendBeacon(
+    `${serverUrl.replace(/\/$/, "")}/api/popup-events`,
+    blob,
+  );
 }
 
 async function postPopupEvent(serverUrl, event) {
@@ -1096,9 +1112,13 @@ async function boot() {
       }
     });
 
-    // 팝업 종료 감지 — dwellMs 최종 반영(단일 set, teardown에 상대적으로 안전).
-    // 최종 쓰기가 잘려도 세션 중 스냅샷이 남아 다음 boot에서 승격된다.
-    const finalizePopupMetrics = () => persistLivePopupEvent(popupMetrics);
+    // 팝업 종료 감지 — dwellMs 최종 반영(단일 set, teardown에 상대적으로 안전) +
+    // sendBeacon 백업 전송(전송 경로 2) 동시 시도. 최종 쓰기가 잘려도 세션 중 스냅샷이
+    // 남아 다음 boot에서 승격되므로, sendBeacon이 실패해도 데이터가 사라지지 않는다.
+    const finalizePopupMetrics = () => {
+      persistLivePopupEvent(popupMetrics);
+      sendPopupEventBeacon(stored.serverUrl, popupMetrics);
+    };
     window.addEventListener("pagehide", finalizePopupMetrics);
     document.addEventListener("visibilitychange", () => {
       if (document.hidden) finalizePopupMetrics();


### PR DESCRIPTION
## 개요
### 크롬 확장 팝업의 구조적 한계
크롬 확장의 액션 팝업(chrome.action 기본 팝업)은 일반 탭이 아니라 독립된 임시 브라우징 컨텍스트다. 사용자가 포커스를 잃게 만드는 순간(바깥 클릭 등) 문서가 즉시 파괴되며, chrome.action.onClosed 같은 전용 종료 콜백이 존재하지 않는다. pagehide/visibilitychange로 "곧 닫힌다"는 신호는 받을 수 있지만, 그 핸들러 안에서 시작한 fetch()가 끝까지 실행된다는 보장은 없다. 따라서 생명주기에 묶여 중단될 수도 있다.

### 발견 계기
소규모의 1차 테스트 후 DB 점검 과정에서 popup_events 테이블이 연구 종료 시점까지 누락 없이 누적되는지를 코드로 추적하다가, 현재 전송 구조에 구조적 개선할 포인트가 있음을 확인했다.

### 기존에 개발했던 대안 ("다음 오픈 때 확정" 지연 큐)
팝업 close 시점 fetch를 신뢰할 수 없다는 문제를 기존 코드는 "닫힌 팝업의 마지막 스냅샷을, 그 다음 팝업이 열릴 때 전송한다"는 방식으로 우회하고 있었다.

```mermaid
sequenceDiagram
    participant P1 as 팝업 N-1 (사용 중)
    participant LS as chrome.storage.local
    participant P2 as 팝업 N (다음 오픈)
    participant S as 서버

    P1->>LS: livePopupEvent 기록 (상호작용·1초마다 갱신)
    Note over P1: pagehide/visibilitychange 발생<br/>→ 문서 파괴, 전송 시도 없음
    Note over LS: livePopupEvent에 최신 스냅샷만 남음

    P2->>LS: drainPreviousPopupEvents()
    LS-->>P2: 이전 livePopupEvent 읽음 → pendingPopupEvents 큐로 승격
    P2->>S: flushPendingPopupEvents() → POST /api/popup-events
    S-->>P2: 200 OK (eventId 기준 dedup)
```

### 문제점("다음 오픈"이 영영 없으면 영원히 유실)
이 구조는 close 시점 fetch 문제를 잘 우회했지만, 확정 트리거가 다음 팝업 오픈뿐이라는 것이 문제였다. 참여자가 연구 기간 중 마지막으로 연 팝업은 그 다음 오픈이 존재하지 않으므로 서버에 도달하지 못한다. 대조군이 경우 연구 기간 종료 후에도 팝업을 열 수도 있지만 실험군의 경우에는 그러지 못할 수도 있다. 그리고 연구 목적 상 사용자의 시청기록 데이터가 유실되는 경우는 최대한 방지해야 했다.  

```mermaid
sequenceDiagram
    participant P as 마지막 팝업(연구 기간 중)
    participant LS as chrome.storage.local
    participant S as 서버

    P->>LS: livePopupEvent 기록
    Note over P: 문서 파괴 (전송 없음)
    Note over LS: livePopupEvent에 남아있음
    Note over P,S: 참여자가 다시 팝업을 열지 않음<br/>→ drain 트리거 자체가 없음<br/>→ 서버 전송 영원히 발생 안 함
```

## 변경 사항

### 해결 방안: close 시점 sendBeacon 백업 전송 추가
기존 지연 큐(경로 1)는 그대로 두고, pagehide/visibilitychange(hidden) 핸들러에서 navigator.sendBeacon으로 같은 스냅샷을 즉시 한 번 더 전송 시도한다(경로 2). sendBeacon은 문서가 파괴되는 도중에도 브라우저가 전송을 이어가도록 스펙상 보장된 API라, fetch가 가진 근본적 한계를 정확히 겨냥한 선택이다.
> navigator.sendBeacon(): 웹 브라우저가 탭을 닫거나 다른 페이지로 이동할 때도 서버로 데이터를 안정적이고 비동기적으로 전송할 수 있게 해주는 MDN Web Docs의 API 메서드

```mermaid
sequenceDiagram
    participant P as 팝업(닫히는 중)
    participant LS as chrome.storage.local
    participant S as 서버

    par 경로 1 (기존, 백업으로 유지)
        P->>LS: persistLivePopupEvent()(로컬 스냅샷 저장)
    and 경로 2 (신규 추가)
        P->>S: navigator.sendBeacon(POST /api/popup-events)
    end
    S-->>S: eventId 기준 INSERT OR IGNORE (중복 자동 제거)
    Note over P,S: 경로 2 성공 시 → 이 팝업이 마지막 오픈이어도 즉시 서버 도달<br/>경로 2 실패 시 → 경로 1이 다음 오픈 때 그대로 재시도(폴백 유지)
```

#### 이 방법이 최선이라고 판단한 이유 

- 순수 추가(additive): 기존 큐 순서·재시도 로직을 전혀 변경하지 않아 회귀 위험이 거의 없다.
- 중복 안전: 이미 존재하는 eventId 멱등 키 + 서버의 INSERT OR IGNORE가 경로 1·2의 경합을 그대로 해결해줘서, 새 잠금/가드 로직이 필요 없었다.
- 문제에 맞는 도구: fetch 재시도나 타임아웃 조정이 아니라, "문서 파괴 중에도 전송을 보장"하도록 설계된 표준 API를 그 정확한 용도로 사용했다.
- 서버 무변경: 클라이언트만 수정해 문제를 해결, 서버 스키마·엔드포인트 변경 없음.

## 테스트 확인

- [x]  eslint 통과
- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인
- [x]  콘솔 에러 없음
- [x] 팝업을 열고 닫은 뒤 Network 탭에서 beacon 타입 요청이 /api/popup-events로 발생하는지, 서버 DB에 해당 eventId 행이 생성되는지 확인

## 스크린샷 (UI 변경 시)

<!-- 팝업 UI 변경이 있으면 before/after 첨부 -->

## 참고 사항

sendBeacon은 브라우저가 전송을 "시도"했다는 것만 알려줄 뿐, 실제로 서버에 도달했는지(네트워크 단절, 서버 다운 등)는 클라이언트가 알 방법이 없다. 이번 변경은 "아예 시도조차 안 하던" 상태를 "시도는 하되 결과는 확인 못 함"으로 개선한 것이지, 완전한 전달 보장이라고 할 수는 없다.  

이를 보완하고자  매일 참여자별로 팝업/세션/영상시청 등 각 이벤트 종류가 정상적으로 들어오고 있는지 점검하고 로깅을 남기는 서버 cron을 별도로 두는 방안을 검토 중이다(예: 하루 이상 특정 이벤트 유형이 끊긴 참여자를 탐지해 기록). 이건 "클라이언트가 보냈는지"가 아니라 "서버가 실제로 받았는지"를 관찰하는 것이라 이번 PR과는 다른 층위의 보완책이며, 별도 이슈/PR로 분리할 예정이다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 팝업이 닫힐 때 상호작용 이벤트가 누락되지 않도록 백업 전송 경로를 추가했습니다.
  * 동일한 이벤트가 중복으로 저장되지 않도록 처리했습니다.
  * 기존 이벤트 재시도 및 큐 처리 방식은 계속 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->