### PR TITLE
ci: CI에 테스트 실행 추가, CD는 CI 통과 후 rsync로 배포하도록 전환

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - name: Install server dependencies
-        run: pnpm install --prod --filter server
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Validate server syntax
         run: |
@@ -36,3 +36,6 @@ jobs:
         run: |
           node -e "JSON.parse(require('fs').readFileSync('extension/manifest.json', 'utf8'))"
           echo "manifest.json is valid JSON"
+
+      - name: Run test suite
+        run: pnpm test

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,21 +1,47 @@
 name: Deploy Server
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "server/**"
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
 
-# 이 워크플로는 SSH로 서버에 접속해 배포할 뿐 GITHUB_TOKEN으로 GitHub API를 호출하는
-# 단계가 없다 — 최소 권한 원칙에 따라 기본 상속 권한을 전부 꺼둔다.
 permissions: {}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     steps:
-      - name: Deploy to Oracle Cloud
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Load SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Sync runtime files to server
+        run: |
+          rsync -avz \
+            --exclude='.git/' \
+            --exclude='.github/' \
+            --exclude='docs/' \
+            --exclude='extension/' \
+            --exclude='node_modules/' \
+            --exclude='server/test/' \
+            --exclude='server/node_modules/' \
+            --exclude='server/.env' \
+            --exclude='server/*.db*' \
+            -e "ssh -o StrictHostKeyChecking=no" \
+            ./ ubuntu@${{ secrets.SERVER_HOST }}:~/youtube-bias-feedback/
+
+      - name: Install deps & restart
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -26,8 +52,7 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             cd ~/youtube-bias-feedback
-            git checkout main
-            git pull origin main
+            rm -rf server/test extension docs .github .git
             pnpm install --prod
             if [ -z "${{ secrets.DB_ENCRYPTION_KEY }}" ]; then
               echo "DB_ENCRYPTION_KEY secret이 비어 있어 배포를 중단합니다." >&2

--- a/extension/test/background.e2e.test.js
+++ b/extension/test/background.e2e.test.js
@@ -5,6 +5,17 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 // 실제 확장 동작에 영향이 없다. 모듈 최상단이 chrome.alarms.create 등 부작용을 즉시 실행하므로,
 // 매 테스트마다 chrome 목을 새로 세팅한 뒤 vi.resetModules()로 모듈을 새로 import한다
 
+// config.js는 gitignore 대상이라 로컬엔 개발자가 미리 채워둔 실제 값이 있을 수 있지만,
+// CI처럼 새로 체크아웃한 환경에선 scripts/ensure-config.js가 config.example.js를 그대로
+// 복사해 SERVER_URL이 "YOUR_SERVER_URL_HERE" placeholder로 남는다. background.js는 이
+// placeholder를 보면 postSessionToServer를 조용히 건너뛰므로, 로컬에서만 우연히 통과하고
+// CI에서는 항상 실패하는 결과가 났었다. 테스트가 로컬 파일 상태에 좌우되지 않도록 고정값으로 목킹한다.
+vi.mock("../config.js", () => ({
+  SERVER_URL: "http://localhost:3000",
+  YOUTUBE_API_KEY: "test-youtube-key",
+  GEMINI_API_KEY: "test-gemini-key",
+}));
+
 function createChromeMock() {
   let store = {};
   return {


### PR DESCRIPTION
## 개요

CI가 로컬 테스트를 한 번도 실행하지 않고, CD는 CI 결과와 무관하게 독립 트리거되던 문제를 고쳤다. 동시에 배포 방식을 `git pull`에서 `rsync`로 바꿔, 테스트 코드·문서·확장 소스 같은 서버 실행에 불필요한 파일이 프로덕션 서버에 쌓이지 않도록 했다.

> rsync는 원격 및 로컬 환경에서 파일과 폴더를 빠르고 효율적으로 복사하고 동기화하는 오픈소스 명령어 도구이다. 전체 파일을 매번 다시 복사하지 않고, 기존 파일과 새 파일의 변경된 부분만 찾아 전송하므로 속도가 매우 빠르고 네트워크 자원을 아낄 수 있다.

## 변경 사항

### ci.yml
  - `pnpm install --prod --filter server` → `pnpm install --frozen-lockfile`(전체 워크스페이스 설치, `vitest`/`supertest` 등 devDependency 포함)  
  - 마지막에 `pnpm test` 단계 추가 
### .github/workflows/deploy-server.yml
  - 트리거를 `push`(경로 필터 `server/**`) → `workflow_run: workflows: ["CI"]`로 교체, `conclusion == 'success' && head_branch == 'main'`일 때만 배포  
  - `git checkout main; git pull origin main` → `rsync`로 필요한 파일만 전송하는 방식으로 교체
    - `--delete`는 의도적으로 쓰지 않음 (서버에만 있는 `.env`/실제 연구 데이터 DB(`*.db*`)/`node_modules`가 자동으로 지워지는 걸 원천 차단하기 위함)  
    - 대신 더 이상 동기화하지 않는 5개 디렉터리(`server/test`, `extension`, `docs`, `.github`, `.git`)만 배포 스크립트에서 이름을 못박아 명시적으로 `rm -rf` (이미 없으면 no-op이라 매 배포 반복 실행해도 안전)  
    - 네이티브 모듈(`better-sqlite3-multiple-ciphers`)은 여전히 서버에서 직접 `pnpm install --prod` (CI 러너에서 빌드해 보내면 아키텍처 불일치로 깨질 수 있어 그대로 둠)
    - `webfactory/ssh-agent`로 기존 `SSH_PRIVATE_KEY` 시크릿을 재사용  

## 테스트 확인

- [x] `pnpm install --frozen-lockfile` 로컬 재현 성공(락파일과 일치, CI와 동일 명령)
- [x] `pnpm test` 로컬 실행 → 37 files / 496 tests 전부 통과(CI가 그대로 실행할 명령과 동일)
- [x] 두 워크플로 YAML 문법 검증(`yaml.safe_load`) 통과
- [x] 실제 GitHub Actions 상에서 `workflow_run` 트리거 동작 확인 (main 병합 후에만 확인 가능)  
- [x] Oracle 서버에 `rsync` 설치 여부 확인  
- [x] 콘솔 에러 없음
