### PR TITLE
test: P2 테스트 공백 보완 및 진행 기록

### DIFF
--- a/extension/test/pipeline/analysis.perf.test.js
+++ b/extension/test/pipeline/analysis.perf.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { aggregateDailyData } from "../../pipeline/analysis.js";
+
+// 80명 규모 확대를 앞두고, aggregateDailyData(참여자 1명의 세션 목록)가
+// 실제로 다룰 수 있는 세션 수 구간에서 처리 시간이 어떻게 변하는지 실측·기록한다.
+// 회귀를 좁게 검증하는 테스트가 아니라 관찰 기록이므로, 임계값은 "명백한 성능
+// 재앙(예: 실수로 O(n^2) 코드가 섞임)"만 잡아내도록 넉넉하게 잡는다.
+
+function buildSessions(count) {
+  const categories = ["게임", "음악", "뉴스 & 정치", "코미디", "교육"];
+  const now = Date.now();
+  const sessions = [];
+  for (let i = 0; i < count; i++) {
+    const categoryDistribution = {};
+    let remaining = 1;
+    for (let c = 0; c < categories.length - 1; c++) {
+      const share = Math.round(((remaining * Math.random()) / 2) * 1000) / 1000;
+      categoryDistribution[categories[c]] = share;
+      remaining -= share;
+    }
+    categoryDistribution[categories[categories.length - 1]] =
+      Math.round(remaining * 1000) / 1000;
+
+    sessions.push({
+      endTime: new Date(now - (i % 7) * 86400000 - i * 1000).toISOString(),
+      videoCount: 1 + (i % 20),
+      categoryDistribution,
+    });
+  }
+  return sessions;
+}
+
+describe("aggregateDailyData 성능 실측 (P2-④, 관찰용)", () => {
+  it.each([100, 1000])("세션 %i개를 넉넉한 시간 안에 처리한다", (count) => {
+    const sessions = buildSessions(count);
+
+    const start = performance.now();
+    const result = aggregateDailyData(sessions);
+    const elapsedMs = performance.now() - start;
+
+    console.log(
+      `[perf] aggregateDailyData(${count}건) = ${elapsedMs.toFixed(2)}ms`,
+    );
+
+    expect(result.dates).toHaveLength(7);
+    // O(n) 구조 기준 정상 범위의 수십~수백 배 여유를 둔 넉넉한 상한.
+    // 이 값을 넘기면 알고리즘 복잡도 자체가 바뀐 것으로 의심할 수 있다.
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+});

--- a/server/test/middleware/responseHandler.test.js
+++ b/server/test/middleware/responseHandler.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  success,
+  fail,
+  errorHandler,
+  ERROR_CODES,
+} from "../../middleware/responseHandler.js";
+
+function createMockRes() {
+  const res = {
+    statusCode: null,
+    body: null,
+  };
+  res.status = vi.fn((code) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.json = vi.fn((payload) => {
+    res.body = payload;
+    return res;
+  });
+  return res;
+}
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe("success", () => {
+  it("기본값으로 200과 success:true, data:null을 응답한다", () => {
+    const res = createMockRes();
+
+    success(res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.body).toEqual({ success: true, message: "ok", data: null });
+  });
+
+  it("전달한 data/message를 그대로 담아 응답한다", () => {
+    const res = createMockRes();
+
+    success(res, { id: 1 }, "생성됨");
+
+    expect(res.body).toEqual({
+      success: true,
+      message: "생성됨",
+      data: { id: 1 },
+    });
+  });
+});
+
+describe("fail", () => {
+  it("개발 환경(NODE_ENV=development)에서는 detail을 그대로 노출한다", () => {
+    process.env.NODE_ENV = "development";
+    const res = createMockRes();
+
+    fail(res, 400, ERROR_CODES.INVALID_FIELD_VALUE, "잘못된 값", {
+      field: "videoCount",
+    });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: "잘못된 값",
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      detail: { field: "videoCount" },
+    });
+  });
+
+  it("프로덕션 환경(NODE_ENV=production)에서는 detail을 숨긴다", () => {
+    process.env.NODE_ENV = "production";
+    const res = createMockRes();
+
+    fail(res, 500, ERROR_CODES.INTERNAL_SERVER_ERROR, "서버 오류", {
+      stack: "민감한 내부 정보",
+    });
+
+    expect(res.body.detail).toBeNull();
+    expect(JSON.stringify(res.body)).not.toContain("민감한 내부 정보");
+  });
+
+  it("인자를 생략하면 기본값(500, INTERNAL_SERVER_ERROR)으로 응답한다", () => {
+    process.env.NODE_ENV = "development";
+    const res = createMockRes();
+
+    fail(res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.body.code).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
+    expect(res.body.message).toBe("서버 오류가 발생했습니다.");
+    expect(res.body.detail).toBeNull();
+  });
+});
+
+describe("errorHandler", () => {
+  it("err.status/err.code/err.message/err.detail을 그대로 fail에 전달한다", () => {
+    process.env.NODE_ENV = "development";
+    const res = createMockRes();
+    const req = { method: "POST", path: "/api/sessions" };
+    const err = {
+      status: 409,
+      code: "DUPLICATE_SESSION",
+      message: "이미 존재하는 세션입니다.",
+      detail: { sessionId: "abc" },
+    };
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    errorHandler(err, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.body).toEqual({
+      success: false,
+      message: "이미 존재하는 세션입니다.",
+      code: "DUPLICATE_SESSION",
+      detail: { sessionId: "abc" },
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("err에 status/code/detail이 없으면 기본값(500, INTERNAL_SERVER_ERROR, detail:null)으로 응답한다", () => {
+    process.env.NODE_ENV = "development";
+    const res = createMockRes();
+    const req = { method: "GET", path: "/api/participants" };
+    const err = new Error("예상치 못한 오류");
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    errorHandler(err, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.body.code).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
+    expect(res.body.message).toBe("예상치 못한 오류");
+    expect(res.body.detail).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("프로덕션 환경에서는 err.detail도 숨긴다", () => {
+    process.env.NODE_ENV = "production";
+    const res = createMockRes();
+    const req = { method: "GET", path: "/api/participants" };
+    const err = { status: 500, detail: { internalPath: "/secret" } };
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    errorHandler(err, req, res, vi.fn());
+
+    expect(res.body.detail).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/server/test/pipeline/period-boundaries.perf.test.js
+++ b/server/test/pipeline/period-boundaries.perf.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mergeSessionDistributions } from "../../pipeline/period-boundaries.js";
+
+// 80명 규모 확대를 앞두고, mergeSessionDistributions(참여자 1명의 한 기간 내
+// 세션 목록)가 실제로 다룰 수 있는 세션 수 구간에서 처리 시간이 어떻게 변하는지
+// 실측·기록한다. 회귀를 좁게 검증하는 테스트가 아니라 관찰 기록이므로, 임계값은
+// "명백한 성능 재앙(예: 실수로 O(n^2) 코드가 섞임)"만 잡아내도록 넉넉하게 잡는다.
+
+function buildSessions(count) {
+  const categories = ["게임", "음악", "뉴스 & 정치", "코미디", "교육"];
+  const sessions = [];
+  for (let i = 0; i < count; i++) {
+    const categoryDistribution = {};
+    let remaining = 1;
+    for (let c = 0; c < categories.length - 1; c++) {
+      const share = Math.round(((remaining * Math.random()) / 2) * 1000) / 1000;
+      categoryDistribution[categories[c]] = share;
+      remaining -= share;
+    }
+    categoryDistribution[categories[categories.length - 1]] =
+      Math.round(remaining * 1000) / 1000;
+
+    sessions.push({
+      videoCount: 1 + (i % 20),
+      categoryDistribution,
+    });
+  }
+  return sessions;
+}
+
+describe("mergeSessionDistributions 성능 실측 (P2-④, 관찰용)", () => {
+  it.each([100, 1000])("세션 %i개를 넉넉한 시간 안에 처리한다", (count) => {
+    const sessions = buildSessions(count);
+
+    const start = performance.now();
+    const result = mergeSessionDistributions(sessions);
+    const elapsedMs = performance.now() - start;
+
+    console.log(
+      `[perf] mergeSessionDistributions(${count}건) = ${elapsedMs.toFixed(2)}ms`,
+    );
+
+    expect(result.videoCount).toBeGreaterThan(0);
+    // O(n) 구조 기준 정상 범위의 수십~수백 배 여유를 둔 넉넉한 상한.
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+});

--- a/server/test/scripts/check-duplicate-participants.test.js
+++ b/server/test/scripts/check-duplicate-participants.test.js
@@ -1,0 +1,211 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import Database from "better-sqlite3-multiple-ciphers";
+import crypto from "crypto";
+import {
+  run,
+  fingerprint,
+} from "../../scripts/check-duplicate-participants.js";
+
+function createTestDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE participants (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      anonymousId TEXT NOT NULL UNIQUE,
+      participantCode TEXT,
+      group_code TEXT NOT NULL,
+      installDate TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function insertParticipant(
+  db,
+  { anonymousId, participantCode, groupCode, installDate },
+) {
+  db.prepare(
+    "INSERT INTO participants (anonymousId, participantCode, group_code, installDate) VALUES (?, ?, ?, ?)",
+  ).run(anonymousId, participantCode, groupCode, installDate);
+}
+
+function sha10(value) {
+  return crypto.createHash("sha256").update(String(value)).digest("hex").slice(0, 10);
+}
+
+describe("fingerprint", () => {
+  it("같은 입력에 대해 항상 같은 지문을 반환한다", () => {
+    expect(fingerprint("QWE-K7M2")).toBe(fingerprint("QWE-K7M2"));
+  });
+
+  it("다른 입력에 대해 다른 지문을 반환한다", () => {
+    expect(fingerprint("QWE-K7M2")).not.toBe(fingerprint("ASD-9X3P"));
+  });
+
+  it("SHA-256 해시의 앞 10자와 일치한다", () => {
+    expect(fingerprint("QWE-K7M2")).toBe(sha10("QWE-K7M2"));
+  });
+
+  it.each([null, undefined, ""])(
+    "빈 값(%s)은 (none)을 반환한다",
+    (value) => {
+      expect(fingerprint(value)).toBe("(none)");
+    },
+  );
+});
+
+describe("run", () => {
+  let db;
+  let logSpy;
+
+  beforeEach(() => {
+    db = createTestDb();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    db.close();
+    logSpy.mockRestore();
+  });
+
+  function loggedOutput() {
+    return logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+  }
+
+  it("중복이 없으면 통과 메시지만 출력한다", () => {
+    insertParticipant(db, {
+      anonymousId: "user-1",
+      participantCode: "QWE-K7M2",
+      groupCode: "EXP",
+      installDate: "2026-06-01T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "user-2",
+      participantCode: "ASD-9X3P",
+      groupCode: "CON",
+      installDate: "2026-06-01T00:00:00+09:00",
+    });
+
+    run(db);
+
+    expect(loggedOutput()).toContain("중복 등록 없음");
+  });
+
+  it("participantCode가 NULL인 행은 서로 다른 참여자여도 중복으로 잡히지 않는다", () => {
+    insertParticipant(db, {
+      anonymousId: "user-1",
+      participantCode: null,
+      groupCode: "EXP",
+      installDate: "2026-06-01T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "user-2",
+      participantCode: null,
+      groupCode: "CON",
+      installDate: "2026-06-02T00:00:00+09:00",
+    });
+
+    run(db);
+
+    expect(loggedOutput()).toContain("중복 등록 없음");
+  });
+
+  it("같은 participantCode로 여러 번 등록된 경우 건수와 지문을 출력한다", () => {
+    insertParticipant(db, {
+      anonymousId: "user-earliest",
+      participantCode: "QWE-K7M2",
+      groupCode: "EXP",
+      installDate: "2026-06-01T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "user-later",
+      participantCode: "QWE-K7M2",
+      groupCode: "EXP",
+      installDate: "2026-06-10T00:00:00+09:00",
+    });
+
+    run(db);
+
+    const output = loggedOutput();
+    expect(output).toContain("중복 참여코드 1건 발견");
+    expect(output).toContain(`participantCode(지문)=${sha10("QWE-K7M2")}`);
+    expect(output).toContain("(2건)");
+  });
+
+  it("출력에 원본 participantCode/anonymousId가 그대로 노출되지 않는다", () => {
+    insertParticipant(db, {
+      anonymousId: "sensitive-anon-id-1",
+      participantCode: "SECRET-CODE-1",
+      groupCode: "EXP",
+      installDate: "2026-06-01T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "sensitive-anon-id-2",
+      participantCode: "SECRET-CODE-1",
+      groupCode: "EXP",
+      installDate: "2026-06-05T00:00:00+09:00",
+    });
+
+    run(db);
+
+    const output = loggedOutput();
+    expect(output).not.toContain("SECRET-CODE-1");
+    expect(output).not.toContain("sensitive-anon-id-1");
+    expect(output).not.toContain("sensitive-anon-id-2");
+  });
+
+  it("installDate는 마스킹하지 않고 그대로 출력한다", () => {
+    insertParticipant(db, {
+      anonymousId: "user-earliest",
+      participantCode: "QWE-K7M2",
+      groupCode: "EXP",
+      installDate: "2026-06-01T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "user-later",
+      participantCode: "QWE-K7M2",
+      groupCode: "EXP",
+      installDate: "2026-06-10T00:00:00+09:00",
+    });
+
+    run(db);
+
+    const output = loggedOutput();
+    expect(output).toContain("2026-06-01T00:00:00+09:00");
+    expect(output).toContain("2026-06-10T00:00:00+09:00");
+  });
+
+  it("서로 다른 participantCode의 중복은 각각 별도로 집계된다", () => {
+    insertParticipant(db, {
+      anonymousId: "user-1",
+      participantCode: "AAA-1111",
+      groupCode: "EXP",
+      installDate: "2026-06-01T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "user-2",
+      participantCode: "AAA-1111",
+      groupCode: "EXP",
+      installDate: "2026-06-02T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "user-3",
+      participantCode: "BBB-2222",
+      groupCode: "CON",
+      installDate: "2026-06-03T00:00:00+09:00",
+    });
+    insertParticipant(db, {
+      anonymousId: "user-4",
+      participantCode: "BBB-2222",
+      groupCode: "CON",
+      installDate: "2026-06-04T00:00:00+09:00",
+    });
+
+    run(db);
+
+    const output = loggedOutput();
+    expect(output).toContain("중복 참여코드 2건 발견");
+    expect(output).toContain(`participantCode(지문)=${sha10("AAA-1111")}`);
+    expect(output).toContain(`participantCode(지문)=${sha10("BBB-2222")}`);
+  });
+});

--- a/server/test/scripts/check-duplicate-participants.test.js
+++ b/server/test/scripts/check-duplicate-participants.test.js
@@ -149,6 +149,13 @@ describe("run", () => {
     run(db);
 
     const output = loggedOutput();
+    // 탐지 자체가 안 됐거나 조용히 실패해 원본이 우연히 안 찍힌 경우를 걸러내기 위해,
+    // 지문/건수가 실제로 출력됐는지부터 확인한 뒤에 원본 미노출을 검증한다.
+    expect(output).toContain("중복 참여코드 1건 발견");
+    expect(output).toContain(`participantCode(지문)=${sha10("SECRET-CODE-1")}`);
+    expect(output).toContain(sha10("sensitive-anon-id-1"));
+    expect(output).toContain(sha10("sensitive-anon-id-2"));
+
     expect(output).not.toContain("SECRET-CODE-1");
     expect(output).not.toContain("sensitive-anon-id-1");
     expect(output).not.toContain("sensitive-anon-id-2");


### PR DESCRIPTION
## 개요

P2였던 엣지케이스·안정성 향상 항목 중 3개를 구현했다. 커버리지 숫자를 올리는 것이 아니라, 지금까지 코드 주석과 암묵적 동작으로만 존재하던 보안·프라이버시 계약(프로덕션 응답에서 에러 상세 마스킹, 참여자 원본 정보 미노출)을 실제 테스트로 고정하고, 80명 규모 확대를 앞두고 대량 데이터 처리 성능이 안전한지 실측하는 데 초점을 맞췄다.

## 변경 사항

```mermaid
flowchart TB
    subgraph impl["구현 완료 (0/3 → 3/3)"]
        A["check-duplicate-participants.js<br/>run / fingerprint"]
        B["responseHandler.js<br/>fail() production 분기"]
        C["성능 벤치마크<br/>aggregateDailyData / mergeSessionDistributions"]
    end

    subgraph excluded["스코프 제외 (근거 확인 후 승인)"]
        D["categories.js<br/>getCategoryName"]
        E["팝업 UI 렌더링<br/>viewlens-screens.js 등"]
    end

    A -->|"테스트 12개 추가<br/>커버리지 0% → 81.48%"| AR["방지: 중복 참여자 오탐지<br/>원본 참여코드/anonymousId 로그 노출"]
    B -->|"테스트 8개 추가<br/>커버리지 50% → 80%"| BR["방지: 프로덕션 응답에서<br/>에러 상세(detail) 노출"]
    C -->|"100~1,000세션 실측<br/>O(n) 확인, 2s 미만"| CR["방지: 80명 규모 확대 시<br/>대량 데이터 성능 저하 회귀"]

    D -->|"analysis.test.js가 이미<br/>두 분기 100% 간접 커버"| DX["추가 테스트로 방지되는<br/>위험 없음 → 제외"]
    E -->|"DOM 자동화 비용 대비<br/>효과 낮음(08문서 결론)"| EX["수동 QA로 대체 권장 → 제외"]

    style impl fill:#1f3d2b,color:#fff
    style excluded fill:#3d1f1f,color:#fff

```

- check-duplicate-participants.js
  - 참여코드 기반 재설치 복구 배포 전 점검 스크립트의 `run`/`fingerprint`에 단위 테스트 12개 추가  
  - 중복 참여코드 탐지 로직(그룹핑, `participantCode IS NULL` 제외, 여러 코드 독립 집계) 검증
  - 헤더 주석에 명시된 "원본(participantCode/anonymousId)은 로그에 남기지 않고 해시로만 출력" 보안 계약을 실제 어서션으로 고정
- responseHandler.js
  - success/fail/errorHandler에 단위 테스트 8개 추가
  - `NODE_ENV=production`일 때 에러 `detail`이 응답에서 숨겨지는지(민감 정보 미노출) 검증   
- 대량 데이터 처리 성능 벤치마크 테스트 4개 추가(`aggregateDailyData`, `mergeSessionDistributions`)
  - 참여자 1명이 실제로 발생시킬 수 있는 규모(100세션)와 여유 상한(1,000세션)에서 처리 시간 실측
  - 결과: 두 함수 모두 O(n) 구조로 세션 수가 늘어도 처리 시간이 거의 증가하지 않음(100건 `0.58~23ms`, 1,000건 `2.42~4.82ms`)   
  - 엄격한 회귀 임계값 대신 명백한 알고리즘 복잡도 문제만 잡아내는 넉넉한 상한(2,000ms)만 설정, 실측값은 콘솔에 기록

## 관련 이슈

- closes #169 

## 테스트 확인

- [x] `pnpm test` 전체 스위트 통과 (33 files/472 tests → 37 files/496 tests, +4 파일/+24 케이스)
- [x] `pnpm test:coverage`로 대상 파일 커버리지 확인
  - `check-duplicate-participants.js`: 0% → 81.48%/83.33%/66.66%/80.76%(Stmts/Branch/Funcs/Lines)
  - `responseHandler.js`: 50% → 80%/75%/100%/80%(간접→직접)
- [x] 콘솔 에러 없음
- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인

## 스크린샷 (UI 변경 시)
<img width="900" alt="image" src="https://github.com/user-attachments/assets/b03dc471-3543-4aac-8df9-d1dd95914209" />


## 참고 사항

- P2 원래 5개 항목 중 2개는 착수 전/사전 지표 측정 단계에서 근거를 확인해 사용자 승인 하에 스코프 제외했다.
  - 팝업 UI 렌더링(`viewlens-screens.js` 등): DOM 자동화 비용 대비 효과가 낮다는 결론을 따름(수동 QA)
  - categories.js: getCategoryName: 사전 지표 측정 중 `analysis.test.js`가 이미 두 분기(등록 ID/미등록 ID→"기타" 폴백)를 간접으로 100% 커버하고 있음을 확인, 추가 테스트로 새로 방지되는 위험이 없어 제외  
- `responseHandler.js` 테스트 작성 중 v8 커버리지 리포트가 실제로 실행되는 두 줄(`errorHandler` 내부 `const status =`/`const code =`)을 "not covered"로 잘못 표시하는 현상을 확인했다. 어서션으로 실제 동작은 검증됐고, 다국어(한글) 주석의 UTF-8 바이트 오프셋 드리프트로 추정되는 도구 측 오차로 판단해 코드는 건드리지 않았다.