### PR TITLE
test: P1 위험 기반 테스트 4개 항목 구현 및 리팩터링 

### DIFF
--- a/extension/test/pipeline/youtube.test.js
+++ b/extension/test/pipeline/youtube.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { fetchVideoCategories } from "../../pipeline/youtube.js";
+
+function ids(n, prefix = "v") {
+  return Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+}
+
+function idsFromUrl(url) {
+  const params = new URL(url).searchParams;
+  return params.get("id").split(",");
+}
+
+function itemsResponse(idList, categoryId = "10") {
+  return {
+    ok: true,
+    json: async () => ({
+      items: idList.map((id) => ({ id, snippet: { categoryId } })),
+    }),
+  };
+}
+
+describe("fetchVideoCategories — 배치 분할 및 실패 폴백", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("50개 이하면 fetch를 1회만 호출하고 각 id에 categoryId를 매핑한다", async () => {
+    const videoIds = ids(30);
+    global.fetch = vi.fn().mockResolvedValue(itemsResponse(videoIds));
+
+    const result = await fetchVideoCategories(videoIds);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      Object.fromEntries(videoIds.map((id) => [id, "10"])),
+    );
+  });
+
+  it("정확히 50개(배치 경계)면 단일 배치로 처리한다", async () => {
+    const videoIds = ids(50);
+    global.fetch = vi.fn().mockResolvedValue(itemsResponse(videoIds));
+
+    await fetchVideoCategories(videoIds);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(idsFromUrl(global.fetch.mock.calls[0][0])).toHaveLength(50);
+  });
+
+  it("51개면 50개/1개, 두 번의 배치로 나눠 호출한다", async () => {
+    const videoIds = ids(51);
+    global.fetch = vi.fn().mockImplementation(async (url) => {
+      const requested = idsFromUrl(url);
+      return itemsResponse(requested);
+    });
+
+    const result = await fetchVideoCategories(videoIds);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(idsFromUrl(global.fetch.mock.calls[0][0])).toHaveLength(50);
+    expect(idsFromUrl(global.fetch.mock.calls[1][0])).toHaveLength(1);
+    expect(Object.keys(result)).toHaveLength(51);
+  });
+
+  it("빈 배열이면 fetch를 호출하지 않고 빈 객체를 반환한다", async () => {
+    global.fetch = vi.fn();
+
+    const result = await fetchVideoCategories([]);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+
+  it("API 응답에 일부 id만 있으면(삭제/비공개 영상) 나머지는 null로 유지한다", async () => {
+    const videoIds = ["a", "b", "c"];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          { id: "a", snippet: { categoryId: "10" } },
+          { id: "c", snippet: { categoryId: "20" } },
+        ],
+      }),
+    });
+
+    const result = await fetchVideoCategories(videoIds);
+
+    expect(result).toEqual({ a: "10", b: null, c: "20" });
+  });
+
+  it("response.ok가 false면 해당 청크의 모든 id를 null로 채운다", async () => {
+    const videoIds = ["a", "b"];
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+
+    const result = await fetchVideoCategories(videoIds);
+
+    expect(result).toEqual({ a: null, b: null });
+  });
+
+  it("fetch 자체가 reject되면(네트워크 오류) 해당 청크의 모든 id를 null로 채운다", async () => {
+    const videoIds = ["a", "b"];
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("network down"));
+
+    const result = await fetchVideoCategories(videoIds);
+
+    expect(result).toEqual({ a: null, b: null });
+  });
+
+  it("한 배치가 실패해도 다른 배치는 독립적으로 정상 처리된다", async () => {
+    const videoIds = ids(51);
+    global.fetch = vi.fn().mockImplementation(async (url) => {
+      const requested = idsFromUrl(url);
+      if (requested.length === 50) {
+        return { ok: false, status: 500 };
+      }
+      return itemsResponse(requested);
+    });
+
+    const result = await fetchVideoCategories(videoIds);
+
+    for (let i = 0; i < 50; i++) expect(result[`v${i}`]).toBeNull();
+    expect(result.v50).toBe("10");
+  });
+});

--- a/server/db.js
+++ b/server/db.js
@@ -202,4 +202,4 @@ function addColumn(table, name, type) {
   }
 }
 
-module.exports = { db, initializeDB };
+module.exports = { db, initializeDB, addColumn };

--- a/server/routes/popup-events-validate.js
+++ b/server/routes/popup-events-validate.js
@@ -1,0 +1,47 @@
+// POST /api/popup-events 요청 본문 검증
+
+const { ERROR_CODES } = require("../middleware/responseHandler");
+
+// 값이 있으면 음수 아닌 정수여야 하는 필드 (미전송 시 null)
+const COUNT_FIELDS = ["dwellMs", "tabTodayClicks", "tabWeekClicks"];
+
+function validatePopupEvent(body) {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "body" };
+  }
+
+  const { anonymousId, feedbackViewed, openedAt } = body;
+
+  if (typeof anonymousId !== "string" || !anonymousId.trim()) {
+    return { code: ERROR_CODES.MISSING_REQUIRED_FIELD, field: "anonymousId" };
+  }
+  for (const field of COUNT_FIELDS) {
+    const value = body[field];
+    if (
+      value !== undefined &&
+      value !== null &&
+      (!Number.isInteger(value) || value < 0)
+    ) {
+      return { code: ERROR_CODES.INVALID_FIELD_VALUE, field };
+    }
+  }
+  if (
+    feedbackViewed !== undefined &&
+    feedbackViewed !== null &&
+    feedbackViewed !== 0 &&
+    feedbackViewed !== 1
+  ) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "feedbackViewed" };
+  }
+  if (
+    openedAt !== undefined &&
+    openedAt !== null &&
+    isNaN(Date.parse(openedAt))
+  ) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "openedAt" };
+  }
+
+  return null;
+}
+
+module.exports = { validatePopupEvent, COUNT_FIELDS };

--- a/server/routes/popup-events.js
+++ b/server/routes/popup-events.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const { db } = require("../db");
-const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
+const { success, fail } = require("../middleware/responseHandler");
+const { validatePopupEvent } = require("./popup-events-validate");
 
 const router = express.Router();
 
@@ -11,44 +12,6 @@ const insertPopupEvent = db.prepare(`
   INSERT OR IGNORE INTO popup_events (eventId, anonymousId, dwellMs, tabTodayClicks, tabWeekClicks, feedbackViewed, openedAt)
   VALUES (@eventId, @anonymousId, @dwellMs, @tabTodayClicks, @tabWeekClicks, @feedbackViewed, @openedAt)
 `);
-
-// 값이 있으면 음수 아닌 정수여야 하는 필드 (미전송 시 null)
-const COUNT_FIELDS = ["dwellMs", "tabTodayClicks", "tabWeekClicks"];
-
-function validatePopupEvent(body) {
-  const { anonymousId, feedbackViewed, openedAt } = body;
-
-  if (typeof anonymousId !== "string" || !anonymousId.trim()) {
-    return { code: ERROR_CODES.MISSING_REQUIRED_FIELD, field: "anonymousId" };
-  }
-  for (const field of COUNT_FIELDS) {
-    const value = body[field];
-    if (
-      value !== undefined &&
-      value !== null &&
-      (!Number.isInteger(value) || value < 0)
-    ) {
-      return { code: ERROR_CODES.INVALID_FIELD_VALUE, field };
-    }
-  }
-  if (
-    feedbackViewed !== undefined &&
-    feedbackViewed !== null &&
-    feedbackViewed !== 0 &&
-    feedbackViewed !== 1
-  ) {
-    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "feedbackViewed" };
-  }
-  if (
-    openedAt !== undefined &&
-    openedAt !== null &&
-    isNaN(Date.parse(openedAt))
-  ) {
-    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "openedAt" };
-  }
-
-  return null;
-}
 
 router.post("/", (req, res, next) => {
   const error = validatePopupEvent(req.body);

--- a/server/routes/video-events-validate.js
+++ b/server/routes/video-events-validate.js
@@ -1,0 +1,35 @@
+// POST /api/video-events 요청 본문 검증
+
+const { ERROR_CODES } = require("../middleware/responseHandler");
+
+function validateVideoEvent(body) {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "body" };
+  }
+
+  for (const field of ["anonymousId", "videoId", "watchedAt"]) {
+    const value = body[field];
+    if (typeof value !== "string" || !value.trim()) {
+      return { code: ERROR_CODES.MISSING_REQUIRED_FIELD, field };
+    }
+  }
+
+  if (isNaN(Date.parse(body.watchedAt))) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "watchedAt" };
+  }
+
+  // sessions.sessionId와 마찬가지로 이 영상이 속한 세션을 가리키는 값 — 구버전 확장
+  // 하위호환으로 미전송(null)은 허용하되, 보냈다면 빈 문자열은 거부한다.
+  const { sessionId } = body;
+  if (
+    sessionId !== undefined &&
+    sessionId !== null &&
+    (typeof sessionId !== "string" || sessionId.trim() === "")
+  ) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "sessionId" };
+  }
+
+  return null;
+}
+
+module.exports = { validateVideoEvent };

--- a/server/routes/video-events.js
+++ b/server/routes/video-events.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const { db } = require("../db");
-const { success, fail, ERROR_CODES } = require("../middleware/responseHandler");
+const { success, fail } = require("../middleware/responseHandler");
+const { validateVideoEvent } = require("./video-events-validate");
 
 const router = express.Router();
 
@@ -10,46 +11,18 @@ const insertEvent = db.prepare(`
 `);
 
 router.post("/", (req, res, next) => {
+  const error = validateVideoEvent(req.body);
+  if (error) {
+    return fail(
+      res,
+      400,
+      error.code,
+      `${error.field} 필드가 올바르지 않습니다.`,
+      error.field,
+    );
+  }
+
   const { anonymousId, videoId, watchedAt, title, sessionId } = req.body;
-
-  for (const field of ["anonymousId", "videoId", "watchedAt"]) {
-    const value = req.body[field];
-    if (typeof value !== "string" || !value.trim()) {
-      return fail(
-        res,
-        400,
-        ERROR_CODES.MISSING_REQUIRED_FIELD,
-        `${field} 필드가 올바르지 않습니다.`,
-        field,
-      );
-    }
-  }
-
-  if (isNaN(Date.parse(watchedAt))) {
-    return fail(
-      res,
-      400,
-      ERROR_CODES.INVALID_FIELD_VALUE,
-      "watchedAt 필드가 올바르지 않습니다.",
-      "watchedAt",
-    );
-  }
-
-  // sessions.sessionId와 마찬가지로 이 영상이 속한 세션을 가리키는 값 — 구버전 확장
-  // 하위호환으로 미전송(null)은 허용하되, 보냈다면 빈 문자열은 거부한다.
-  if (
-    sessionId !== undefined &&
-    sessionId !== null &&
-    (typeof sessionId !== "string" || sessionId.trim() === "")
-  ) {
-    return fail(
-      res,
-      400,
-      ERROR_CODES.INVALID_FIELD_VALUE,
-      "sessionId 필드가 올바르지 않습니다.",
-      "sessionId",
-    );
-  }
 
   try {
     insertEvent.run({

--- a/server/scripts/backup-db-validate.js
+++ b/server/scripts/backup-db-validate.js
@@ -1,0 +1,14 @@
+// offsitePush 오프사이트 백업의 원격 쉘 명령(mkdir/find) 인자 검증.
+// remoteDir/remoteRetention은 execFileSync로 원격 쉘 명령 문자열에 그대로 삽입되므로,
+// 쉘 메타문자·공백 유입이나 비정상 정수값이 원격에서 의도치 않은 실행/구문 오류로
+// 이어지지 않도록 막는다. (실패해도 로컬 백업은 이미 성공했으므로 best-effort로 건너뜀)
+
+function isValidRemoteDir(remoteDir) {
+  return /^[a-zA-Z0-9_/-]+$/.test(remoteDir);
+}
+
+function isValidRemoteRetention(remoteRetention) {
+  return Number.isInteger(remoteRetention) && remoteRetention >= 0;
+}
+
+module.exports = { isValidRemoteDir, isValidRemoteRetention };

--- a/server/scripts/backup-db.js
+++ b/server/scripts/backup-db.js
@@ -31,6 +31,10 @@ const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 const Database = require("better-sqlite3-multiple-ciphers");
+const {
+  isValidRemoteDir,
+  isValidRemoteRetention,
+} = require("./backup-db-validate");
 
 // cron으로 실행될 때는 server/.env가 자동으로 로드되지 않으므로 명시적으로 불러온다.
 require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
@@ -112,13 +116,13 @@ function offsitePush(dest) {
 
   // remoteDir/remoteRetention은 원격 쉘 명령(mkdir/find)에 삽입되므로 검증한다.
   // 쉘 메타문자·공백 유입 시 원격에서 의도치 않은 실행/구문 오류 방지. (실패해도 로컬 백업은 유효)
-  if (!/^[a-zA-Z0-9_/-]+$/.test(remoteDir)) {
+  if (!isValidRemoteDir(remoteDir)) {
     console.warn(
       "[backup] 오프사이트 건너뜀: E1_BACKUP_DIR에 허용되지 않는 문자가 있습니다.",
     );
     return;
   }
-  if (!Number.isInteger(remoteRetention) || remoteRetention < 0) {
+  if (!isValidRemoteRetention(remoteRetention)) {
     console.warn(
       "[backup] 오프사이트 건너뜀: E1_RETENTION_DAYS가 0 이상의 정수가 아닙니다.",
     );

--- a/server/test/db.test.js
+++ b/server/test/db.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+//  실제 server/db.js를 그대로 로드해 addColumn의 멱등성·에러 전파를 검증한다.
+// DB_PATH를 임시 파일로 오버라이드해 운영 DB를 열 위험 없이 실제 파일을 require한다.
+const require = createRequire(import.meta.url);
+const TEST_DB_PATH = path.join(os.tmpdir(), `viewlens-db-${process.pid}.db`);
+fs.rmSync(TEST_DB_PATH, { force: true });
+process.env.DB_ENCRYPTION_KEY = "vitest-in-memory-only";
+process.env.DB_PATH = TEST_DB_PATH;
+
+const { db, initializeDB, addColumn } = require("../db.js");
+
+afterAll(() => {
+  db.close();
+  fs.rmSync(TEST_DB_PATH, { force: true });
+});
+
+describe("initializeDB — 반복 실행 안전성(서버 재기동 시나리오)", () => {
+  it("여러 번 호출해도 예외 없이 통과한다", () => {
+    expect(() => initializeDB()).not.toThrow();
+    expect(() => initializeDB()).not.toThrow();
+    expect(() => initializeDB()).not.toThrow();
+  });
+});
+
+describe("addColumn", () => {
+  it("컬럼이 없는 테이블에 새 컬럼을 추가한다", () => {
+    db.exec(
+      "CREATE TABLE IF NOT EXISTS add_column_new_test (id INTEGER PRIMARY KEY)",
+    );
+
+    addColumn("add_column_new_test", "newCol", "TEXT");
+
+    const columns = db.prepare("PRAGMA table_info(add_column_new_test)").all();
+    expect(columns.some((c) => c.name === "newCol")).toBe(true);
+  });
+
+  it("이미 컬럼이 있는 테이블에 같은 컬럼을 다시 추가해도 예외 없이 조용히 통과한다(멱등성)", () => {
+    db.exec(
+      "CREATE TABLE IF NOT EXISTS add_column_idempotent_test (id INTEGER PRIMARY KEY)",
+    );
+    addColumn("add_column_idempotent_test", "col", "TEXT");
+
+    expect(() =>
+      addColumn("add_column_idempotent_test", "col", "TEXT"),
+    ).not.toThrow();
+    // 반복 실행돼도 컬럼이 중복 생성되지 않는지 확인
+    const columns = db
+      .prepare("PRAGMA table_info(add_column_idempotent_test)")
+      .all();
+    expect(columns.filter((c) => c.name === "col")).toHaveLength(1);
+  });
+
+  it("컬럼 추가가 아닌 다른 이유(테이블 없음)로 실패하면 에러를 삼키지 않고 그대로 전파한다", () => {
+    expect(() => addColumn("no_such_table_at_all", "col", "TEXT")).toThrow(
+      /no such table/i,
+    );
+  });
+});

--- a/server/test/routes/popup-events-validate.test.js
+++ b/server/test/routes/popup-events-validate.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { validatePopupEvent } from "../../routes/popup-events-validate.js";
+import { ERROR_CODES } from "../../middleware/responseHandler.js";
+
+function basePayload(overrides = {}) {
+  return {
+    eventId: "evt-1",
+    anonymousId: "exp-user",
+    dwellMs: 4200,
+    tabTodayClicks: 2,
+    tabWeekClicks: 1,
+    feedbackViewed: 1,
+    openedAt: "2026-08-13T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+describe("validatePopupEvent — 잘못된 형태의 body", () => {
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["배열", []],
+    ["문자열", "not-an-object"],
+    ["숫자", 42],
+  ])("body가 %s이면 예외 없이 INVALID_FIELD_VALUE(field: body)를 반환한다", (_label, body) => {
+    expect(() => validatePopupEvent(body)).not.toThrow();
+    expect(validatePopupEvent(body)).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "body",
+    });
+  });
+});
+
+describe("validatePopupEvent — anonymousId", () => {
+  it("anonymousId만 있는 최소 payload는 통과한다", () => {
+    expect(validatePopupEvent({ anonymousId: "exp-user" })).toBeNull();
+  });
+
+  it.each([
+    ["없음", undefined],
+    ["null", null],
+    ["빈 문자열", ""],
+    ["공백만", "   "],
+    ["숫자", 123],
+  ])("anonymousId가 %s이면 MISSING_REQUIRED_FIELD를 반환한다", (_label, value) => {
+    expect(validatePopupEvent(basePayload({ anonymousId: value }))).toEqual({
+      code: ERROR_CODES.MISSING_REQUIRED_FIELD,
+      field: "anonymousId",
+    });
+  });
+});
+
+describe("validatePopupEvent — 카운트 필드 (dwellMs/tabTodayClicks/tabWeekClicks)", () => {
+  it.each(["dwellMs", "tabTodayClicks", "tabWeekClicks"])(
+    "%s는 미전송(undefined)이면 통과한다(하위호환)",
+    (field) => {
+      const payload = basePayload({ [field]: undefined });
+      expect(validatePopupEvent(payload)).toBeNull();
+    },
+  );
+
+  it.each(["dwellMs", "tabTodayClicks", "tabWeekClicks"])(
+    "%s는 null이면 통과한다(하위호환)",
+    (field) => {
+      expect(validatePopupEvent(basePayload({ [field]: null }))).toBeNull();
+    },
+  );
+
+  it.each(["dwellMs", "tabTodayClicks", "tabWeekClicks"])(
+    "%s는 0이면 허용한다(경계값)",
+    (field) => {
+      expect(validatePopupEvent(basePayload({ [field]: 0 }))).toBeNull();
+    },
+  );
+
+  it.each(["dwellMs", "tabTodayClicks", "tabWeekClicks"])(
+    "%s가 음수면 거부한다",
+    (field) => {
+      expect(validatePopupEvent(basePayload({ [field]: -1 }))).toEqual({
+        code: ERROR_CODES.INVALID_FIELD_VALUE,
+        field,
+      });
+    },
+  );
+
+  it.each(["dwellMs", "tabTodayClicks", "tabWeekClicks"])(
+    "%s가 정수가 아니면(실수) 거부한다",
+    (field) => {
+      expect(validatePopupEvent(basePayload({ [field]: 1.5 }))).toEqual({
+        code: ERROR_CODES.INVALID_FIELD_VALUE,
+        field,
+      });
+    },
+  );
+
+  it.each(["dwellMs", "tabTodayClicks", "tabWeekClicks"])(
+    "%s가 숫자 문자열이면 거부한다(타입 강제 변환 없음)",
+    (field) => {
+      expect(validatePopupEvent(basePayload({ [field]: "10" }))).toEqual({
+        code: ERROR_CODES.INVALID_FIELD_VALUE,
+        field,
+      });
+    },
+  );
+});
+
+describe("validatePopupEvent — feedbackViewed", () => {
+  it.each([undefined, null])("%s이면 통과한다(하위호환)", (value) => {
+    expect(validatePopupEvent(basePayload({ feedbackViewed: value }))).toBeNull();
+  });
+
+  it.each([0, 1])("%i는 허용한다", (value) => {
+    expect(validatePopupEvent(basePayload({ feedbackViewed: value }))).toBeNull();
+  });
+
+  it.each([2, -1, true, "1"])("%p는 거부한다(0/1 외 값)", (value) => {
+    expect(validatePopupEvent(basePayload({ feedbackViewed: value }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "feedbackViewed",
+    });
+  });
+});
+
+describe("validatePopupEvent — openedAt", () => {
+  it.each([undefined, null])("%s이면 통과한다(하위호환)", (value) => {
+    expect(validatePopupEvent(basePayload({ openedAt: value }))).toBeNull();
+  });
+
+  it("파싱 가능한 날짜 문자열이면 통과한다", () => {
+    expect(
+      validatePopupEvent(basePayload({ openedAt: "2026-08-13T10:00:00+09:00" })),
+    ).toBeNull();
+  });
+
+  it("파싱 불가능한 문자열이면 거부한다", () => {
+    expect(validatePopupEvent(basePayload({ openedAt: "not-a-date" }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "openedAt",
+    });
+  });
+});

--- a/server/test/routes/popup-events.wiring.test.js
+++ b/server/test/routes/popup-events.wiring.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// sessions.wiring.test.js/participants.wiring.test.js와 동일한 이유: 실제
+// server/routes/popup-events.js를 그대로 로드해 OR IGNORE(eventId 멱등 키) 배선까지
+// 검증한다. DB_PATH를 임시 파일로 오버라이드해 운영 DB를 열 위험 없이 실제 파일을 require한다.
+const require = createRequire(import.meta.url);
+const TEST_DB_PATH = path.join(
+  os.tmpdir(),
+  `viewlens-popup-events-wiring-${process.pid}.db`,
+);
+fs.rmSync(TEST_DB_PATH, { force: true });
+process.env.DB_ENCRYPTION_KEY = "vitest-in-memory-only";
+process.env.DB_PATH = TEST_DB_PATH;
+
+const { db, initializeDB } = require("../../db.js");
+initializeDB();
+
+const { errorHandler } = require("../../middleware/responseHandler.js");
+const popupEventsRouter = require("../../routes/popup-events.js");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/popup-events", popupEventsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+const app = buildApp();
+
+afterAll(() => {
+  db.close();
+  fs.rmSync(TEST_DB_PATH, { force: true });
+});
+
+beforeEach(() => {
+  db.exec("DELETE FROM popup_events");
+});
+
+function basePayload(overrides = {}) {
+  return {
+    eventId: "wiring-evt-1",
+    anonymousId: "wiring-user",
+    dwellMs: 1200,
+    tabTodayClicks: 1,
+    tabWeekClicks: 0,
+    feedbackViewed: 1,
+    openedAt: "2026-08-13T09:00:00+09:00",
+    ...overrides,
+  };
+}
+
+describe("실제 server/routes/popup-events.js 라우터 배선", () => {
+  it("POST /api/popup-events — 파일을 그대로 로드해도 정상 저장된다", async () => {
+    const res = await request(app)
+      .post("/api/popup-events")
+      .send(basePayload());
+    expect(res.status).toBe(200);
+
+    const row = db
+      .prepare("SELECT * FROM popup_events WHERE eventId = ?")
+      .get("wiring-evt-1");
+    expect(row.anonymousId).toBe("wiring-user");
+  });
+
+  it("POST /api/popup-events — anonymousId 누락 시 400 (validatePopupEvent가 실제로 연결돼 있는지)", async () => {
+    const payload = basePayload();
+    delete payload.anonymousId;
+
+    const res = await request(app).post("/api/popup-events").send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("MISSING_REQUIRED_FIELD");
+    expect(
+      db.prepare("SELECT COUNT(*) AS c FROM popup_events").get().c,
+    ).toBe(0);
+  });
+
+  it("같은 eventId로 재전송해도 한 행만 남는다(OR IGNORE 멱등성)", async () => {
+    await request(app).post("/api/popup-events").send(basePayload());
+    const res = await request(app)
+      .post("/api/popup-events")
+      .send(basePayload({ dwellMs: 9999 }));
+
+    expect(res.status).toBe(200);
+    const rows = db
+      .prepare("SELECT * FROM popup_events WHERE eventId = ?")
+      .all("wiring-evt-1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dwellMs).toBe(1200); // 재전송 값(9999)이 아니라 최초 값 유지
+  });
+
+  it("eventId 없는 구버전 요청은 dedup 없이 매번 새 행으로 저장된다", async () => {
+    const payload = basePayload();
+    delete payload.eventId;
+
+    await request(app).post("/api/popup-events").send(payload);
+    await request(app).post("/api/popup-events").send(payload);
+
+    const rows = db
+      .prepare("SELECT * FROM popup_events WHERE anonymousId = ?")
+      .all("wiring-user");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("등록되지 않은 경로는 404 — 예기치 않은 라우트가 실수로 노출되지 않았는지 확인", async () => {
+    const res = await request(app).get(
+      "/api/popup-events/no-such-route",
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/test/routes/video-events-validate.test.js
+++ b/server/test/routes/video-events-validate.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { validateVideoEvent } from "../../routes/video-events-validate.js";
+import { ERROR_CODES } from "../../middleware/responseHandler.js";
+
+function basePayload(overrides = {}) {
+  return {
+    anonymousId: "exp-user",
+    videoId: "dQw4w9WgXcQ",
+    watchedAt: "2026-08-13T10:00:00+09:00",
+    title: "영상 제목",
+    sessionId: "s1",
+    ...overrides,
+  };
+}
+
+describe("validateVideoEvent — 잘못된 형태의 body", () => {
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["배열", []],
+    ["문자열", "not-an-object"],
+    ["숫자", 42],
+  ])("body가 %s이면 예외 없이 INVALID_FIELD_VALUE(field: body)를 반환한다", (_label, body) => {
+    expect(() => validateVideoEvent(body)).not.toThrow();
+    expect(validateVideoEvent(body)).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "body",
+    });
+  });
+});
+
+describe("validateVideoEvent — 필수 필드 (anonymousId/videoId/watchedAt)", () => {
+  it("모든 필수 필드가 채워진 정상 payload는 통과한다", () => {
+    expect(validateVideoEvent(basePayload())).toBeNull();
+  });
+
+  it.each(["anonymousId", "videoId", "watchedAt"])(
+    "%s가 없으면 MISSING_REQUIRED_FIELD를 반환한다",
+    (field) => {
+      const payload = basePayload();
+      delete payload[field];
+      expect(validateVideoEvent(payload)).toEqual({
+        code: ERROR_CODES.MISSING_REQUIRED_FIELD,
+        field,
+      });
+    },
+  );
+
+  it.each(["anonymousId", "videoId", "watchedAt"])(
+    "%s가 빈 문자열이면 MISSING_REQUIRED_FIELD를 반환한다",
+    (field) => {
+      expect(validateVideoEvent(basePayload({ [field]: "" }))).toEqual({
+        code: ERROR_CODES.MISSING_REQUIRED_FIELD,
+        field,
+      });
+    },
+  );
+
+  it.each(["anonymousId", "videoId", "watchedAt"])(
+    "%s가 공백만 있으면 MISSING_REQUIRED_FIELD를 반환한다",
+    (field) => {
+      expect(validateVideoEvent(basePayload({ [field]: "   " }))).toEqual({
+        code: ERROR_CODES.MISSING_REQUIRED_FIELD,
+        field,
+      });
+    },
+  );
+
+  it.each(["anonymousId", "videoId", "watchedAt"])(
+    "%s가 문자열이 아니면(숫자) MISSING_REQUIRED_FIELD를 반환한다",
+    (field) => {
+      expect(validateVideoEvent(basePayload({ [field]: 123 }))).toEqual({
+        code: ERROR_CODES.MISSING_REQUIRED_FIELD,
+        field,
+      });
+    },
+  );
+});
+
+describe("validateVideoEvent — watchedAt 형식", () => {
+  it("파싱 불가능한 문자열이면 INVALID_FIELD_VALUE(watchedAt)를 반환한다", () => {
+    expect(validateVideoEvent(basePayload({ watchedAt: "not-a-date" }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "watchedAt",
+    });
+  });
+});
+
+describe("validateVideoEvent — sessionId (옵션 필드, 하위호환)", () => {
+  it.each([undefined, null])("%s이면 통과한다(구버전 확장 하위호환)", (value) => {
+    expect(validateVideoEvent(basePayload({ sessionId: value }))).toBeNull();
+  });
+
+  it("빈 문자열이면 거부한다", () => {
+    expect(validateVideoEvent(basePayload({ sessionId: "" }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "sessionId",
+    });
+  });
+
+  it("공백만 있으면 거부한다", () => {
+    expect(validateVideoEvent(basePayload({ sessionId: "   " }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "sessionId",
+    });
+  });
+
+  it("문자열이 아니면(숫자) 거부한다", () => {
+    expect(validateVideoEvent(basePayload({ sessionId: 123 }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "sessionId",
+    });
+  });
+
+  it("유효한 문자열이면 통과한다", () => {
+    expect(validateVideoEvent(basePayload({ sessionId: "s-abc" }))).toBeNull();
+  });
+});
+
+describe("validateVideoEvent — title (옵션, 검증 대상 아님)", () => {
+  it("title이 없어도 통과한다", () => {
+    const payload = basePayload();
+    delete payload.title;
+    expect(validateVideoEvent(payload)).toBeNull();
+  });
+});

--- a/server/test/routes/video-events.wiring.test.js
+++ b/server/test/routes/video-events.wiring.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// sessions.wiring.test.js와 동일한 이유: 실제 server/routes/video-events.js를 그대로
+// 로드해 배선(라우트 등록, 검증 함수 연결, DB insert)까지 검증한다. DB_PATH를 임시 파일로
+// 오버라이드해 운영 DB를 열 위험 없이 실제 파일을 require한다.
+const require = createRequire(import.meta.url);
+const TEST_DB_PATH = path.join(
+  os.tmpdir(),
+  `viewlens-video-events-wiring-${process.pid}.db`,
+);
+fs.rmSync(TEST_DB_PATH, { force: true });
+process.env.DB_ENCRYPTION_KEY = "vitest-in-memory-only";
+process.env.DB_PATH = TEST_DB_PATH;
+
+const { db, initializeDB } = require("../../db.js");
+initializeDB();
+
+const { errorHandler } = require("../../middleware/responseHandler.js");
+const videoEventsRouter = require("../../routes/video-events.js");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/video-events", videoEventsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+const app = buildApp();
+
+afterAll(() => {
+  db.close();
+  fs.rmSync(TEST_DB_PATH, { force: true });
+});
+
+beforeEach(() => {
+  db.exec("DELETE FROM video_events");
+});
+
+function basePayload(overrides = {}) {
+  return {
+    anonymousId: "wiring-user",
+    videoId: "wiring-v1",
+    watchedAt: "2026-08-13T09:00:00+09:00",
+    title: "테스트 영상",
+    sessionId: "wiring-s1",
+    ...overrides,
+  };
+}
+
+describe("실제 server/routes/video-events.js 라우터 배선", () => {
+  it("POST /api/video-events — 파일을 그대로 로드해도 정상 저장된다", async () => {
+    const res = await request(app)
+      .post("/api/video-events")
+      .send(basePayload());
+    expect(res.status).toBe(200);
+
+    const row = db
+      .prepare("SELECT * FROM video_events WHERE videoId = ?")
+      .get("wiring-v1");
+    expect(row.anonymousId).toBe("wiring-user");
+    expect(row.sessionId).toBe("wiring-s1");
+  });
+
+  it("POST /api/video-events — videoId 누락 시 400 (validateVideoEvent가 실제로 연결돼 있는지)", async () => {
+    const payload = basePayload();
+    delete payload.videoId;
+
+    const res = await request(app).post("/api/video-events").send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("MISSING_REQUIRED_FIELD");
+    expect(
+      db.prepare("SELECT COUNT(*) AS c FROM video_events").get().c,
+    ).toBe(0);
+  });
+
+  it("POST /api/video-events — sessionId 미전송(구버전 확장)이면 null로 저장된다", async () => {
+    const payload = basePayload();
+    delete payload.sessionId;
+
+    const res = await request(app).post("/api/video-events").send(payload);
+    expect(res.status).toBe(200);
+
+    const row = db
+      .prepare("SELECT * FROM video_events WHERE videoId = ?")
+      .get("wiring-v1");
+    expect(row.sessionId).toBeNull();
+  });
+
+  it("POST /api/video-events — sessionId가 빈 문자열이면 400", async () => {
+    const res = await request(app)
+      .post("/api/video-events")
+      .send(basePayload({ sessionId: "" }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_FIELD_VALUE");
+  });
+
+  it("등록되지 않은 경로는 404 — 예기치 않은 라우트가 실수로 노출되지 않았는지 확인", async () => {
+    const res = await request(app).get(
+      "/api/video-events/no-such-route",
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/test/scripts/backup-db-validate.test.js
+++ b/server/test/scripts/backup-db-validate.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidRemoteDir,
+  isValidRemoteRetention,
+} from "../../scripts/backup-db-validate.js";
+
+describe("isValidRemoteDir — 원격 쉘 명령(mkdir/find)에 삽입되는 디렉터리 검증", () => {
+  it.each(["db-backups", "backups/sub", "back_up-01", "a"])(
+    "영문/숫자/_/-// 로만 이뤄진 경로 '%s'는 허용한다",
+    (dir) => {
+      expect(isValidRemoteDir(dir)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["세미콜론으로 명령 연결", "db-backups; rm -rf /"],
+    ["&&로 명령 연결", "db-backups && whoami"],
+    ["파이프", "db-backups|cat /etc/passwd"],
+    ["백틱 명령 치환", "db-backups`whoami`"],
+    ["$() 명령 치환", "$(whoami)"],
+    ["공백 포함", "db backups"],
+    ["빈 문자열", ""],
+    ["개행 포함", "db-backups\nwhoami"],
+  ])("%s('%s')는 거부한다", (_label, dir) => {
+    expect(isValidRemoteDir(dir)).toBe(false);
+  });
+});
+
+describe("isValidRemoteRetention — 원격 find -mtime 인자로 쓰이는 보관일수 검증", () => {
+  it.each([0, 1, 14, 365])("%i(0 이상의 정수)는 허용한다", (value) => {
+    expect(isValidRemoteRetention(value)).toBe(true);
+  });
+
+  it.each([
+    ["음수", -1],
+    ["실수", 1.5],
+    ["숫자 문자열(타입 강제 변환 없음)", "14"],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+  ])("%s(%p)는 거부한다", (_label, value) => {
+    expect(isValidRemoteRetention(value)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 개요

video-events.js/popup-events.js 검증+라우트, youtube.js 전용 단위 테스트, db.js: addColumn, backup-db.js 셸 인젝션 방어를 구현했다. 검증 로직을 별도 파일로 분리해 단위 테스트하고, 실제 라우트 파일은 DB_PATH 환경변수로 임시 DB를 지정해 그대로 로드·검증하는 패턴이다. 목표는 커버리지 숫자가 아니라 연구 데이터 1차 수집 경로(고빈도 엔드포인트)와 사고 이력이 있는 로직의 회귀 방지선 구축이다.

### 구축한 테스트 환경 구조

```mermaid
flowchart LR
    subgraph L1["1. 단위 테스트<br/>(순수 로직, ESM import)"]
        direction TB
        UT["*-validate.test.js<br/>db.test.js · youtube.test.js"]
    end

    subgraph L2["2. 분리된 검증 모듈<br/><br/>((신규 운영 코드)"]
        direction TB
        VM["popup-events-validate.js<br/>video-events-validate.js<br/>backup-db-validate.js"]
    end

    subgraph L3["3. 라우트 배선 테스트<br/><br/>(CJS require + supertest)"]
        direction TB
        WT["popup-events.wiring.test.js<br/>video-events.wiring.test.js"]
    end

    subgraph L4["4. 실제 운영 파일"]
        direction TB
        RT["popup-events.js<br/>video-events.js"]
        DBJ["db.js<br/>(addColumn)"]
    end

    subgraph L5["임시 DB"]
        TMP[("os.tmpdir()/*.db<br/>운영 DB 아님")]
    end

    UT -->|"직접 호출, 모킹 없음"| VM
    VM -->|require| RT
    WT -->|"실제 HTTP 요청"| RT
    WT -->|"require(실제 파일 그대로)"| DBJ
    RT --> DBJ
    DBJ -->|"DB_PATH 환경변수로 지정"| TMP

```

3번 레이어에서 popup-events.js/video-events.js를 그대로 require해서, 검증 로직뿐 아니라 라우트 배선(에러 코드 매핑, DB insert 연결) 자체가 맞는지까지 확인한다. db.js는 DB_PATH 환경변수가 있으면 그 경로를, 없으면 운영 DB 경로를 쓰도록 되어 있어 테스트가 운영 DB 파일을 열 위험 없이 실제 파일을 그대로 실행할 수 있다.

## 변경 사항

- popup-events-validate.js, video-events-validate.js: 라우트에 있던 검증 로직 분리, 분리 과정에서 body가 null/배열/문자열이면 500이 나가던 버그 발견·수정(400으로 정정)
- popup-events.js, video-events.js 수정: 분리된 검증 모듈 호출로 교체
- db.js 수정: addColumn을 module.exports에 추가
- backup-db-validate.js 신규: offsitePush의 셸 인젝션 방어 로직
- server/scripts/backup-db.js 수정: 검증 두 줄을 분리 함수 호출로 교체

## 관련 이슈

- closes #167  

## 테스트 확인

- [x]  pnpm test  472개 테스트 전부 통과
- [x]  pnpm test:coverage P1 대상 파일 전부 0%(또는 간접 커버)에서 유효 커버리지로 상승 확인
- [x]  콘솔 에러 없음 
- [x]  로컬에서 확장 프로그램 리로드 후 정상 동작 확인 

## 스크린샷 (UI 변경 시)
<img width="900" alt="image" src="https://github.com/user-attachments/assets/a6b13863-b5c3-415e-afd7-cb4645dc3fa2" />
