### PR TITLE
bug: YouTube 영상 제목의 placeholder 및 stale 값 저장 문제 수정

### DIFF
--- a/docs/07-작업5.md
+++ b/docs/07-작업5.md
@@ -502,3 +502,87 @@
 - [ ] `viewlens-screens.js` — `screenToday()` 안 2곳의 `koreanDateLabel(new Date())`를 `koreanDateLabel(_effectiveToday(VL._installDate))`로 교체
 
 - 관련 문서: 없음
+
+---
+
+## Epic: 1차 테스트 DB 점검 후속 수정
+
+- 설명: 1차 테스트(약 7명) 종료 후 DB를 점검하며 발견한 의문점·이상 가능성을 정리한 `docs/blog/1차 테스트 후 데이터베이스 점검.md`를 기준으로, 관련 소스코드를 직접 추적해 원인을 확인하고 필요한 수정을 진행했다. 점검 항목 중 대부분(참여자 식별 로직, `studyEndModalShownAt` 등 컬럼 목적, `session_id` 용도, 엔트로피 계산식)은 코드 추적 결과 정상 동작 또는 설계상 트레이드오프로 판명되어 별도 수정이 필요 없었고, 실제 코드 수정이 필요했던 것은 아래 세 이슈다.
+- 진행 현황: **이슈 1·2·3 전부 완료**(구현·검증 완료, 커밋은 사용자가 직접 진행).
+- 착수 순서: 세 이슈 모두 서로 독립적 — `popup_events`(이슈 1), `video_events` 스키마(이슈 2), `content.js` title 파싱(이슈 3)이 서로 다른 파일·다른 데이터 흐름을 다뤄 병행 가능. 다만 커밋은 하나의 논리적 단위씩 분리해 진행함(이슈 3은 내부적으로 2개 커밋).
+- 관련 문서: `docs/blog/1차 테스트 후 데이터베이스 점검.md`(원본 점검 문서, 이 Epic의 배경 전체)
+
+---
+
+### 이슈 1: [클라이언트] `popup_events` 참여자별 마지막 팝업 이벤트 유실 방지 (sendBeacon 백업 전송)
+
+- 설명: `popup_events`는 "다음 팝업이 열릴 때 직전 팝업의 스냅샷을 확정 큐로 승격해 서버로 전송"하는 지연 큐 구조(경로 1)로만 동작하고 있었다. 크롬 확장 액션 팝업은 포커스를 잃는 즉시 문서가 파괴되고 `chrome.action.onClosed` 같은 전용 종료 콜백이 없어, close 시점의 `fetch`가 teardown에 끊길 위험이 있다는 게 이 설계의 원래 근거였다. 문제는 이 구조상 **참여자가 연구 기간 중 마지막으로 연 팝업의 이벤트는 다음 오픈이 없어 확정 트리거 자체가 발생하지 않는다**는 점 — 확률이 아니라 구조적으로 100% 유실된다. `pagehide`/`visibilitychange` 핸들러에서 `navigator.sendBeacon`으로 같은 스냅샷을 병행 전송(경로 2)하도록 추가했다.
+- Priority: Medium / Owner: FE
+- Dependencies: 없음
+- 상태: **완료**(로컬 브라우저 실측 검증까지 완료)
+
+#### 설계 결정 (배경)
+
+- **`fetch` 대신 `sendBeacon` — teardown 문제를 정확히 겨냥**: `pagehide`/`visibilitychange`는 "곧 닫힌다"는 신호는 주지만, 그 핸들러 안에서 시작한 `fetch`가 끝까지 실행된다는 보장은 없다(문서 파괴 시 진행 중인 요청이 중단됨). `sendBeacon`은 문서가 파괴되는 도중에도 브라우저가 대신 전송을 이어가도록 스펙상 보장하는 API라, 이 문제에 정확히 대응한다.
+- **기존 경로 1을 대체하지 않고 순수 추가(additive)**: `eventId`(팝업 오픈당 1회 발급하는 멱등 키) + 서버의 `INSERT OR IGNORE` + UNIQUE 인덱스가 이미 존재해, 경로 1과 경로 2가 같은 이벤트를 둘 다 성공시켜도 서버에는 한 행만 남는다. 기존 주석에는 "sendBeacon을 안 써서 중복 전송이 없다"고 적혀 있었는데, 이건 `eventId` 멱등 키가 도입(2026-07-02, `fef8eed`)되기 전 시점의 낡은 근거였음을 확인하고 주석도 갱신했다.
+- **`sendBeacon` 실패 시에도 안전**: 성공 여부를 알 수 없는 fire-and-forget API라, 실패해도 기존 로컬 스냅샷 저장(`persistLivePopupEvent`, 매초 갱신)이 그대로 백업으로 남아 다음 오픈 때 경로 1이 재시도한다.
+- **로컬 브라우저 실측으로 검증**: 팝업을 열고 닫은 뒤, 다음 팝업을 열지 않은 상태에서 서버 DB를 직접 조회해, 방금 닫은 팝업의 이벤트 행이 **경로 1이 발동할 수 없는 상황(다음 오픈 없음)인데도** 이미 들어와 있는 것을 확인했다(`createdAt`이 `openedAt + dwellMs`, 즉 close 시각과 정확히 일치 — "다음 오픈 시각"이 아님을 시각 비교로 확정).
+
+#### Tasks
+
+- [x] `extension/popup/viewlens-popup.js` — `sendPopupEventBeacon(serverUrl, m)` 신규 함수 추가(`Blob` + `application/json` 타입으로 `navigator.sendBeacon` 호출)
+- [x] `finalizePopupMetrics`가 `persistLivePopupEvent`와 함께 `sendPopupEventBeacon`도 호출하도록 변경(`pagehide`/`visibilitychange` 두 핸들러 모두 공유)
+- [x] 상단 설계 주석을 "전송 경로 1(기본)/경로 2(백업)" 구조로 재정리(sendBeacon 미사용 근거가 낡았음을 반영)
+- [x] 로컬 서버 + 개발자 모드 확장으로 실제 브라우저 테스트, DB 직접 조회로 경로 2 동작 확정
+
+- 관련 문서: `docs/blog/1차 테스트 후 데이터베이스 점검.md` 2-1·2-2절("데이터가 연구 종료 시점까지 누락 없이 누적되는가?")
+
+---
+
+### 이슈 2: [서버+클라이언트] `video_events`에 `sessionId` 컬럼 추가
+
+- 설명: `video_events`에는 애초에 `sessionId` 컬럼이 없어, 어느 세션에 속한 영상 시청인지 알려면 매번 `watchedAt BETWEEN sessions.startTime AND endTime` 형태의 시간 범위 조인이 필요했다. 클라이언트(`content.js`)가 영상 기록 시점에 이미 `currentSession.sessionId`를 들고 있으므로, 이를 그대로 실어 보내 서버에 저장하도록 스키마와 라우트를 확장했다.
+- Priority: Low / Owner: BE+FE
+- Dependencies: 없음
+- 상태: **완료**(코드리뷰 대응 포함)
+
+#### 설계 결정 (배경)
+
+- **FK 제약을 걸지 않음 — 타이밍상 불가능함을 확인**: `POST /api/video-events`는 영상이 감지될 때마다(세션 진행 중) 실시간으로 나가지만, `POST /api/sessions`는 세션이 끝날 때(`analyzeSession`, 30분 비활성 등)만 나간다. 즉 같은 세션 안에서 video_events가 먼저 여러 건 도착하고, 대응하는 `sessions` 행은 한참 뒤에야 생긴다. `anonymousId`가 `participants`에 FK로 강제되지 않는 것과 같은 이유로, `sessionId`도 저장 시점에 세션 존재를 검증하지 않는 느슨한 참조로 설계했다.
+- **소급 적용 없음**: 이 컬럼 도입 이전(1차 테스트 포함) 행은 `sessionId`가 NULL이며, 그 구간은 계속 시간 범위 조인으로 분석해야 한다.
+- **⚠️ 코드리뷰(coderabbitai) 대응 — "소유권 검증 없이 저장됨" 지적에 대한 결정**: PR 리뷰에서 "존재하지 않거나 다른 참여자의 세션을 가리키는 `sessionId`가 그대로 저장될 수 있다"는 지적이 있었다. 즉시 `(anonymousId, sessionId)`를 `sessions`에서 찾아 없으면 거부하는 방향은 채택하지 않았다 — 위에서 확인한 타이밍(이벤트가 세션보다 먼저 도착) 때문에 진행 중인 세션의 정상 이벤트 대부분이 거부되는 부작용이 있다. `sessionId`가 클라이언트에서 `String(Date.now())`로 생성돼(`content.js`) 서로 다른 참여자의 세션이 우연히 같은 밀리초에 겹칠 확률이 사실상 0이라는 점에서, 오염 위험은 "클라이언트 버그가 있을 때만" 발생하는 낮은 리스크로 판단했다. `sessions` 저장 후 사후에 `(anonymousId, sessionId)` 매치 여부를 대조하는 방향은 타당한 개선안으로 동의했으나, 지금 당장 필요한지는 2차 테스트 데이터를 보고 판단하기로 하고 이번 범위에서는 as-is로 결정(PR에 근거를 답글로 남김).
+
+#### Tasks
+
+- [x] `server/db.js` — `video_events`에 `sessionId TEXT` 컬럼 추가(`CREATE TABLE` + `addColumn` 이중 반영)
+- [x] `server/routes/video-events.js` — `sessionId` 수신·검증(보냈다면 non-empty 문자열, 미전송은 구버전 하위호환으로 허용)·저장
+- [x] `extension/content.js` — `recordVideo()`의 서버 전송 payload에 `session.sessionId` 추가
+- [x] coderabbitai 코드리뷰 지적에 대한 결정 근거를 PR 답글로 기록(사후 검증은 보류, as-is 유지)
+
+- 관련 문서: `docs/blog/1차 테스트 후 데이터베이스 점검.md` 3-1절("`session_id` 컬럼의 의미와 활용 위치")
+
+---
+
+### 이슈 3: [클라이언트] `video_events.title` 데이터 품질 버그 2건 수정
+
+- 설명: `video_events` 137건을 점검하다가 서로 다른 성격의 title 오염 두 가지를 발견했다 — ①로딩 중 placeholder("YouTube")가 그대로 title로 저장되는 경우(16건) ②영상이 바뀐 직후 `document.title` 갱신이 늦어 직전 영상의 title을 그대로 캡처하는 경우(13건, stale title). 둘 다 `extension/content.js`의 `parseTitle()`/`waitForTitle()`에서 "언제 값을 채택할지 판단하는 기준"에 있던 문제였다.
+- Priority: Medium / Owner: FE
+- Dependencies: 없음
+- 상태: **완료**(두 버그 각각 별도 커밋으로 분리, 실측 데이터로 원인 확정 후 수정)
+
+#### 설계 결정 (배경)
+
+- **원인 확정을 추측이 아니라 실측 쿼리로 함**: `title IS NULL`이 0건인데 `title = 'YouTube'`가 16건이라는 실측 결과가, "원본 `document.title`이 정확히 `'YouTube'`였다"는 가설(그랬다면 null로 걸러졌어야 함)을 기각하고 "접두사(안 읽은 알림 개수 `(N) `) 제거 후에야 `'YouTube'`가 되는 경우"라는 정확한 원인을 특정하는 데 결정적이었다(예: `"(1) YouTube"` → 접두사 제거 → `"YouTube"`). 처음 제안했던 "raw 값에 trim만 추가"하는 수정안은 이 실측 결과와 맞지 않아 폐기하고, placeholder 판정 시점을 접두사·접미사 제거 **이후**로 옮기는 방향으로 재설계했다.
+- **stale title도 실측(13건)으로 필요성을 먼저 확인 후 착수**: `waitForTitle()`이 "직전에 채택한 title(`lastTitle`)과 다르면 즉시 채택"하도록, 같으면 재시도하도록 비교 조건을 추가했다. `lastTitle`은 title을 **실제로 확보했을 때만** 갱신한다 — timeout으로 null이 나온 경우 `document.title`이 여전히 옛 값에 머물러 있으므로 그대로 유지해야 다음 영상 판정도 정확하다.
+- **두 수정 모두 같은 원칙 적용 — "틀린 값보단 결측이 낫다"**: 예산(2초) 안에 확정 못 하면 stale 값을 그대로 쓰지 않고 `null`을 반환한다. `title`은 카테고리/엔트로피 계산(videoId 기준 별도 YouTube API 조회)과 무관해 이 결측이 다양성 지표에 영향을 주지 않는다.
+- **소급 적용 없음**: 기존 오염 29건(16+13)은 그대로 남고, 이번 수정은 앞으로 수집되는 데이터부터 적용된다.
+- Node 시뮬레이션으로 관측된 실제 케이스(`"(1) YouTube"`, 늦게 갱신/끝까지 stale/즉시 갱신/최초 영상 4개 시나리오)를 재현·검증 후 반영. `vitest` 전체 195개 테스트 회귀 없음 확인.
+
+#### Tasks
+
+- [x] `extension/content.js` `parseTitle()` — placeholder 판정을 접두사·접미사 제거 이후 값(`cleaned`) 기준으로 변경(1번째 커밋)
+- [x] `extension/content.js` `waitForTitle(prevTitle, ...)` — 직전 확보 title과 비교해 stale이면 재시도, timeout 시 `null` 반환(2번째 커밋)
+- [x] `handleVideoChange()` — `lastTitle` 모듈 변수 추가(video 없는 페이지로 이동 시 `lastVideoId`와 함께 초기화, title을 실제로 확보했을 때만 갱신)
+- [x] 실제 브라우저(로컬 서버 + 개발자 모드 확장)로 정상 경로 회귀 확인 — 8건 연속 시청 로그에서 placeholder·stale 사례 없이 전부 정상 title 캡처됨을 확인
+
+- 관련 문서: `docs/blog/1차 테스트 후 데이터베이스 점검.md` 4-1·4-2절(원래는 "video_events 중복 기록" 의심으로 점검을 시작했으나, 실측 결과 중복이 아니라 이 title 품질 문제였음을 확인)

--- a/extension/content.js
+++ b/extension/content.js
@@ -28,13 +28,13 @@ function parseTitle() {
   return cleaned && cleaned !== "YouTube" ? cleaned : null;
 }
 
-function waitForTitle(maxRetries = 10, interval = 200) {
+function waitForTitle(prevTitle, maxRetries = 10, interval = 200) {
   return new Promise((resolve) => {
     let attempts = 0;
 
     const check = () => {
       const title = parseTitle();
-      if (title) {
+      if (title && title !== prevTitle) {
         resolve(title);
         return;
       }
@@ -112,12 +112,15 @@ function recordVideo(videoId, title) {
 }
 
 let lastVideoId = null;
+// waitForTitle의 staleness 비교 기준(새 title을 실제로 확보했을 때만 갱신)
+let lastTitle = null;
 
 async function handleVideoChange() {
   const videoId = extractVideoId(location.href);
 
   if (!videoId) {
     lastVideoId = null;
+    lastTitle = null;
     return;
   }
 
@@ -125,7 +128,8 @@ async function handleVideoChange() {
 
   lastVideoId = videoId;
 
-  const title = await waitForTitle();
+  const title = await waitForTitle(lastTitle);
+  if (title) lastTitle = title;
   console.log("[content] video detected:", { videoId, title });
 
   await recordVideo(videoId, title);

--- a/extension/content.js
+++ b/extension/content.js
@@ -19,8 +19,13 @@ function extractVideoId(url) {
 
 function parseTitle() {
   const raw = document.title;
-  if (!raw || raw === "YouTube") return null;
-  return raw.replace(/^\(\d+\)\s+/, "").replace(/\s+-\s+YouTube$/, "") || null;
+  if (!raw) return null;
+  // placeholder 판정은 접두사(안 읽은 알림 개수)·접미사(" - YouTube") 제거 이후에 해야 한다.
+  const cleaned = raw
+    .replace(/^\(\d+\)\s+/, "")
+    .replace(/\s+-\s+YouTube$/, "")
+    .trim();
+  return cleaned && cleaned !== "YouTube" ? cleaned : null;
 }
 
 function waitForTitle(maxRetries = 10, interval = 200) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -94,6 +94,7 @@ function recordVideo(videoId, title) {
             videoId,
             title: title ?? null,
             watchedAt: now,
+            sessionId: session.sessionId,
           }),
         }).catch(() => {});
       }

--- a/server/db.js
+++ b/server/db.js
@@ -86,6 +86,8 @@ function initializeDB() {
       videoId     TEXT    NOT NULL,
       title       TEXT,
       watchedAt   TEXT    NOT NULL,
+      -- 이 영상이 속한 세션의 sessions.sessionId 
+      sessionId   TEXT,
       createdAt   TEXT    DEFAULT (datetime('now'))
     );
 
@@ -177,6 +179,7 @@ function initializeDB() {
   addColumn("participants", "studyEndModalShownAt", "TEXT");
   addColumn("participants", "studyEndReviewViewedAt", "TEXT");
   addColumn("participants", "studyEndCodeVerifiedAt", "TEXT");
+  addColumn("video_events", "sessionId", "TEXT");
 
   // popup_events.eventId도 같은 이유로 addColumn 필요. UNIQUE는 ALTER TABLE ADD COLUMN이
   // 만들 수 없으므로(SQLite 제약) 컬럼 추가 후 별도 유니크 인덱스로 건다 — 신규/기존 DB 모두

--- a/server/routes/video-events.js
+++ b/server/routes/video-events.js
@@ -5,12 +5,12 @@ const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
 const router = express.Router();
 
 const insertEvent = db.prepare(`
-  INSERT INTO video_events (anonymousId, videoId, title, watchedAt)
-  VALUES (@anonymousId, @videoId, @title, @watchedAt)
+  INSERT INTO video_events (anonymousId, videoId, title, watchedAt, sessionId)
+  VALUES (@anonymousId, @videoId, @title, @watchedAt, @sessionId)
 `);
 
 router.post("/", (req, res, next) => {
-  const { anonymousId, videoId, watchedAt, title } = req.body;
+  const { anonymousId, videoId, watchedAt, title, sessionId } = req.body;
 
   for (const field of ["anonymousId", "videoId", "watchedAt"]) {
     const value = req.body[field];
@@ -35,8 +35,30 @@ router.post("/", (req, res, next) => {
     );
   }
 
+  // sessions.sessionId와 마찬가지로 이 영상이 속한 세션을 가리키는 값 — 구버전 확장
+  // 하위호환으로 미전송(null)은 허용하되, 보냈다면 빈 문자열은 거부한다.
+  if (
+    sessionId !== undefined &&
+    sessionId !== null &&
+    (typeof sessionId !== "string" || sessionId.trim() === "")
+  ) {
+    return fail(
+      res,
+      400,
+      ERROR_CODES.INVALID_FIELD_VALUE,
+      "sessionId 필드가 올바르지 않습니다.",
+      "sessionId",
+    );
+  }
+
   try {
-    insertEvent.run({ anonymousId, videoId, title: title ?? null, watchedAt });
+    insertEvent.run({
+      anonymousId,
+      videoId,
+      title: title ?? null,
+      watchedAt,
+      sessionId: sessionId ?? null,
+    });
   } catch (err) {
     return next(err);
   }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 했는지 -->

video_events.title이 실제 영상 제목이 아니라 잘못된 값으로 저장되는 두 가지 문제를 1차 테스트 DB 점검 중 발견해 수정했다. 두 문제 모두 YouTube SPA 페이지 전환 직후 document.title을 읽어와 영상 제목을 캡처하는 로직에서 발생한다.

### 기존에 작동하던 모습 

```mermaid
sequenceDiagram
    participant YT as YouTube 페이지(SPA)
    participant CS as content.js
    participant DOM as document.title

    YT->>CS: yt-navigate-finish / popstate (새 영상 전환)
    CS->>CS: extractVideoId(location.href)
    CS->>CS: waitForTitle() 시작 (최대 10회 × 200ms)
    loop 최대 10회
        CS->>DOM: document.title 읽기
        DOM-->>CS: raw title
        CS->>CS: raw === "YouTube" 면 재시도(로딩 placeholder로 간주)<br/>아니면 접두사·접미사 제거 후 즉시 채택
    end
    CS->>CS: recordVideo(videoId, title) → 로컬 저장 + 서버 POST
```

이 폴링 구조 자체(최대 2초 재시도, 접두사/접미사 정리)는 의도대로 잘 작동해왔었는데
문제는 "언제 값을 채택할지 판단하는 기준" 두 군데에 있었다.

#### 로딩 placeholder("YouTube")가 그대로 title로 저장됨
raw === "YouTube" 판정이 접두사(안 읽은 알림 개수 "(1) ")·접미사(" - YouTube") 제거 이전에 있었다. "(1) YouTube"처럼 영상 제목이 아직 안 실린 로딩 중 상태는 원본 문자열이 "YouTube"와 정확히 일치하지 않아 이 가드를 통과했다가, 이어지는 접두사 제거 정규식이 "(1) "를 지우면서 결과적으로 정확히 "YouTube"가 되어 그대로 저장됐다.

video_events 137건 중 16건이 title = 'YouTube', title IS NULL은 0건이었다. 원본이 애초에 정확히 "YouTube"였다면 null로 걸러졌어야 하는데 그런 행이 하나도 없다는 게, 문제가 "치환 후에야 placeholder가 되는" 경로에서 발생했다는 증거이다.

#### 영상이 바뀐 직후 직전 영상의 title을 그대로 캡처(stale title)
waitForTitle()은 "truthy하고 placeholder가 아니면" 무조건 즉시 채택했다. document.title 갱신이 yt-navigate-finish 발생보다 늦어질 수 있는데, 이 경우 아직 안 바뀐 직전 영상의 title을 새 videoId에 그대로 붙여버렸다.  

연속된 두 이벤트의 videoId는 다른데 title은 완전히 동일한 쌍이 13건 조회되었다. 

## 변경 사항

```mermaid
sequenceDiagram
    participant YT as YouTube 페이지(SPA)
    participant CS as content.js
    participant DOM as document.title

    YT->>CS: yt-navigate-finish / popstate
    CS->>CS: extractVideoId(location.href)
    CS->>CS: waitForTitle(lastTitle) 시작
    loop 최대 10회
        CS->>DOM: document.title 읽기
        DOM-->>CS: raw title
        CS->>CS: 접두사·접미사 제거 → cleaned (판정은 이 시점 값 기준)
        CS->>CS: cleaned === "YouTube" → 재시도(placeholder)
        CS->>CS: cleaned === lastTitle → 재시도(stale)
        CS->>CS: 둘 다 아니면 채택
    end
    alt 예산(2초) 내 확정
        CS->>CS: lastTitle = title 갱신<br/>recordVideo(videoId, title)
    else 끝까지 placeholder/stale만 관측
        CS->>CS: recordVideo(videoId, null)
    end
```

- 문제 1 수정: parseTitle()에서 placeholder 판정을 접두사·접미사 제거 이후 값(cleaned)으로 옮김   
- 문제 2 수정: waitForTitle(prevTitle, ...)이 직전에 실제로 확보한 title(lastTitle)과 새로 읽은 값을 비교해, 같으면 재시도. 예산 내내 다른 값을 못 보면 stale 값을 저장하는 대신 null 반환 

### 이 방법이 최선인 이유

두 문제 다 기존 폴링/정리 로직을 새로 만들지 않고 판정 시점·판정 기준만 최소로 수정했다.  
재시도 구조, 정규식, 호출부(waitForTitle을 감싸는 handleVideoChange)의 나머지 흐름은 그대로 재사용했다.  
"형태는 멀쩡하지만 내용이 틀린 값(stale)"과 "형태부터 placeholder인 값" 두 실패 유형을 각각 해결하여 하나의 범용 필터로 뭉뚱그리지 않으려고 했다. 두 수정 모두 애매하면 title=null을 택한다. 연구 데이터로서는 틀린 값보다 결측이 안전하다는 판단이며, 카테고리/엔트로피 계산은 title이 아니라 videoId 기준 별도 조회라 이 결측이 다양성 지표에 영향을 주지 않는다.  
실측 데이터(16건, 13건)로 원인을 먼저 확정한 뒤 그에 정확히 대응하는 수정만 반영한 상태이다. 추측성 광범위 수정(예: 문자열 유사도 비교, DOM 구조 재파싱 등)은 배제했다.  

## 테스트 확인

- [x]  eslint 통과
- [x]  vitest 전체 195개 테스트 통과 
- [x]  Node 시뮬레이션으로 waitForTitle 4가지 시나리오 검증
- [x]  실제 브라우저에서 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * YouTube 영상 제목을 더 정확하게 인식하여 제목이 없거나 기본 문구만 표시되는 경우 잘못 기록되지 않도록 개선했습니다.
  * 같은 영상이 반복 감지되어 중복 기록되는 문제를 수정했습니다.
  * 영상 전환 시 이전 영상 정보가 올바르게 초기화되도록 개선했습니다.

* **개선 사항**
  * 영상 기록에 세션 정보가 함께 저장되어 기록을 세션별로 구분할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->