### PR TITLE
feat: 최소 관제 체계(MVM) 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,15 @@ jobs:
           node --check server/db.js
           node --check server/routes/sessions.js
           node --check server/routes/surveys.js
+          node --check server/routes/health.js
           node --check server/middleware/responseHandler.js
+          node --check server/monitoring/healthchecks-ping.js
+          node --check server/monitoring/state.js
+          node --check server/monitoring/server-health-check.js
+          node --check server/monitoring/error-monitor.js
+          node --check server/monitoring/research-pipeline-monitor.js
+          bash -n server/scripts/period-reviews-checked.sh
+          bash -n server/scripts/backup-checked.sh
 
       - name: Validate extension manifest
         run: |

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -63,4 +63,9 @@ jobs:
             echo "DB_ENCRYPTION_KEY=${{ secrets.DB_ENCRYPTION_KEY }}" >> server/.env
             echo "PERIOD_REVIEW_GEMINI_API_KEY=${{ secrets.PERIOD_REVIEW_GEMINI_API_KEY }}" >> server/.env
             echo "STUDY_END_REVEAL_CODE=${{ secrets.STUDY_END_REVEAL_CODE }}" >> server/.env
+            echo "SERVER_HEALTH_PING_URL=${{ secrets.SERVER_HEALTH_PING_URL }}" >> server/.env
+            echo "ERROR_MONITOR_PING_URL=${{ secrets.ERROR_MONITOR_PING_URL }}" >> server/.env
+            echo "RESEARCH_PIPELINE_PING_URL=${{ secrets.RESEARCH_PIPELINE_PING_URL }}" >> server/.env
+            echo "HEALTH_URL=https://viewlens.site/health" >> server/.env
+            echo "ERROR_LOG_PATH=/home/ubuntu/.pm2/logs/youtube-bias-server-error.log" >> server/.env
             pm2 restart youtube-bias-server

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -66,6 +66,9 @@ jobs:
             echo "SERVER_HEALTH_PING_URL=${{ secrets.SERVER_HEALTH_PING_URL }}" >> server/.env
             echo "ERROR_MONITOR_PING_URL=${{ secrets.ERROR_MONITOR_PING_URL }}" >> server/.env
             echo "RESEARCH_PIPELINE_PING_URL=${{ secrets.RESEARCH_PIPELINE_PING_URL }}" >> server/.env
+            echo "DB_BACKUP_NIGHT_PING_URL=${{ secrets.DB_BACKUP_NIGHT_PING_URL }}" >> server/.env
+            echo "DB_BACKUP_MORNING_PING_URL=${{ secrets.DB_BACKUP_MORNING_PING_URL }}" >> server/.env
+            echo "PERIOD_REVIEWS_PING_URL=${{ secrets.PERIOD_REVIEWS_PING_URL }}" >> server/.env
             echo "HEALTH_URL=https://viewlens.site/health" >> server/.env
             echo "ERROR_LOG_PATH=/home/ubuntu/.pm2/logs/youtube-bias-server-error.log" >> server/.env
             pm2 restart youtube-bias-server

--- a/docs/07-작업5.md
+++ b/docs/07-작업5.md
@@ -700,6 +700,8 @@
 - **Ping URL 출처를 두 가지로 분리**: 신규 Node 기반 모니터 3개(`server-health-check.js`/`error-monitor.js`/`research-pipeline-monitor.js`)는 각자 `server/.env`를 로드해 ping URL을 읽는다. 반면 저장소로 편입한 bash 래퍼 2개(`period-reviews-checked.sh`/`backup-checked.sh`)는 `.env`를 파싱하지 않고 crontab 라인의 실행 인자로 ping URL을 받는다(같은 스크립트를 밤/아침 두 크론에서 다른 URL로 재사용).
 - **⚠️ 구현 중 발견한 버그 — 배포 시 신규 env 값이 매번 초기화됨**: `deploy-server.yml`이 배포마다 `server/.env`를 통째로 새로 쓰는데(`> server/.env`), 신규 모니터링 키를 여기에 반영하지 않으면 서버에 수동으로 넣어도 다음 배포 때 조용히 사라지는 구조였다 — 이 Epic 자체가 막으려는 문제(조용한 실패)를 배포 스크립트가 스스로 재현할 뻔했다. `deploy-server.yml`에 3개 ping URL(GitHub Secrets)과 민감하지 않은 `HEALTH_URL`/`ERROR_LOG_PATH`(고정값)를 추가해 해결했다.
 - **백업 성공 판정 — exit code만으론 부족함을 재확인**: `backup-db.js`의 오프사이트(E1) 전송은 best-effort라 실패해도 exit 0을 반환한다(기존 설계). `backup-checked.sh`가 exit code뿐 아니라 출력 로그의 "오프사이트 전송 실패" 문구까지 확인해야만 성공으로 ping하도록, 기존 서버 로컬 래퍼의 설계 원칙을 저장소 코드로 그대로 재현했다.
+- **⚠️ 에러 로그 무음 처리 버그(코드리뷰 지적 반영)**: `readNewText()`가 "로그 파일 없음/읽기 실패"와 "파일은 있는데 새 내용 없음"을 구분하지 않고 둘 다 빈 문자열로 반환해, `ERROR_LOG_PATH`가 잘못돼도 매번 성공 ping을 보내는 무음 실패가 있었다(이 Epic이 막으려는 문제를 감시 스크립트 자신이 재현하는 셈이라 심각도 높음으로 판단). `ok`/`reason` 필드를 추가해 파일 접근 실패 시 즉시 `/fail` ping을 보내도록 수정.
+- **동시 실행 경쟁 상태 — 코드가 아니라 crontab 레벨(`flock -n`)에서 방어(코드리뷰 지적 검토 후 다른 방식 채택)**: 상태 파일(`state.js`)을 읽고-판단하고-쓰는 구간이 같은 스크립트의 두 실행에서 겹치면 중복 알림·카운트 불일치가 생길 수 있다는 지적을 받았다. 다만 실행 주기(10분~6시간)가 실제 실행 시간(수 초, ping은 10초 상한)보다 훨씬 길어 예약 실행끼리 겹칠 확률은 사실상 0이고, 겹치는 유일한 현실적 경우는 수동 실행과 예약 실행이 우연히 마주치는 것뿐이다. 애플리케이션 코드에 락(스테일 락 처리 등 부가 복잡도 필요)을 직접 구현하는 대신, crontab 각 줄을 `flock -n /tmp/viewlens-<name>.lock`으로 감싸 OS 표준 도구로 해결했다(`docs/blog/wiki/Monitoring-and-Operations.md` 5절) — 코드·테스트 변경 없음.
 
 #### Tasks
 

--- a/docs/07-작업5.md
+++ b/docs/07-작업5.md
@@ -671,3 +671,65 @@
 - [x] (2026-08-29 후속 5) 코드리뷰로 테스트 결함 발견·수정 — `study-end-gate.test.js`의 레이트리밋 테스트가 모듈 최상단에서 한 번만 만든 공유 `app`(따라서 공유 `validateRateLimit` 상태)을 썼다. 앞선 테스트들의 POST가 같은 IP 할당량을 이미 소비해, `max`가 5가 아니라 1이어도 우연히 통과할 수 있는 구조였다(직접 `max: 1`로 바꿔 재현 확인 후 되돌림). 이 테스트만 `buildApp()`을 다시 호출해 전용 rate limiter 인스턴스를 쓰도록 격리하고, 첫 5회는 200·6번째는 429를 각각 단언하도록 변경(`server/test/routes/study-end-gate.test.js`). 테스트 개수 변화 없음(로직 강화), 362개 유지.
 
 - 관련 문서: `docs/08-테스트전략.md`, `docs/blog/테스트/09-P0테스트-진행기록.md`
+
+---
+
+## Epic: 최소 관제 체계(MVM) 구축 — 서버/에러/파이프라인 침묵 장애 감시
+
+- 설명: "1차 테스트 파일럿 운영 중 발견된 배포·파이프라인 결함 대응" Epic(위)에서 도입한 Healthchecks.io 데드맨스위치 3개(`period-reviews`/`backup-night`/`backup-morning`)는 서버 로컬 파일(`~/bin/*.sh`)로만 존재해 저장소에 코드가 없었고, 서버/DB 헬스체크·에러 로그 감시·**연구 데이터 수집 파이프라인 자체의 침묵 장애 감시**는 전혀 없었다. `extension/content.js`가 YouTube의 `yt-navigate-finish` 이벤트와 `document.title` DOM 파싱에 의존해 시청을 감지하는데, YouTube가 이 구조를 바꾸면 에러 없이 조용히 감지가 멈출 수 있다는 것이 이 시스템에서 가장 위험한 Silent Failure 시나리오로 식별됐다. 이 Epic은 6주 연구 기간 동안 관리자가 매일 서버에 접속하지 않아도 서버 다운·DB 실패·크론 중단·심각한 에러·데이터 수집 파이프라인 중단을 이메일로 놓치지 않도록 하는 최소 관제 체계를 구축한다.
+- 진행 현황: **코드 구현 완료**(아래 이슈 1). Healthchecks.io 신규 체크 생성·GitHub Secrets 등록·서버 crontab 갱신 등 **운영 활성화는 사용자가 서버/GitHub에서 직접 수행해야 하는 남은 작업**(Claude Code 세션이 SSH·gh CLI 접근 권한이 없어 대행 불가).
+- 착수 순서: 공유 인프라(ping 헬퍼·상태 저장소) → 서버/에러 감시 → 파이프라인 침묵 감시 → 기존 3체크 저장소 편입 → 문서화, 총 5단계로 순차 진행(각 단계마다 전체 테스트 스위트 회귀 확인 후 커밋).
+- 관련 문서: `docs/blog/wiki/Monitoring-and-Operations.md`(운영 가이드 — crontab 설치 명령, Healthchecks.io Check 표, 관리자 대응 절차. `docs/blog/`가 `.gitignore` 대상이라 로컬 전용, git 미추적)
+
+---
+
+### 이슈 1: [서버] Healthchecks.io 기반 최소 관제 체계 구현
+
+- 설명: 서버 헬스체크(DB 접근 여부 포함), PM2 에러 로그 무음 실패 감시(지문+쿨다운), 전체 참여자 시청 활동 침묵 감시, 기존 크론 래퍼 저장소 편입까지 하나의 일관된 체계로 구현했다.
+- Priority: High / Owner: BE(운영)
+- Dependencies: 없음
+- 상태: **코드 구현 완료** — 운영 활성화(아래 Tasks의 미착수 항목) 대기
+
+#### 설계 결정 (배경)
+
+- **Extension heartbeat 미도입**: 먼저 기존 데이터(`video_events`가 영상 감지마다 즉시 insert)만으로 충분히 판단 가능한지 검토했고, 이미 가장 세밀한 활동 신호라 판단해 heartbeat를 추가하지 않기로 결정했다(불필요한 네트워크 요청·배터리 소모 방지).
+- **참여자 수 절대 임계값을 쓰지 않음**: 2차 테스트(~20명) → 본조사(80명)로 참여자 규모가 바뀔 예정이라, `research-pipeline-monitor.js`는 "정확히 7일 전 같은 6시간대"와의 상대 비교로 전체 침묵을 판정한다. 7일치 히스토리가 아직 없는 연구 초반엔 직전 윈도우 연속 2회(12시간) 침묵 규칙으로 대체해, 새벽 자연 저활동 구간의 오탐을 막는다. 개별 참여자 한둘의 비활성은 정상으로 간주하고 대상에서 제외했다.
+- **에러 로그 감시 — 지문(fingerprint) + 쿨다운**: `errorHandler`가 남기는 `[Error] ...` 라인만 대상으로(정상 4xx 검증 실패는 애초에 안 걸림), 세션ID·숫자·UUID를 정규화한 뒤 해시로 같은 종류의 에러를 묶는다. 새 지문은 즉시 알림, 쿨다운(기본 30분) 내 재발은 억제하되 누적 횟수는 계속 세어 쿨다운 경과 후 "총 N회 발생"으로 재알림한다. 로그 전체를 매번 다시 읽지 않고 커서(파일 offset+inode) 기반으로 새 바이트만 읽으며, `pm2-logrotate`로 인한 로테이션(inode 변경·offset이 파일 크기보다 큼)도 감지해 안전하게 리셋한다.
+- **알림 정책 — 문제 발생 시에만(사용자 결정)**: 일일 요약 이메일은 만들지 않았다. 평소엔 Healthchecks.io 대시보드(Up/Late/Down)로만 확인하고, 이메일은 문제가 실제로 발생했을 때만 오도록 해 알림 피로를 최소화했다.
+- **이메일 발송 로직 직접 구현 안 함**: Healthchecks.io의 Down/Late 알림 기능에 위임했다. 각 스크립트는 Healthchecks.io ping(성공/`/fail`)만 담당한다.
+- **Ping URL 출처를 두 가지로 분리**: 신규 Node 기반 모니터 3개(`server-health-check.js`/`error-monitor.js`/`research-pipeline-monitor.js`)는 각자 `server/.env`를 로드해 ping URL을 읽는다. 반면 저장소로 편입한 bash 래퍼 2개(`period-reviews-checked.sh`/`backup-checked.sh`)는 `.env`를 파싱하지 않고 crontab 라인의 실행 인자로 ping URL을 받는다(같은 스크립트를 밤/아침 두 크론에서 다른 URL로 재사용).
+- **⚠️ 구현 중 발견한 버그 — 배포 시 신규 env 값이 매번 초기화됨**: `deploy-server.yml`이 배포마다 `server/.env`를 통째로 새로 쓰는데(`> server/.env`), 신규 모니터링 키를 여기에 반영하지 않으면 서버에 수동으로 넣어도 다음 배포 때 조용히 사라지는 구조였다 — 이 Epic 자체가 막으려는 문제(조용한 실패)를 배포 스크립트가 스스로 재현할 뻔했다. `deploy-server.yml`에 3개 ping URL(GitHub Secrets)과 민감하지 않은 `HEALTH_URL`/`ERROR_LOG_PATH`(고정값)를 추가해 해결했다.
+- **백업 성공 판정 — exit code만으론 부족함을 재확인**: `backup-db.js`의 오프사이트(E1) 전송은 best-effort라 실패해도 exit 0을 반환한다(기존 설계). `backup-checked.sh`가 exit code뿐 아니라 출력 로그의 "오프사이트 전송 실패" 문구까지 확인해야만 성공으로 ping하도록, 기존 서버 로컬 래퍼의 설계 원칙을 저장소 코드로 그대로 재현했다.
+
+#### Tasks
+
+**공유 인프라**
+- [x] `server/monitoring/healthchecks-ping.js` — ping 성공/실패 헬퍼(URL 없으면 안전하게 skip, 타임아웃·네트워크 오류 흡수)
+- [x] `server/monitoring/state.js` — 크론 실행 간 상태(로그 커서·에러 지문·연속 침묵 횟수) JSON 저장(원자적 쓰기)
+
+**서버/에러 감시**
+- [x] `server/routes/health.js`/`server/app.js` — `/health`에 DB `SELECT 1` 확인 추가(`db:"ok"|"fail"` 구분)
+- [x] `server/monitoring/server-health-check.js` — `/health` 외부 폴링(10분 주기 권장)
+- [x] `server/monitoring/error-monitor.js` — PM2 에러 로그 커서 기반 tail + 지문+쿨다운 중복 알림 방지(30분 주기 권장)
+
+**파이프라인 침묵 감시**
+- [x] `server/monitoring/research-pipeline-monitor.js` — 전체 참여자 `video_events ∪ sessions` 활동을 7일 전 동일 시간대(없으면 연속 2회 규칙)와 비교(6시간 주기 권장)
+
+**기존 체크 저장소 편입**
+- [x] `server/scripts/period-reviews-checked.sh`, `server/scripts/backup-checked.sh` — 서버 로컬 파일이던 기존 래퍼를 저장소 코드로 재현(ping URL은 crontab 인자로)
+
+**문서화·배포 파이프라인**
+- [x] `server/.env.example` — 신규 키 이름 추가
+- [x] `.github/workflows/ci.yml` — 신규 JS 5개 `node --check` + 셸 2개 `bash -n` 구문 검증 추가
+- [x] `.github/workflows/deploy-server.yml` — 배포 시 신규 env 값이 초기화되던 문제 수정(GitHub Secrets 3개 + 고정값 2개 반영)
+- [x] `docs/blog/wiki/Monitoring-and-Operations.md` — Failure Model, 아키텍처, Check 6개 표, crontab 설치 명령, 관리자 가이드(로컬 문서, git 미추적)
+- [x] 전체 vitest 스위트 회귀 없음 확인(단계마다 반복 검증)
+
+**운영 활성화(미착수 — 사용자 작업 필요)**
+- [ ] Healthchecks.io에 신규 체크 3개 생성(`server-health`/`error-monitor`/`research-pipeline`, Simple 스케줄)
+- [ ] GitHub Secrets에 `SERVER_HEALTH_PING_URL`/`ERROR_MONITOR_PING_URL`/`RESEARCH_PIPELINE_PING_URL` 등록
+- [ ] `ERROR_LOG_PATH` 실제 경로 확인(서버에서 `pm2 info youtube-bias-server`로 검증, 추정값은 `/home/ubuntu/.pm2/logs/youtube-bias-server-error.log`)
+- [ ] 서버 crontab 갱신 — 기존 3줄을 새 저장소 경로로 교체 + 신규 3줄 추가(`docs/blog/wiki/Monitoring-and-Operations.md` 5절 명령 그대로)
+- [ ] 배포 후 각 스크립트 1회 수동 실행 → Healthchecks.io 대시보드에서 6개 체크 전부 Up 확인
+
+- 관련 문서: `docs/blog/wiki/Monitoring-and-Operations.md`, "1차 테스트 파일럿 운영 중 발견된 배포·파이프라인 결함 대응" Epic(위, 기존 3체크 도입 배경)

--- a/server/.env.example
+++ b/server/.env.example
@@ -17,6 +17,14 @@ SERVER_HEALTH_PING_URL=
 ERROR_MONITOR_PING_URL=
 RESEARCH_PIPELINE_PING_URL=
 
+# DB 백업 cron이 밤 23시/아침 8시 실행마다 ping할
+# 서로 다른 Healthchecks.io Check URL. crontab에 URL을 직접 적지 않고 여기서만 관리한다.
+DB_BACKUP_NIGHT_PING_URL=
+DB_BACKUP_MORNING_PING_URL=
+
+# 기간(주차) 리뷰 생성 cron이 ping할 Healthchecks.io Check URL
+PERIOD_REVIEWS_PING_URL=
+
 # server-health-check.js가 확인할 자기 자신의 /health 절대 URL
 HEALTH_URL=
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -10,3 +10,18 @@ PERIOD_REVIEW_GEMINI_API_KEY=
 
 # 대조군 연구종료 설문 연동 리뷰 열람 게이트용 공통 코드
 STUDY_END_REVEAL_CODE=
+
+# ── 모니터링 ──
+# 아래 세 스크립트가 완료/실패 시 ping할 Healthchecks.io Check URL
+SERVER_HEALTH_PING_URL=
+ERROR_MONITOR_PING_URL=
+RESEARCH_PIPELINE_PING_URL=
+
+# server-health-check.js가 확인할 자기 자신의 /health 절대 URL
+HEALTH_URL=
+
+# error-monitor.js가 새 에러만 tail할 PM2 에러 로그 경로
+ERROR_LOG_PATH=
+
+# 모니터링 상태 파일(로그 커서·에러 지문·쿨다운) 저장 디렉터리. 미설정 시 ~/.viewlens-monitoring
+MONITOR_STATE_DIR=

--- a/server/app.js
+++ b/server/app.js
@@ -3,7 +3,8 @@ require("dotenv").config();
 const express = require("express");
 const cors = require("cors");
 const { success, errorHandler } = require("./middleware/responseHandler");
-const { initializeDB } = require("./db");
+const { db, initializeDB } = require("./db");
+const { buildHealthPayload } = require("./routes/health");
 
 initializeDB();
 
@@ -13,7 +14,7 @@ app.use(cors());
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  return success(res, { status: "healthy", timestamp: Date.now() });
+  return success(res, buildHealthPayload(db));
 });
 
 app.use("/api/participants", require("./routes/participants"));

--- a/server/monitoring/error-monitor.js
+++ b/server/monitoring/error-monitor.js
@@ -21,7 +21,11 @@ const crypto = require("crypto");
 require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
 
 const { readState, writeState } = require("./state");
-const { pingSuccess, pingFail } = require("./healthchecks-ping");
+const {
+  pingSuccess,
+  pingFail,
+  shouldPersistState,
+} = require("./healthchecks-ping");
 
 const PING_ENV_VAR = "ERROR_MONITOR_PING_URL";
 const STATE_NAME = "error-monitor";
@@ -162,13 +166,6 @@ function decideAlerts(
   }
 
   return { alerts, fingerprints: updated };
-}
-
-/**
- * ping 결과를 보고 상태(커서·지문)를 저장해도 되는지 판정한다
- */
-function shouldPersistState(pingResult) {
-  return pingResult.ok || pingResult.skipped;
 }
 
 async function main() {

--- a/server/monitoring/error-monitor.js
+++ b/server/monitoring/error-monitor.js
@@ -58,12 +58,33 @@ function fingerprint(message) {
  * 새로 추가된 로그 바이트만 읽는다. 파일이 로테이션됐으면(inode 변경 또는 저장된
  * offset보다 파일이 작아짐) 커서를 0으로 리셋해 새 파일 전체를 새로 읽는다.
  * fsImpl을 주입해 파일시스템 없이 테스트 가능.
+ *
+ * ok:false(파일 없음·읽기 실패)와 "파일은 읽었지만 새 내용이 없음"을 반드시 구분해서
+ * 반환한다 — 둘 다 text:""로 합쳐버리면, ERROR_LOG_PATH가 잘못됐을 때도 "새 에러 없음"으로
+ * 오인해 매번 성공 ping을 보내는 무음 실패가 된다(감시 대상을 실제로는 하나도 못 읽고
+ * 있는데 계속 "정상"으로 보고하는, 이 스크립트가 막으려는 문제를 스스로 재현하는 셈).
  */
 function readNewText(filePath, cursor = {}, fsImpl = fs) {
-  if (!fsImpl.existsSync(filePath)) {
-    return { text: "", cursor: { inode: null, offset: 0 } };
+  let stat;
+  try {
+    if (!fsImpl.existsSync(filePath)) {
+      return {
+        text: "",
+        cursor: { inode: null, offset: 0 },
+        ok: false,
+        reason: `파일 없음: ${filePath}`,
+      };
+    }
+    stat = fsImpl.statSync(filePath);
+  } catch (err) {
+    return {
+      text: "",
+      cursor: { inode: null, offset: 0 },
+      ok: false,
+      reason: err.message,
+    };
   }
-  const stat = fsImpl.statSync(filePath);
+
   const rotated =
     (cursor.inode != null && cursor.inode !== stat.ino) ||
     (cursor.offset ?? 0) > stat.size;
@@ -71,19 +92,29 @@ function readNewText(filePath, cursor = {}, fsImpl = fs) {
 
   const length = stat.size - startOffset;
   if (length <= 0) {
-    return { text: "", cursor: { inode: stat.ino, offset: stat.size } };
+    return {
+      text: "",
+      cursor: { inode: stat.ino, offset: stat.size },
+      ok: true,
+    };
   }
 
-  const fd = fsImpl.openSync(filePath, "r");
   try {
-    const buffer = Buffer.alloc(length);
-    fsImpl.readSync(fd, buffer, 0, length, startOffset);
-    return {
-      text: buffer.toString("utf8"),
-      cursor: { inode: stat.ino, offset: stat.size },
-    };
-  } finally {
-    fsImpl.closeSync(fd);
+    const fd = fsImpl.openSync(filePath, "r");
+    try {
+      const buffer = Buffer.alloc(length);
+      fsImpl.readSync(fd, buffer, 0, length, startOffset);
+      return {
+        text: buffer.toString("utf8"),
+        cursor: { inode: stat.ino, offset: stat.size },
+        ok: true,
+      };
+    } finally {
+      fsImpl.closeSync(fd);
+    }
+  } catch (err) {
+    // 권한 문제 등으로 열기/읽기 자체가 실패한 경우 — 커서는 건드리지 않고 실패로 보고한다.
+    return { text: "", cursor, ok: false, reason: err.message };
   }
 }
 
@@ -146,7 +177,19 @@ async function main() {
   }
 
   const state = readState(STATE_NAME, { cursor: {}, fingerprints: {} });
-  const { text, cursor } = readNewText(logPath, state.cursor);
+  const { text, cursor, ok, reason } = readNewText(logPath, state.cursor);
+
+  if (!ok) {
+    // 커서는 갱신하지 않는다 — 경로가 고쳐지면 다음 실행이 정상적으로 이어받아야 한다.
+    await pingFail(
+      PING_ENV_VAR,
+      `ERROR_LOG_PATH를 읽을 수 없습니다(${logPath}): ${reason}`,
+    );
+    console.error(`[error-monitor] 로그 읽기 실패(${logPath}):`, reason);
+    process.exitCode = 1;
+    return;
+  }
+
   const errorLines = extractErrorLines(text);
   const { alerts, fingerprints } = decideAlerts(errorLines, state.fingerprints);
 

--- a/server/monitoring/error-monitor.js
+++ b/server/monitoring/error-monitor.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * PM2 에러 로그 무음 실패 감시 (cron 실행용)
+ *
+ * server/middleware/responseHandler.js의 errorHandler가 남기는 `[Error] ...` 라인만
+ * 감시 대상으로 삼는다. 이 접두사는 "예상 못 한 서버 예외"에만 붙으므로, 검증 실패 같은
+ * 정상적인 4xx 응답은 fail()에서 바로 반환돼 애초에 여기 걸리지 않는다.
+ *
+ * 매번 로그 전체를 다시 읽지 않고 마지막 확인 지점 이후만 읽는다.
+ * 같은 에러가 반복돼도 이메일이 반복 발송되지 않도록 지문(fingerprint) + 쿨다운으로
+ * 중복 알림을 억제하되, 쿨다운이 지나 다시 발생하면 그 사이 누적 횟수와 함께 재알림한다.
+ *
+ * 사용:
+ *   ERROR_LOG_PATH=/home/ubuntu/.pm2/logs/youtube-bias-server-error.log \
+ *     node server/monitoring/error-monitor.js
+ */
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+const { readState, writeState } = require("./state");
+const { pingSuccess, pingFail } = require("./healthchecks-ping");
+
+const PING_ENV_VAR = "ERROR_MONITOR_PING_URL";
+const STATE_NAME = "error-monitor";
+const ERROR_PREFIX = "[Error] ";
+const DEFAULT_COOLDOWN_MS = 30 * 60 * 1000;
+
+/** 로그 텍스트 중 errorHandler가 남긴 에러 라인만 추출한다. */
+function extractErrorLines(text) {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(ERROR_PREFIX));
+}
+
+// sessionId·videoId 같은 숫자·UUID를 지우면, 같은 종류의 에러는 매번 같은 문자열로 정규화된다.
+function normalizeMessage(message) {
+  return message
+    .replace(
+      /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+      "#",
+    )
+    .replace(/\d+/g, "#");
+}
+
+function fingerprint(message) {
+  return crypto
+    .createHash("sha256")
+    .update(normalizeMessage(message))
+    .digest("hex")
+    .slice(0, 10);
+}
+
+/**
+ * 새로 추가된 로그 바이트만 읽는다. 파일이 로테이션됐으면(inode 변경 또는 저장된
+ * offset보다 파일이 작아짐) 커서를 0으로 리셋해 새 파일 전체를 새로 읽는다.
+ * fsImpl을 주입해 파일시스템 없이 테스트 가능.
+ */
+function readNewText(filePath, cursor = {}, fsImpl = fs) {
+  if (!fsImpl.existsSync(filePath)) {
+    return { text: "", cursor: { inode: null, offset: 0 } };
+  }
+  const stat = fsImpl.statSync(filePath);
+  const rotated =
+    (cursor.inode != null && cursor.inode !== stat.ino) ||
+    (cursor.offset ?? 0) > stat.size;
+  const startOffset = rotated ? 0 : (cursor.offset ?? 0);
+
+  const length = stat.size - startOffset;
+  if (length <= 0) {
+    return { text: "", cursor: { inode: stat.ino, offset: stat.size } };
+  }
+
+  const fd = fsImpl.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    fsImpl.readSync(fd, buffer, 0, length, startOffset);
+    return {
+      text: buffer.toString("utf8"),
+      cursor: { inode: stat.ino, offset: stat.size },
+    };
+  } finally {
+    fsImpl.closeSync(fd);
+  }
+}
+
+/**
+ * 새로 발견된 에러 라인들과 기존 지문 상태를 비교해 알림 대상을 정한다.
+ * 순수 함수 — 파일시스템/네트워크 없이 테스트 가능.
+ */
+function decideAlerts(
+  errorLines,
+  fingerprints = {},
+  now = Date.now(),
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+) {
+  const updated = { ...fingerprints };
+  const alerts = [];
+
+  // 같은 지문이 이번 실행에서 여러 번 나와도(짧은 시간에 반복 발생) 하나의 알림으로 묶는다.
+  const grouped = new Map();
+  for (const line of errorLines) {
+    const fp = fingerprint(line);
+    if (!grouped.has(fp)) grouped.set(fp, { message: line, count: 0 });
+    grouped.get(fp).count += 1;
+  }
+
+  for (const [fp, { message, count }] of grouped) {
+    const prev = updated[fp];
+    if (!prev) {
+      updated[fp] = { firstSeenAt: now, lastAlertedAt: now, count };
+      alerts.push({ fingerprint: fp, message, count, isNew: true });
+      continue;
+    }
+    const totalCount = prev.count + count;
+    if (now - prev.lastAlertedAt >= cooldownMs) {
+      updated[fp] = { ...prev, lastAlertedAt: now, count: totalCount };
+      alerts.push({
+        fingerprint: fp,
+        message,
+        count: totalCount,
+        isNew: false,
+      });
+    } else {
+      // 쿨다운 안이면 알리지 않되, 누적 횟수는 계속 세어 다음 알림 때 정확한 횟수를 알린다.
+      updated[fp] = { ...prev, count: totalCount };
+    }
+  }
+
+  return { alerts, fingerprints: updated };
+}
+
+async function main() {
+  const logPath = process.env.ERROR_LOG_PATH;
+  if (!logPath) {
+    console.error("[error-monitor] ERROR_LOG_PATH 환경변수가 필요합니다.");
+    await pingFail(
+      PING_ENV_VAR,
+      "ERROR_LOG_PATH 환경변수 누락 — 설정 확인 필요",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const state = readState(STATE_NAME, { cursor: {}, fingerprints: {} });
+  const { text, cursor } = readNewText(logPath, state.cursor);
+  const errorLines = extractErrorLines(text);
+  const { alerts, fingerprints } = decideAlerts(errorLines, state.fingerprints);
+
+  writeState(STATE_NAME, { cursor, fingerprints });
+
+  if (alerts.length === 0) {
+    await pingSuccess(PING_ENV_VAR);
+    console.log(
+      `[error-monitor] 새 에러 없음 (신규 라인 ${errorLines.length}줄 검사)`,
+    );
+    return;
+  }
+
+  const detail = alerts
+    .map((a) => `[${a.isNew ? "신규" : "재발"} x${a.count}] ${a.message}`)
+    .join("\n");
+  await pingFail(PING_ENV_VAR, detail);
+  console.error(
+    `[error-monitor] 알림 대상 에러 ${alerts.length}건:\n${detail}`,
+  );
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("[error-monitor] 스크립트 오류:", err.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  extractErrorLines,
+  normalizeMessage,
+  fingerprint,
+  readNewText,
+  decideAlerts,
+};

--- a/server/monitoring/error-monitor.js
+++ b/server/monitoring/error-monitor.js
@@ -164,6 +164,13 @@ function decideAlerts(
   return { alerts, fingerprints: updated };
 }
 
+/**
+ * ping 결과를 보고 상태(커서·지문)를 저장해도 되는지 판정한다
+ */
+function shouldPersistState(pingResult) {
+  return pingResult.ok || pingResult.skipped;
+}
+
 async function main() {
   const logPath = process.env.ERROR_LOG_PATH;
   if (!logPath) {
@@ -193,23 +200,31 @@ async function main() {
   const errorLines = extractErrorLines(text);
   const { alerts, fingerprints } = decideAlerts(errorLines, state.fingerprints);
 
-  writeState(STATE_NAME, { cursor, fingerprints });
-
+  let pingResult;
   if (alerts.length === 0) {
-    await pingSuccess(PING_ENV_VAR);
+    pingResult = await pingSuccess(PING_ENV_VAR);
     console.log(
       `[error-monitor] 새 에러 없음 (신규 라인 ${errorLines.length}줄 검사)`,
     );
+  } else {
+    const detail = alerts
+      .map((a) => `[${a.isNew ? "신규" : "재발"} x${a.count}] ${a.message}`)
+      .join("\n");
+    pingResult = await pingFail(PING_ENV_VAR, detail);
+    console.error(
+      `[error-monitor] 알림 대상 에러 ${alerts.length}건:\n${detail}`,
+    );
+  }
+
+  if (!shouldPersistState(pingResult)) {
+    console.error(
+      "[error-monitor] Healthchecks.io 전송 실패 — 상태 저장을 보류하고 다음 실행에서 처음부터 재시도합니다.",
+    );
+    process.exitCode = 1;
     return;
   }
 
-  const detail = alerts
-    .map((a) => `[${a.isNew ? "신규" : "재발"} x${a.count}] ${a.message}`)
-    .join("\n");
-  await pingFail(PING_ENV_VAR, detail);
-  console.error(
-    `[error-monitor] 알림 대상 에러 ${alerts.length}건:\n${detail}`,
-  );
+  writeState(STATE_NAME, { cursor, fingerprints });
 }
 
 if (require.main === module) {
@@ -225,4 +240,5 @@ module.exports = {
   fingerprint,
   readNewText,
   decideAlerts,
+  shouldPersistState,
 };

--- a/server/monitoring/healthchecks-ping.js
+++ b/server/monitoring/healthchecks-ping.js
@@ -1,0 +1,59 @@
+// Healthchecks.io ping 공유 헬퍼
+// 모니터링 스크립트들의 실패 유무를 알리는 유일한 통로.
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const MAX_BODY_LENGTH = 10000; // Healthchecks.io ping 본문(로그) 상한
+
+// 네트워크 지연으로 무한 대기하면 뒤이은 크론 작업까지 막힐 수 있어 타임아웃을 건다
+// (server/scripts/backup-db.js의 SSH 타임아웃과 동일한 이유).
+async function ping(
+  envVarName,
+  {
+    method = "GET",
+    suffix = "",
+    body,
+    fetchImpl = fetch,
+    env = process.env,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = {},
+) {
+  const url = env[envVarName];
+  if (!url) {
+    console.warn(
+      `[healthchecks] ${envVarName} 환경변수가 없어 ping을 건너뜁니다.`,
+    );
+    return { skipped: true, ok: false };
+  }
+
+  const target = `${url.replace(/\/$/, "")}${suffix}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    await fetchImpl(target, { method, body, signal: controller.signal });
+    return { skipped: false, ok: true };
+  } catch (err) {
+    // ping 실패가 모니터링 스크립트 자체를 죽이면 안 된다 — 경고만 남기고 계속 진행.
+    console.warn(`[healthchecks] ping 실패(${envVarName}):`, err.message);
+    return { skipped: false, ok: false, error: err.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** 정상 완료 신호. */
+function pingSuccess(envVarName, opts = {}) {
+  return ping(envVarName, { method: "GET", ...opts });
+}
+
+/** 실패 신호. detail은 Healthchecks.io에 로그로 남는 본문(최대 10KB로 절단). */
+function pingFail(envVarName, detail = "", opts = {}) {
+  return ping(envVarName, {
+    method: "POST",
+    suffix: "/fail",
+    body: String(detail).slice(0, MAX_BODY_LENGTH),
+    ...opts,
+  });
+}
+
+module.exports = { ping, pingSuccess, pingFail };

--- a/server/monitoring/healthchecks-ping.js
+++ b/server/monitoring/healthchecks-ping.js
@@ -30,7 +30,16 @@ async function ping(
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    await fetchImpl(target, { method, body, signal: controller.signal });
+    const response = await fetchImpl(target, {
+      method,
+      body,
+      signal: controller.signal,
+    });
+    // fetch는 네트워크 수준 실패(끊김·타임아웃)에서만 reject한다
+    //  4xx/5xx 응답은 예외 없이 정상적으로 resolve되므로, response.ok를 직접 확인해야 진짜 전송 성공을 알 수 있다.
+    if (!response.ok) {
+      return { skipped: false, ok: false, error: `HTTP ${response.status}` };
+    }
     return { skipped: false, ok: true };
   } catch (err) {
     // ping 실패가 모니터링 스크립트 자체를 죽이면 안 된다 — 경고만 남기고 계속 진행.
@@ -56,4 +65,12 @@ function pingFail(envVarName, detail = "", opts = {}) {
   });
 }
 
-module.exports = { ping, pingSuccess, pingFail };
+/**
+ * ping 결과를 보고 그 ping에 의존하는 로컬 상태를 저장해도 되는지 판정한다.
+ * 실제로 전송에 성공했거나(ok) URL이 아예 없어 애초에 보낼 방법이 없을 때(skipped)만 저장한다.
+ */
+function shouldPersistState(pingResult) {
+  return pingResult.ok || pingResult.skipped;
+}
+
+module.exports = { ping, pingSuccess, pingFail, shouldPersistState };

--- a/server/monitoring/research-pipeline-monitor.js
+++ b/server/monitoring/research-pipeline-monitor.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * 연구 데이터 수집 파이프라인 침묵 장애 감시
+ *
+ * 이 스크립트는 전체 참여자의 시청 활동이 과거 대비 갑자기 끊겼는지를 감시한다.
+ *
+ * 참여자 수 변경을 대비하여 절대 참여자 수 임계값을 쓰지 않는다.
+ * 대신 "정확히 7일 전 같은 시간대"와 비교해, 그때는 활동이 있었는데 지금 6시간 동안
+ * 전혀 없으면 전체 중단으로 판단한다. 연구 시작 후 7일이 안 지나 비교 데이터가 없으면
+ * 직전 6시간 윈도우와 비교하되 연속 2회(12시간) 침묵이어야 알린다(새벽 자연 저활동 구간의
+ * 오탐 방지). 개별 참여자 한둘이 조용한 것은 정상적인 비활성일 수 있어 대상이 아니다 —
+ * 전체가 동시에 조용해질 때만 이상으로 본다.
+ *
+ * 사용:
+ *   node server/monitoring/research-pipeline-monitor.js
+ */
+const path = require("path");
+
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+const { readState, writeState } = require("./state");
+const { pingSuccess, pingFail } = require("./healthchecks-ping");
+
+const PING_ENV_VAR = "RESEARCH_PIPELINE_PING_URL";
+const STATE_NAME = "research-pipeline";
+
+const WINDOW_MS = 6 * 60 * 60 * 1000;
+const COMPARE_OFFSET_MS = 7 * 24 * 60 * 60 * 1000;
+const REQUIRED_CONSECUTIVE = 2;
+
+/**
+ * 순수 판정 함수(DB 접근 없이 테스트 가능)
+ * events: 최근 (windowMs + compareOffsetMs) 범위 활동 타임스탬프 배열
+ * hasParticipants: 등록된 참여자가 한 명이라도 있는지(연구 시작 전이면 항상 정상 취급)
+ * hasWeekOldParticipant: 설치 후 compareOffsetMs(기본 7일) 이상 지난 참여자가 있는지
+ */
+function evaluatePipelineHealth({
+  now,
+  events,
+  hasParticipants,
+  hasWeekOldParticipant,
+  consecutiveZero = 0,
+  windowMs = WINDOW_MS,
+  compareOffsetMs = COMPARE_OFFSET_MS,
+  requiredConsecutive = REQUIRED_CONSECUTIVE,
+}) {
+  if (!hasParticipants) {
+    return {
+      status: "skipped",
+      reason: "no_participants",
+      consecutiveZero: 0,
+    };
+  }
+
+  const currentStart = now - windowMs;
+  const currentCount = events.filter(
+    (ts) => ts >= currentStart && ts < now,
+  ).length;
+
+  if (currentCount > 0) {
+    return { status: "ok", currentCount, consecutiveZero: 0 };
+  }
+
+  if (hasWeekOldParticipant) {
+    const compareStart = currentStart - compareOffsetMs;
+    const compareEnd = now - compareOffsetMs;
+    const compareCount = events.filter(
+      (ts) => ts >= compareStart && ts < compareEnd,
+    ).length;
+    if (compareCount > 0) {
+      return {
+        status: "alert",
+        reason: "flatline_vs_7_days_ago",
+        currentCount: 0,
+        compareCount,
+        consecutiveZero: 0,
+      };
+    }
+    // 7일 전 같은 시간대도 원래 조용했다 — 그 시간대 자체의 정상적인 저활동으로 간주하고 리셋.
+    return { status: "ok", currentCount: 0, consecutiveZero: 0 };
+  }
+
+  // 연구 시작 초반이라 비교할 히스토리가 없다 — 직전 윈도우 연속 침묵 횟수로만 판단.
+  const nextConsecutive = consecutiveZero + 1;
+  if (nextConsecutive >= requiredConsecutive) {
+    return {
+      status: "alert",
+      reason: "flatline_consecutive_windows",
+      currentCount: 0,
+      consecutiveZero: nextConsecutive,
+    };
+  }
+  return {
+    status: "warn_pending",
+    currentCount: 0,
+    consecutiveZero: nextConsecutive,
+  };
+}
+
+/**
+ * DB에서 참여자 존재 여부·"설치 후 7일 이상 지난 참여자 존재 여부"·최근 활동
+ * 타임스탬프(video_events ∪ sessions)를 모은다.
+ */
+function collectRecentActivity(
+  db,
+  now,
+  lookbackMs,
+  compareOffsetMs = COMPARE_OFFSET_MS,
+) {
+  const cutoffIso = new Date(now - lookbackMs).toISOString();
+
+  const hasParticipants =
+    db.prepare("SELECT COUNT(*) AS c FROM participants").get().c > 0;
+
+  // installDate(등록 시 Date.parse로 검증된 문자열, participants-store.js)가
+  // compareOffsetMs 이상 지난 참여자가 있어야 "N일 전 같은 시간대" 비교가 의미를 가진다.
+  const earliestInstall = db
+    .prepare("SELECT MIN(installDate) AS earliest FROM participants")
+    .get().earliest;
+  const earliestInstallMs = earliestInstall ? Date.parse(earliestInstall) : NaN;
+  const hasWeekOldParticipant =
+    Number.isFinite(earliestInstallMs) &&
+    earliestInstallMs <= now - compareOffsetMs;
+
+  // video_events.watchedAt은 클라이언트가 저장한 ISO8601 문자열이라 문자열 비교로 충분하다.
+  const videoRows = db
+    .prepare("SELECT watchedAt AS ts FROM video_events WHERE watchedAt >= ?")
+    .all(cutoffIso);
+  // sessions.createdAt은 SQLite datetime('now') 형식(UTC, 'T' 없음)이라 ISO cutoff와
+  // 직접 문자열 비교가 안 맞을 수 있어 datetime()으로 양쪽을 정규화해 비교한다.
+  const sessionRows = db
+    .prepare(
+      "SELECT createdAt AS ts FROM sessions WHERE datetime(createdAt) >= datetime(?)",
+    )
+    .all(cutoffIso);
+
+  const events = [...videoRows, ...sessionRows]
+    .map((r) => Date.parse(r.ts))
+    .filter((ts) => Number.isFinite(ts));
+
+  return { hasParticipants, hasWeekOldParticipant, events };
+}
+
+async function main() {
+  const { db } = require("../db");
+  const now = Date.now();
+  const lookbackMs = WINDOW_MS + COMPARE_OFFSET_MS;
+
+  const state = readState(STATE_NAME, { consecutiveZero: 0 });
+  const { hasParticipants, hasWeekOldParticipant, events } =
+    collectRecentActivity(db, now, lookbackMs);
+
+  const result = evaluatePipelineHealth({
+    now,
+    events,
+    hasParticipants,
+    hasWeekOldParticipant,
+    consecutiveZero: state.consecutiveZero,
+  });
+
+  writeState(STATE_NAME, { consecutiveZero: result.consecutiveZero });
+
+  if (result.status === "alert") {
+    await pingFail(
+      PING_ENV_VAR,
+      `연구 데이터 수집 파이프라인 침묵 의심 (${result.reason}, 최근 6시간 이벤트 0건)`,
+    );
+    console.error("[research-pipeline] 침묵 의심:", result);
+    return;
+  }
+
+  await pingSuccess(PING_ENV_VAR);
+  console.log("[research-pipeline] 정상:", result);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("[research-pipeline] 스크립트 오류:", err.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { evaluatePipelineHealth, collectRecentActivity };

--- a/server/monitoring/research-pipeline-monitor.js
+++ b/server/monitoring/research-pipeline-monitor.js
@@ -149,9 +149,14 @@ function collectRecentActivity(
     Number.isFinite(earliestInstallMs) &&
     earliestInstallMs <= now - compareOffsetMs;
 
-  // video_events.watchedAt은 클라이언트가 저장한 ISO8601 문자열이라 문자열 비교로 충분하다.
+  // video_events.watchedAt은 클라이언트가 저장한 ISO8601 문자열인데, 서버가 형식을
+  // UTC('Z')로 강제하지 않아 오프셋 표기(예: +09:00)가 섞여 들어올 수 있다. 단순 문자열
+  // 비교는 오프셋이 다르면 실제 시간 순서와 어긋날 수 있어(예: "14:00+09:00"이 실제로는
+  // "06:00Z"보다 이른데도 문자열로는 더 크게 비교됨) julianday()로 정규화해 비교한다.
   const videoRows = db
-    .prepare("SELECT watchedAt AS ts FROM video_events WHERE watchedAt >= ?")
+    .prepare(
+      "SELECT watchedAt AS ts FROM video_events WHERE julianday(watchedAt) >= julianday(?)",
+    )
     .all(cutoffIso);
   // sessions.createdAt은 SQLite datetime('now') 형식(UTC, 'T' 없음)이라 ISO cutoff와
   // 직접 문자열 비교가 안 맞을 수 있어 datetime()으로 양쪽을 정규화해 비교한다.

--- a/server/monitoring/research-pipeline-monitor.js
+++ b/server/monitoring/research-pipeline-monitor.js
@@ -31,12 +31,14 @@ const STATE_NAME = "research-pipeline";
 const WINDOW_MS = 6 * 60 * 60 * 1000;
 const COMPARE_OFFSET_MS = 7 * 24 * 60 * 60 * 1000;
 const REQUIRED_CONSECUTIVE = 2;
+const MIN_ADJACENT_WINDOW_MS = WINDOW_MS / 2;
 
 /**
  * 순수 판정 함수(DB 접근 없이 테스트 가능)
  * events: 최근 (windowMs + compareOffsetMs) 범위 활동 타임스탬프 배열
  * hasParticipants: 등록된 참여자가 한 명이라도 있는지(연구 시작 전이면 항상 정상 취급)
  * hasWeekOldParticipant: 설치 후 compareOffsetMs(기본 7일) 이상 지난 참여자가 있는지
+ * lastEvaluatedAt: 직전 실행 시각(epoch ms). 처음 실행이면 null.
  */
 function evaluatePipelineHealth({
   now,
@@ -44,15 +46,18 @@ function evaluatePipelineHealth({
   hasParticipants,
   hasWeekOldParticipant,
   consecutiveZero = 0,
+  lastEvaluatedAt = null,
   windowMs = WINDOW_MS,
   compareOffsetMs = COMPARE_OFFSET_MS,
   requiredConsecutive = REQUIRED_CONSECUTIVE,
+  minAdjacentWindowMs = MIN_ADJACENT_WINDOW_MS,
 }) {
   if (!hasParticipants) {
     return {
       status: "skipped",
       reason: "no_participants",
       consecutiveZero: 0,
+      lastEvaluatedAt: now,
     };
   }
 
@@ -62,7 +67,12 @@ function evaluatePipelineHealth({
   ).length;
 
   if (currentCount > 0) {
-    return { status: "ok", currentCount, consecutiveZero: 0 };
+    return {
+      status: "ok",
+      currentCount,
+      consecutiveZero: 0,
+      lastEvaluatedAt: now,
+    };
   }
 
   if (hasWeekOldParticipant) {
@@ -78,26 +88,39 @@ function evaluatePipelineHealth({
         currentCount: 0,
         compareCount,
         consecutiveZero: 0,
+        lastEvaluatedAt: now,
       };
     }
     // 7일 전 같은 시간대도 원래 조용했다 — 그 시간대 자체의 정상적인 저활동으로 간주하고 리셋.
-    return { status: "ok", currentCount: 0, consecutiveZero: 0 };
+    return {
+      status: "ok",
+      currentCount: 0,
+      consecutiveZero: 0,
+      lastEvaluatedAt: now,
+    };
   }
 
   // 연구 시작 초반이라 비교할 히스토리가 없다 — 직전 윈도우 연속 침묵 횟수로만 판단.
-  const nextConsecutive = consecutiveZero + 1;
+  const isAdjacentWindow =
+    lastEvaluatedAt == null || now - lastEvaluatedAt >= minAdjacentWindowMs;
+  const nextConsecutive = isAdjacentWindow
+    ? consecutiveZero + 1
+    : consecutiveZero;
+
   if (nextConsecutive >= requiredConsecutive) {
     return {
       status: "alert",
       reason: "flatline_consecutive_windows",
       currentCount: 0,
       consecutiveZero: nextConsecutive,
+      lastEvaluatedAt: now,
     };
   }
   return {
     status: "warn_pending",
     currentCount: 0,
     consecutiveZero: nextConsecutive,
+    lastEvaluatedAt: now,
   };
 }
 
@@ -150,7 +173,10 @@ async function main() {
   const now = Date.now();
   const lookbackMs = WINDOW_MS + COMPARE_OFFSET_MS;
 
-  const state = readState(STATE_NAME, { consecutiveZero: 0 });
+  const state = readState(STATE_NAME, {
+    consecutiveZero: 0,
+    lastEvaluatedAt: null,
+  });
   const { hasParticipants, hasWeekOldParticipant, events } =
     collectRecentActivity(db, now, lookbackMs);
 
@@ -160,6 +186,7 @@ async function main() {
     hasParticipants,
     hasWeekOldParticipant,
     consecutiveZero: state.consecutiveZero,
+    lastEvaluatedAt: state.lastEvaluatedAt,
   });
 
   let pingResult;
@@ -183,7 +210,10 @@ async function main() {
     return;
   }
 
-  writeState(STATE_NAME, { consecutiveZero: result.consecutiveZero });
+  writeState(STATE_NAME, {
+    consecutiveZero: result.consecutiveZero,
+    lastEvaluatedAt: result.lastEvaluatedAt,
+  });
 }
 
 if (require.main === module) {

--- a/server/monitoring/research-pipeline-monitor.js
+++ b/server/monitoring/research-pipeline-monitor.js
@@ -19,7 +19,11 @@ const path = require("path");
 require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
 
 const { readState, writeState } = require("./state");
-const { pingSuccess, pingFail } = require("./healthchecks-ping");
+const {
+  pingSuccess,
+  pingFail,
+  shouldPersistState,
+} = require("./healthchecks-ping");
 
 const PING_ENV_VAR = "RESEARCH_PIPELINE_PING_URL";
 const STATE_NAME = "research-pipeline";
@@ -158,19 +162,28 @@ async function main() {
     consecutiveZero: state.consecutiveZero,
   });
 
-  writeState(STATE_NAME, { consecutiveZero: result.consecutiveZero });
-
+  let pingResult;
   if (result.status === "alert") {
-    await pingFail(
+    pingResult = await pingFail(
       PING_ENV_VAR,
       `연구 데이터 수집 파이프라인 침묵 의심 (${result.reason}, 최근 6시간 이벤트 0건)`,
     );
     console.error("[research-pipeline] 침묵 의심:", result);
+  } else {
+    pingResult = await pingSuccess(PING_ENV_VAR);
+    console.log("[research-pipeline] 정상:", result);
+  }
+
+  // ping이 실제로 실패했으면(네트워크 오류·HTTP 에러 등) 상태를 저장하지 않는다.
+  if (!shouldPersistState(pingResult)) {
+    console.error(
+      "[research-pipeline] Healthchecks.io 전송 실패 — 상태 저장을 보류하고 다음 실행에서 재시도합니다.",
+    );
+    process.exitCode = 1;
     return;
   }
 
-  await pingSuccess(PING_ENV_VAR);
-  console.log("[research-pipeline] 정상:", result);
+  writeState(STATE_NAME, { consecutiveZero: result.consecutiveZero });
 }
 
 if (require.main === module) {

--- a/server/monitoring/research-pipeline-monitor.js
+++ b/server/monitoring/research-pipeline-monitor.js
@@ -158,11 +158,17 @@ function collectRecentActivity(
       "SELECT watchedAt AS ts FROM video_events WHERE julianday(watchedAt) >= julianday(?)",
     )
     .all(cutoffIso);
-  // sessions.createdAt은 SQLite datetime('now') 형식(UTC, 'T' 없음)이라 ISO cutoff와
-  // 직접 문자열 비교가 안 맞을 수 있어 datetime()으로 양쪽을 정규화해 비교한다.
+  // sessions.createdAt은 SQLite datetime('now') 형식(UTC 값이지만 공백 구분, 'Z' 없음).
+  // WHERE 절은 datetime()으로 정규화해 비교하지만, SELECT로 꺼낸 원본 문자열을 그대로
+  // JS Date.parse에 넘기면 위험하다.
+  // 이 저장소 개발 환경(Asia/Seoul)에서 직접 재현: "2026-08-30 12:00:00"이 로컬로 해석되면 실제로는
+  // "2026-08-30T12:00:00Z"인데 "2026-08-30T03:00:00Z"로 9시간 밀려서 파싱된다. 서버가
+  // UTC가 아닌 시간대로 설정되면 6시간 윈도우 판정이 통째로 틀어질 수 있으므로, SQL에서
+  // 'T'+'Z'가 붙은 명확한 UTC ISO 문자열로 바꿔 반환한다.
   const sessionRows = db
     .prepare(
-      "SELECT createdAt AS ts FROM sessions WHERE datetime(createdAt) >= datetime(?)",
+      `SELECT replace(createdAt, ' ', 'T') || 'Z' AS ts FROM sessions
+       WHERE datetime(createdAt) >= datetime(?)`,
     )
     .all(cutoffIso);
 

--- a/server/monitoring/server-health-check.js
+++ b/server/monitoring/server-health-check.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * 서버 헬스체크 모니터
+ *
+ * 자기 자신의 GET /health를 외부 관찰자처럼 주기적으로 확인해, 프로세스가 응답하지
+ * 않거나(서버 다운) DB 접근이 실패한 상태(server/routes/health.js가 db:"fail"로 구분)를
+ * Healthchecks.io로 알린다. PM2가 죽은 프로세스를 재시작해도 재시작 자체가 반복되는
+ * 상황까지는 PM2만으로 알 수 없으므로 외부에서 주기적으로 찔러보는 이 확인이 필요하다.
+ *
+ * 사용:
+ *   HEALTH_URL=https://viewlens.site/health node server/monitoring/server-health-check.js
+ */
+const path = require("path");
+
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+const { pingSuccess, pingFail } = require("./healthchecks-ping");
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const PING_ENV_VAR = "SERVER_HEALTH_PING_URL";
+
+/** 순수 판정 함수 — fetchImpl을 주입해 네트워크 없이 테스트 가능. */
+async function checkHealth({
+  healthUrl = process.env.HEALTH_URL || "http://localhost:3000/health",
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(healthUrl, { signal: controller.signal });
+    if (!res.ok) {
+      return { ok: false, reason: `HTTP ${res.status}` };
+    }
+    const body = await res.json();
+    if (body?.data?.db !== "ok") {
+      return { ok: false, reason: `db=${body?.data?.db ?? "unknown"}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function main() {
+  const result = await checkHealth();
+  if (result.ok) {
+    await pingSuccess(PING_ENV_VAR);
+    console.log("[server-health] 정상");
+    return;
+  }
+  await pingFail(PING_ENV_VAR, `헬스체크 실패: ${result.reason}`);
+  console.error("[server-health] 실패:", result.reason);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("[server-health] 스크립트 오류:", err.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { checkHealth };

--- a/server/monitoring/server-health-check.js
+++ b/server/monitoring/server-health-check.js
@@ -46,13 +46,26 @@ async function checkHealth({
 
 async function main() {
   const result = await checkHealth();
+  const pingResult = result.ok
+    ? await pingSuccess(PING_ENV_VAR)
+    : await pingFail(PING_ENV_VAR, `헬스체크 실패: ${result.reason}`);
+
   if (result.ok) {
-    await pingSuccess(PING_ENV_VAR);
     console.log("[server-health] 정상");
-    return;
+  } else {
+    console.error("[server-health] 실패:", result.reason);
   }
-  await pingFail(PING_ENV_VAR, `헬스체크 실패: ${result.reason}`);
-  console.error("[server-health] 실패:", result.reason);
+
+  // 이 스크립트는 저장하는 상태가 없어(stateless) 이전 항목들과 달리 재시도 로직은
+  // 필요 없지만, ping 자체가 실제로 전달됐는지 확인하지 않으면 "정상"이라는 로그만 남고
+  // Healthchecks.io에는 아무것도 도착하지 않은 상황을 구분할 수 없다.
+  if (!pingResult.ok && !pingResult.skipped) {
+    console.error(
+      "[server-health] Healthchecks.io 전송 자체도 실패:",
+      pingResult.error,
+    );
+    process.exitCode = 1;
+  }
 }
 
 if (require.main === module) {

--- a/server/monitoring/state.js
+++ b/server/monitoring/state.js
@@ -1,0 +1,43 @@
+// 모니터링 스크립트용 JSON 상태 파일 저장소
+// cron으로 반복 실행되며 계속 갱신되는 운영 상태라 git pull/배포와 분리해야하므로 repo 밖에 둔다.
+// 각 모니터가 사용하는 커서·쿨다운 상태를 이름별로 분리된 JSON 파일 하나씩에 담는다.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const DEFAULT_STATE_DIR = path.join(os.homedir(), ".viewlens-monitoring");
+
+function statePath(
+  name,
+  dir = process.env.MONITOR_STATE_DIR || DEFAULT_STATE_DIR,
+) {
+  return path.join(dir, `${name}.json`);
+}
+
+/** 상태 파일이 없거나(최초 실행) 손상됐으면 fallback을 반환한다 — 절대 예외를 던지지 않는다. */
+function readState(name, fallback = {}, dir) {
+  const file = statePath(name, dir);
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.warn(
+        `[monitoring] 상태 파일 읽기 실패(${file}), 기본값 사용:`,
+        err.message,
+      );
+    }
+    return fallback;
+  }
+}
+
+/** 임시 파일에 쓴 뒤 rename하는 원자적 교체 — 쓰다 중단돼도 기존 상태 파일이 손상되지 않는다. */
+function writeState(name, data, dir) {
+  const file = statePath(name, dir);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2));
+  fs.renameSync(tmp, file);
+}
+
+module.exports = { statePath, readState, writeState, DEFAULT_STATE_DIR };

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -1,0 +1,19 @@
+// GET /health가 반환할 상태를 계산하는 순수 함수
+// Express 핸들러에서 분리해 단위 테스트가 가능하게 한다.
+// "서버 프로세스가 살아있다"와 "DB에 실제로 접근 가능하다"는 다른 상태이므로 함께 확인해 구분해서 반환한다.
+// 후자가 죽어도 서버 자체는 응답할 수 있어 200으로 응답하되 db 필드로 구분한다.
+function buildHealthPayload(db, now = Date.now) {
+  let dbOk = true;
+  try {
+    db.prepare("SELECT 1").get();
+  } catch {
+    dbOk = false;
+  }
+  return {
+    status: dbOk ? "healthy" : "degraded",
+    db: dbOk ? "ok" : "fail",
+    timestamp: now(),
+  };
+}
+
+module.exports = { buildHealthPayload };

--- a/server/scripts/backup-checked.sh
+++ b/server/scripts/backup-checked.sh
@@ -34,7 +34,8 @@ echo "$OUTPUT"
 OK=true
 if [ "$STATUS" -ne 0 ]; then
   OK=false
-elif echo "$OUTPUT" | grep -q "오프사이트 전송 실패"; then
+# grep -q로 파이프를 태우지 않는다.
+elif [[ "$OUTPUT" == *"오프사이트 전송 실패"* ]]; then
   OK=false
 fi
 

--- a/server/scripts/backup-checked.sh
+++ b/server/scripts/backup-checked.sh
@@ -7,19 +7,37 @@
 # 있는지도 함께 확인해야만 성공으로 ping한다.
 #
 # 예전엔 서버 로컬 파일(~/bin/backup-checked.sh)로만 존재했다. 저장소에 코드로
-# 편입해 재현 가능하게 한다. Ping URL은 코드에 두지 않고 인자로 받는다. 같은 스크립트를
-# 밤(23:00)·아침(08:00) 두 크론 라인에서 서로 다른 ping URL로 호출한다.
+# 편입해 재현 가능하게 한다.
 #
-# 사용: backup-checked.sh <healthchecks_ping_url>
+#
+# 사용: backup-checked.sh <night|morning>
 # crontab 예(서버 타임존 Asia/Seoul). rsync 배포가 실행 비트를 보존한다고 가정하지 않도록
 # bash를 명시적으로 붙인다:
-#   0 23 * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/backup-checked.sh "https://hc-ping.com/night-xxxx" >> /home/ubuntu/db-backups/backup.log 2>&1
-#   0 8  * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/backup-checked.sh "https://hc-ping.com/morning-xxxx" >> /home/ubuntu/db-backups/backup.log 2>&1
+#   0 23 * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/backup-checked.sh night >> /home/ubuntu/db-backups/backup.log 2>&1
+#   0 8  * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/backup-checked.sh morning >> /home/ubuntu/db-backups/backup.log 2>&1
 
 set -uo pipefail
 
-PING_URL="${1:-}"
+RUN_LABEL="${1:-}"
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# server/.env는 KEY=VALUE 순수 형식이라 bash에서 그대로 source할 수 있다
+# (server/db.js 등 node 스크립트가 dotenv로 읽는 것과 같은 파일, 같은 값).
+if [ -f "$REPO_DIR/server/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_DIR/server/.env"
+  set +a
+fi
+
+case "$RUN_LABEL" in
+  night) PING_URL="${DB_BACKUP_NIGHT_PING_URL:-}" ;;
+  morning) PING_URL="${DB_BACKUP_MORNING_PING_URL:-}" ;;
+  *)
+    echo "[backup-checked] 사용법: backup-checked.sh <night|morning> — 알 수 없는 레이블 '$RUN_LABEL', ping을 건너뜁니다." >&2
+    PING_URL=""
+    ;;
+esac
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"

--- a/server/scripts/backup-checked.sh
+++ b/server/scripts/backup-checked.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# DB 백업 cron 래퍼
+# backup-db.js를 실행하고 성공/실패를 Healthchecks.io에 ping한다.
+#
+# backup-db.js의 오프사이트 전송은 best-effort라 실패해도 exit 0을 반환한다
+# exit code만 보면 이 실패를 놓치므로, 출력 로그에 "오프사이트 전송 실패" 문구가
+# 있는지도 함께 확인해야만 성공으로 ping한다.
+#
+# 예전엔 서버 로컬 파일(~/bin/backup-checked.sh)로만 존재했다. 저장소에 코드로
+# 편입해 재현 가능하게 한다. Ping URL은 코드에 두지 않고 인자로 받는다. 같은 스크립트를
+# 밤(23:00)·아침(08:00) 두 크론 라인에서 서로 다른 ping URL로 호출한다.
+#
+# 사용: backup-checked.sh <healthchecks_ping_url>
+# crontab 예(서버 타임존 Asia/Seoul). rsync 배포가 실행 비트를 보존한다고 가정하지 않도록
+# bash를 명시적으로 붙인다:
+#   0 23 * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/backup-checked.sh "https://hc-ping.com/night-xxxx" >> /home/ubuntu/db-backups/backup.log 2>&1
+#   0 8  * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/backup-checked.sh "https://hc-ping.com/morning-xxxx" >> /home/ubuntu/db-backups/backup.log 2>&1
+
+set -uo pipefail
+
+PING_URL="${1:-}"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+cd "$REPO_DIR" || exit 1
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] backup 시작"
+OUTPUT="$(node server/scripts/backup-db.js 2>&1)"
+STATUS=$?
+echo "$OUTPUT"
+
+OK=true
+if [ "$STATUS" -ne 0 ]; then
+  OK=false
+elif echo "$OUTPUT" | grep -q "오프사이트 전송 실패"; then
+  OK=false
+fi
+
+if [ -z "$PING_URL" ]; then
+  echo "[backup-checked] ping URL이 없어 Healthchecks 알림을 건너뜁니다." >&2
+elif [ "$OK" = true ]; then
+  curl -fsS -m 10 --retry 3 "$PING_URL" -o /dev/null
+else
+  # 실패 로그 본문을 함께 보내 Healthchecks.io에서 원인을 바로 확인할 수 있게 한다.
+  curl -fsS -m 10 --retry 3 --data-binary "$OUTPUT" "$PING_URL/fail" -o /dev/null
+fi
+
+exit "$STATUS"

--- a/server/scripts/period-reviews-checked.sh
+++ b/server/scripts/period-reviews-checked.sh
@@ -3,17 +3,23 @@
 # 성공/실패를 Healthchecks.io에 ping한다(데드맨스위치).
 #
 # 예전엔 서버 로컬 파일(~/bin/period-reviews-checked.sh)로만 존재했다. 저장소에
-# 코드로 편입해 재현 가능하게 한다. Ping URL은 코드에 두지 않고 인자로 받는다.
-#
-# 사용: period-reviews-checked.sh <healthchecks_ping_url>
+# 코드로 편입해 재현 가능하게 한다.
+# 사용: period-reviews-checked.sh
 # crontab 예(서버 타임존 Asia/Seoul). rsync 배포가 실행 비트를 보존한다고 가정하지 않도록
 # bash를 명시적으로 붙인다:
-#   0 4 * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/period-reviews-checked.sh "https://hc-ping.com/xxxx" >> /home/ubuntu/period-reviews.log 2>&1
+#   0 4 * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/period-reviews-checked.sh >> /home/ubuntu/period-reviews.log 2>&1
 
 set -uo pipefail
 
-PING_URL="${1:-}"
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [ -f "$REPO_DIR/server/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_DIR/server/.env"
+  set +a
+fi
+PING_URL="${PERIOD_REVIEWS_PING_URL:-}"
 
 # nvm으로 설치된 node를 cron(로그인 셸이 아님) 환경에서도 찾을 수 있게 한다.
 export NVM_DIR="$HOME/.nvm"

--- a/server/scripts/period-reviews-checked.sh
+++ b/server/scripts/period-reviews-checked.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# period_reviews 생성 cron 래퍼 — generate-period-reviews.js를 실행하고
+# 성공/실패를 Healthchecks.io에 ping한다(데드맨스위치).
+#
+# 예전엔 서버 로컬 파일(~/bin/period-reviews-checked.sh)로만 존재했다. 저장소에
+# 코드로 편입해 재현 가능하게 한다. Ping URL은 코드에 두지 않고 인자로 받는다.
+#
+# 사용: period-reviews-checked.sh <healthchecks_ping_url>
+# crontab 예(서버 타임존 Asia/Seoul). rsync 배포가 실행 비트를 보존한다고 가정하지 않도록
+# bash를 명시적으로 붙인다:
+#   0 4 * * * bash /home/ubuntu/youtube-bias-feedback/server/scripts/period-reviews-checked.sh "https://hc-ping.com/xxxx" >> /home/ubuntu/period-reviews.log 2>&1
+
+set -uo pipefail
+
+PING_URL="${1:-}"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# nvm으로 설치된 node를 cron(로그인 셸이 아님) 환경에서도 찾을 수 있게 한다.
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+cd "$REPO_DIR" || exit 1
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] period-reviews 시작"
+node server/scripts/generate-period-reviews.js
+STATUS=$?
+
+if [ -z "$PING_URL" ]; then
+  echo "[period-reviews-checked] ping URL이 없어 Healthchecks 알림을 건너뜁니다." >&2
+elif [ "$STATUS" -eq 0 ]; then
+  # 네트워크 오류로 무한 대기해 다음 cron까지 막지 않도록 타임아웃·재시도 횟수를 제한한다.
+  curl -fsS -m 10 --retry 3 "$PING_URL" -o /dev/null
+else
+  curl -fsS -m 10 --retry 3 "$PING_URL/fail" -o /dev/null
+fi
+
+exit "$STATUS"

--- a/server/test/monitoring/error-monitor.test.js
+++ b/server/test/monitoring/error-monitor.test.js
@@ -75,12 +75,27 @@ function fakeFs({ exists = true, size, ino, content }) {
 }
 
 describe("readNewText — 커서 이후만 읽기 + 로테이션 대응", () => {
-  it("파일이 없으면 빈 텍스트와 offset 0을 반환한다", () => {
+  it("파일이 없으면 ok:false와 이유를 반환한다(무음 성공 처리 방지)", () => {
     const fsImpl = fakeFs({ exists: false, size: 0, ino: 1, content: "" });
 
     const result = readNewText("/no/such/file.log", {}, fsImpl);
 
-    expect(result).toEqual({ text: "", cursor: { inode: null, offset: 0 } });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("/no/such/file.log");
+    expect(result.text).toBe("");
+    expect(result.cursor).toEqual({ inode: null, offset: 0 });
+  });
+
+  it("파일을 여는 도중 예외가 나도(권한 문제 등) ok:false로 안전하게 반환한다", () => {
+    const fsImpl = fakeFs({ size: 10, ino: 100, content: "[Error] x\n" });
+    fsImpl.openSync = () => {
+      throw new Error("EACCES: permission denied");
+    };
+
+    const result = readNewText("/log", {}, fsImpl);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("permission denied");
   });
 
   it("커서가 없으면(최초 실행) 파일 전체를 읽는다", () => {
@@ -89,6 +104,7 @@ describe("readNewText — 커서 이후만 읽기 + 로테이션 대응", () => 
 
     const result = readNewText("/log", {}, fsImpl);
 
+    expect(result.ok).toBe(true);
     expect(result.text).toBe(content);
     expect(result.cursor).toEqual({ inode: 100, offset: content.length });
   });

--- a/server/test/monitoring/error-monitor.test.js
+++ b/server/test/monitoring/error-monitor.test.js
@@ -4,6 +4,7 @@ import {
   fingerprint,
   readNewText,
   decideAlerts,
+  shouldPersistState,
 } from "../../monitoring/error-monitor.js";
 
 describe("extractErrorLines", () => {
@@ -246,5 +247,21 @@ describe("decideAlerts — 지문 + 쿨다운 기반 중복 알림 방지", () =
 
     expect(alerts).toHaveLength(2);
     expect(new Set(alerts.map((x) => x.fingerprint)).size).toBe(2);
+  });
+});
+
+describe("shouldPersistState — ping이 진짜로 성공/스킵했을 때만 상태 저장을 허용", () => {
+  it("전송에 성공하면(ok:true) 저장을 허용한다", () => {
+    expect(shouldPersistState({ skipped: false, ok: true })).toBe(true);
+  });
+
+  it("ping URL이 없어 애초에 안 보냈으면(skipped:true) 저장을 허용한다", () => {
+    expect(shouldPersistState({ skipped: true, ok: false })).toBe(true);
+  });
+
+  it("실제로 전송을 시도했다가 실패했으면(ok:false, skipped:false) 저장을 막는다", () => {
+    expect(
+      shouldPersistState({ skipped: false, ok: false, error: "network down" }),
+    ).toBe(false);
   });
 });

--- a/server/test/monitoring/error-monitor.test.js
+++ b/server/test/monitoring/error-monitor.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractErrorLines,
+  fingerprint,
+  readNewText,
+  decideAlerts,
+} from "../../monitoring/error-monitor.js";
+
+describe("extractErrorLines", () => {
+  it("[Error] 접두사가 붙은 라인만 추출한다", () => {
+    const text = [
+      "[Error] POST /api/sessions : database is locked",
+      "server listening on 3000",
+      "[Error] GET /api/video-events : no such table",
+      "",
+    ].join("\n");
+
+    expect(extractErrorLines(text)).toEqual([
+      "[Error] POST /api/sessions : database is locked",
+      "[Error] GET /api/video-events : no such table",
+    ]);
+  });
+
+  it("에러 라인이 없으면 빈 배열을 반환한다", () => {
+    expect(extractErrorLines("all good\nnothing here\n")).toEqual([]);
+  });
+
+  it("빈 텍스트에도 크래시하지 않는다", () => {
+    expect(extractErrorLines("")).toEqual([]);
+  });
+});
+
+describe("fingerprint — 같은 종류의 에러는 동적 값이 달라도 같은 지문", () => {
+  it("숫자만 다른 두 에러 메시지는 같은 지문을 갖는다", () => {
+    const a = "[Error] PATCH /api/sessions/12345/feedback-viewed : no row";
+    const b = "[Error] PATCH /api/sessions/98765/feedback-viewed : no row";
+
+    expect(fingerprint(a)).toBe(fingerprint(b));
+  });
+
+  it("UUID만 다른 두 에러 메시지는 같은 지문을 갖는다", () => {
+    const a =
+      "[Error] POST /api/video-events : dup eventId 11111111-1111-1111-1111-111111111111";
+    const b =
+      "[Error] POST /api/video-events : dup eventId 22222222-2222-2222-2222-222222222222";
+
+    expect(fingerprint(a)).toBe(fingerprint(b));
+  });
+
+  it("서로 다른 종류의 에러는 다른 지문을 갖는다", () => {
+    const a = "[Error] POST /api/sessions : database is locked";
+    const b = "[Error] GET /api/video-events : no such table";
+
+    expect(fingerprint(a)).not.toBe(fingerprint(b));
+  });
+});
+
+// fs 대신 가짜 fsImpl을 주입해, 실제 OS의 inode 재사용 여부와 무관하게
+// 로테이션 감지 로직을 결정론적으로 검증한다.
+function fakeFs({ exists = true, size, ino, content }) {
+  return {
+    existsSync: () => exists,
+    statSync: () => ({ size, ino }),
+    openSync: () => "fd",
+    readSync: (_fd, buffer, _offset, length, position) => {
+      const slice = Buffer.from(content, "utf8").subarray(
+        position,
+        position + length,
+      );
+      slice.copy(buffer);
+      return slice.length;
+    },
+    closeSync: () => {},
+  };
+}
+
+describe("readNewText — 커서 이후만 읽기 + 로테이션 대응", () => {
+  it("파일이 없으면 빈 텍스트와 offset 0을 반환한다", () => {
+    const fsImpl = fakeFs({ exists: false, size: 0, ino: 1, content: "" });
+
+    const result = readNewText("/no/such/file.log", {}, fsImpl);
+
+    expect(result).toEqual({ text: "", cursor: { inode: null, offset: 0 } });
+  });
+
+  it("커서가 없으면(최초 실행) 파일 전체를 읽는다", () => {
+    const content = "[Error] first\n";
+    const fsImpl = fakeFs({ size: content.length, ino: 100, content });
+
+    const result = readNewText("/log", {}, fsImpl);
+
+    expect(result.text).toBe(content);
+    expect(result.cursor).toEqual({ inode: 100, offset: content.length });
+  });
+
+  it("커서 이후 추가된 바이트만 읽는다", () => {
+    const content = "[Error] first\n[Error] second\n";
+    const prevOffset = "[Error] first\n".length;
+    const fsImpl = fakeFs({ size: content.length, ino: 100, content });
+
+    const result = readNewText(
+      "/log",
+      { inode: 100, offset: prevOffset },
+      fsImpl,
+    );
+
+    expect(result.text).toBe("[Error] second\n");
+  });
+
+  it("새로 추가된 내용이 없으면 빈 텍스트를 반환한다", () => {
+    const content = "[Error] first\n";
+    const fsImpl = fakeFs({ size: content.length, ino: 100, content });
+
+    const result = readNewText(
+      "/log",
+      { inode: 100, offset: content.length },
+      fsImpl,
+    );
+
+    expect(result.text).toBe("");
+    expect(result.cursor.offset).toBe(content.length);
+  });
+
+  it("inode가 바뀌면(로그 로테이션) 커서를 0으로 리셋해 새 파일 전체를 읽는다", () => {
+    const content = "[Error] after rotation\n";
+    const fsImpl = fakeFs({ size: content.length, ino: 200, content });
+
+    const result = readNewText(
+      "/log",
+      { inode: 100, offset: 9999 },
+      fsImpl,
+    );
+
+    expect(result.text).toBe(content);
+    expect(result.cursor).toEqual({ inode: 200, offset: content.length });
+  });
+
+  it("저장된 offset이 현재 파일 크기보다 크면(로테이션 방증) 리셋한다", () => {
+    const content = "[Error] short\n";
+    const fsImpl = fakeFs({ size: content.length, ino: 100, content });
+
+    const result = readNewText(
+      "/log",
+      { inode: 100, offset: content.length + 500 },
+      fsImpl,
+    );
+
+    expect(result.text).toBe(content);
+  });
+});
+
+describe("decideAlerts — 지문 + 쿨다운 기반 중복 알림 방지", () => {
+  it("에러가 없으면 알림도 없고 기존 지문 상태를 그대로 유지한다", () => {
+    const prev = { abc: { firstSeenAt: 0, lastAlertedAt: 0, count: 3 } };
+
+    const { alerts, fingerprints } = decideAlerts([], prev, 1000);
+
+    expect(alerts).toEqual([]);
+    expect(fingerprints).toEqual(prev);
+  });
+
+  it("처음 보는 에러는 즉시 알림 대상이다", () => {
+    const line = "[Error] POST /api/sessions : database is locked";
+
+    const { alerts, fingerprints } = decideAlerts([line], {}, 1000);
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({ message: line, count: 1, isNew: true });
+    expect(fingerprints[alerts[0].fingerprint]).toEqual({
+      firstSeenAt: 1000,
+      lastAlertedAt: 1000,
+      count: 1,
+    });
+  });
+
+  it("같은 실행 안에서 동일 에러가 여러 번 나오면 하나로 묶어 횟수만 합산한다", () => {
+    const line = "[Error] POST /api/sessions : database is locked";
+
+    const { alerts } = decideAlerts([line, line, line], {}, 1000);
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].count).toBe(3);
+  });
+
+  it("쿨다운 안에서 같은 에러가 다시 나오면 알림을 억제하되 누적 횟수는 계속 센다", () => {
+    const line = "[Error] POST /api/sessions : database is locked";
+    const cooldownMs = 30 * 60 * 1000;
+    const first = decideAlerts([line], {}, 0, cooldownMs);
+
+    const second = decideAlerts(
+      [line],
+      first.fingerprints,
+      cooldownMs - 1, // 쿨다운이 채 지나지 않은 시점
+      cooldownMs,
+    );
+
+    expect(second.alerts).toEqual([]);
+    const fp = Object.keys(second.fingerprints)[0];
+    expect(second.fingerprints[fp].count).toBe(2);
+    expect(second.fingerprints[fp].lastAlertedAt).toBe(0); // 갱신되지 않음
+  });
+
+  it("쿨다운이 지나 같은 에러가 다시 나오면 누적 횟수와 함께 재알림한다", () => {
+    const line = "[Error] POST /api/sessions : database is locked";
+    const cooldownMs = 30 * 60 * 1000;
+    const first = decideAlerts([line], {}, 0, cooldownMs);
+    const second = decideAlerts(
+      [line],
+      first.fingerprints,
+      cooldownMs - 1,
+      cooldownMs,
+    ); // 쿨다운 내 억제, count=2 누적
+
+    const third = decideAlerts(
+      [line],
+      second.fingerprints,
+      cooldownMs + 1, // 쿨다운 경과
+      cooldownMs,
+    );
+
+    expect(third.alerts).toHaveLength(1);
+    expect(third.alerts[0]).toMatchObject({ count: 3, isNew: false });
+  });
+
+  it("서로 다른 에러는 독립적으로 판정된다", () => {
+    const a = "[Error] POST /api/sessions : database is locked";
+    const b = "[Error] GET /api/video-events : no such table";
+
+    const { alerts } = decideAlerts([a, b], {}, 1000);
+
+    expect(alerts).toHaveLength(2);
+    expect(new Set(alerts.map((x) => x.fingerprint)).size).toBe(2);
+  });
+});

--- a/server/test/monitoring/healthchecks-ping.test.js
+++ b/server/test/monitoring/healthchecks-ping.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { pingSuccess, pingFail } from "../../monitoring/healthchecks-ping.js";
+
+describe("pingSuccess/pingFail — 환경변수 누락", () => {
+  it("환경변수가 없으면 네트워크 호출 없이 안전하게 건너뛴다", async () => {
+    const fetchImpl = vi.fn();
+    const result = await pingSuccess("MISSING_PING_URL", {
+      env: {},
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ skipped: true, ok: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("pingFail도 환경변수가 없으면 건너뛴다", async () => {
+    const fetchImpl = vi.fn();
+    const result = await pingFail("MISSING_PING_URL", "에러 상세", {
+      env: {},
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ skipped: true, ok: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("pingSuccess — 정상 ping", () => {
+  it("GET으로 ping URL을 그대로 호출한다", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+
+    const result = await pingSuccess("PING_URL", { env, fetchImpl });
+
+    expect(result).toEqual({ skipped: false, ok: true });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://hc-ping.com/abc-123",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("URL 끝의 슬래시는 제거하고 호출한다", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+    const env = { PING_URL: "https://hc-ping.com/abc-123/" };
+
+    await pingSuccess("PING_URL", { env, fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://hc-ping.com/abc-123",
+      expect.anything(),
+    );
+  });
+});
+
+describe("pingFail — 실패 ping", () => {
+  it("/fail 경로로 POST하고 detail을 본문에 담는다", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+
+    await pingFail("PING_URL", "DB 연결 실패", { env, fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://hc-ping.com/abc-123/fail",
+      expect.objectContaining({ method: "POST", body: "DB 연결 실패" }),
+    );
+  });
+
+  it("detail이 10000자를 넘으면 잘라서 보낸다(Healthchecks.io 본문 상한)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+    const longDetail = "x".repeat(20000);
+
+    await pingFail("PING_URL", longDetail, { env, fetchImpl });
+
+    const [, options] = fetchImpl.mock.calls[0];
+    expect(options.body).toHaveLength(10000);
+  });
+
+  it("detail 없이 호출해도 예외 없이 빈 본문으로 POST한다", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+
+    const result = await pingFail("PING_URL", undefined, { env, fetchImpl });
+
+    expect(result.ok).toBe(true);
+    const [, options] = fetchImpl.mock.calls[0];
+    expect(options.body).toBe("");
+  });
+});
+
+describe("네트워크 오류 처리", () => {
+  it("fetch가 실패해도 예외를 던지지 않고 ok:false를 반환한다", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+
+    const result = await pingSuccess("PING_URL", { env, fetchImpl });
+
+    expect(result).toEqual({
+      skipped: false,
+      ok: false,
+      error: "network down",
+    });
+  });
+
+  it("타임아웃 시에도 예외를 던지지 않는다(AbortError 흡수)", async () => {
+    const fetchImpl = vi.fn(
+      (_url, { signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () =>
+            reject(new Error("The operation was aborted")),
+          );
+        }),
+    );
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+
+    const result = await pingSuccess("PING_URL", {
+      env,
+      fetchImpl,
+      timeoutMs: 5,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/server/test/monitoring/healthchecks-ping.test.js
+++ b/server/test/monitoring/healthchecks-ping.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { pingSuccess, pingFail } from "../../monitoring/healthchecks-ping.js";
+import {
+  pingSuccess,
+  pingFail,
+  shouldPersistState,
+} from "../../monitoring/healthchecks-ping.js";
 
 describe("pingSuccess/pingFail — 환경변수 누락", () => {
   it("환경변수가 없으면 네트워크 호출 없이 안전하게 건너뛴다", async () => {
@@ -120,5 +124,39 @@ describe("네트워크 오류 처리", () => {
     });
 
     expect(result.ok).toBe(false);
+  });
+
+  it("HTTP 응답은 받았지만 상태 코드가 실패(4xx/5xx)면 ok:false로 판정한다(fetch는 이 경우 reject하지 않음)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+
+    const result = await pingSuccess("PING_URL", { env, fetchImpl });
+
+    expect(result).toEqual({ skipped: false, ok: false, error: "HTTP 404" });
+  });
+
+  it("pingFail도 HTTP 실패 응답을 ok:false로 판정한다", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    const env = { PING_URL: "https://hc-ping.com/abc-123" };
+
+    const result = await pingFail("PING_URL", "상세", { env, fetchImpl });
+
+    expect(result).toEqual({ skipped: false, ok: false, error: "HTTP 500" });
+  });
+});
+
+describe("shouldPersistState — ping이 진짜로 성공/스킵했을 때만 상태 저장을 허용", () => {
+  it("전송에 성공하면(ok:true) 저장을 허용한다", () => {
+    expect(shouldPersistState({ skipped: false, ok: true })).toBe(true);
+  });
+
+  it("ping URL이 없어 애초에 안 보냈으면(skipped:true) 저장을 허용한다", () => {
+    expect(shouldPersistState({ skipped: true, ok: false })).toBe(true);
+  });
+
+  it("실제로 전송을 시도했다가 실패했으면(ok:false, skipped:false) 저장을 막는다", () => {
+    expect(
+      shouldPersistState({ skipped: false, ok: false, error: "HTTP 404" }),
+    ).toBe(false);
   });
 });

--- a/server/test/monitoring/research-pipeline-monitor.test.js
+++ b/server/test/monitoring/research-pipeline-monitor.test.js
@@ -200,6 +200,34 @@ describe("collectRecentActivity — 실제 DB 배선", () => {
     expect(hasWeekOldParticipant).toBe(true);
   });
 
+  it("sessions.createdAt(공백 구분, 시간대 표기 없음)을 서버 로컬 시간대와 무관하게 UTC로 파싱한다", () => {
+    db.prepare(
+      "INSERT INTO participants (anonymousId, group_code, installDate) VALUES (?, ?, ?)",
+    ).run("p1", "EXP", "2026-01-01T00:00:00Z");
+
+    // sessions.createdAt은 실제로 SQLite datetime('now')가 만드는 형식(공백 구분,
+    // 시간대 표기 없음)과 동일하게 직접 삽입한다 — 이 값은 UTC 값이다.
+    db.prepare(
+      `INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, createdAt)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      "p1",
+      "s-utc-parse",
+      "2026-08-30T12:00:00Z",
+      "2026-08-30T12:00:00Z",
+      "2026-08-30 12:00:00",
+    );
+
+    const now = Date.parse("2026-08-30T18:00:00Z");
+    const { events } = collectRecentActivity(db, now, 6 * HOUR);
+
+    // Date.UTC는 실행 환경의 로컬 시간대와 무관하게 항상 같은 절대 epoch를 만들어내므로,
+    // 이 값과 정확히 일치해야만 createdAt이 (로컬 시간대로 오파싱되지 않고) UTC로 올바르게
+    // 해석된 것이다. 이 저장소의 개발 환경(Asia/Seoul, UTC+9)에서는 수정 전 코드로 실행하면
+    // 9시간 밀려 파싱되어 이 테스트가 실패한다(직접 재현 확인).
+    expect(events).toContain(Date.UTC(2026, 7, 30, 12, 0, 0));
+  });
+
   it("video_events(ISO 문자열)와 sessions(SQLite datetime 문자열)를 모두 epoch ms로 모은다", () => {
     db.prepare(
       "INSERT INTO participants (anonymousId, group_code, installDate) VALUES (?, ?, ?)",

--- a/server/test/monitoring/research-pipeline-monitor.test.js
+++ b/server/test/monitoring/research-pipeline-monitor.test.js
@@ -239,4 +239,24 @@ describe("collectRecentActivity — 실제 DB 배선", () => {
     expect(events).toHaveLength(2);
     expect(events.every((ts) => ts >= now - lookbackMs)).toBe(true);
   });
+
+  it("video_events.watchedAt에 타임존 오프셋이 섞여도 절대 시각 기준으로 비교한다(문자열 비교 시 오탐 방지)", () => {
+    db.prepare(
+      "INSERT INTO participants (anonymousId, group_code, installDate) VALUES (?, ?, ?)",
+    ).run("p1", "EXP", "2026-01-01T00:00:00Z");
+
+    const now = Date.parse("2026-08-30T12:00:00Z");
+    const lookbackMs = 6 * HOUR; // cutoff = 2026-08-30T06:00:00.000Z
+
+    // 절대 시각으로는 cutoff보다 1시간 이른(윈도우 밖) 이벤트지만, +09:00 오프셋 때문에
+    // 원본 문자열의 시(時) 자릿수가 커서("14" > "06") 단순 문자열 비교로는 윈도우 안으로
+    // 잘못 걸린다 — julianday() 정규화 비교가 아니면 이 테스트는 실패한다.
+    db.prepare(
+      "INSERT INTO video_events (anonymousId, videoId, watchedAt) VALUES (?, ?, ?)",
+    ).run("p1", "v-offset", "2026-08-30T14:00:00+09:00"); // = 2026-08-30T05:00:00Z
+
+    const { events } = collectRecentActivity(db, now, lookbackMs);
+
+    expect(events).toHaveLength(0);
+  });
 });

--- a/server/test/monitoring/research-pipeline-monitor.test.js
+++ b/server/test/monitoring/research-pipeline-monitor.test.js
@@ -1,0 +1,211 @@
+import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { evaluatePipelineHealth } from "../../monitoring/research-pipeline-monitor.js";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe("evaluatePipelineHealth — 순수 판정 로직", () => {
+  it("등록된 참여자가 없으면 항상 skipped(정상 취급)다", () => {
+    const result = evaluatePipelineHealth({
+      now: 1000,
+      events: [],
+      hasParticipants: false,
+    });
+    expect(result).toEqual({
+      status: "skipped",
+      reason: "no_participants",
+      consecutiveZero: 0,
+    });
+  });
+
+  it("최근 6시간 안에 이벤트가 있으면 정상이다", () => {
+    const now = 10 * DAY;
+    const result = evaluatePipelineHealth({
+      now,
+      events: [now - HOUR],
+      hasParticipants: true,
+    });
+    expect(result.status).toBe("ok");
+    expect(result.currentCount).toBe(1);
+    expect(result.consecutiveZero).toBe(0);
+  });
+
+  it("현재 0건이고 7일 전 같은 시간대엔 활동이 있었으면 alert다(전체 침묵 의심)", () => {
+    const now = 10 * DAY;
+    const sevenDaysAgoActivity = now - 7 * DAY - 2 * HOUR; // 현재 윈도우(-6h~now)의 7일 전 대응 구간 안
+    const result = evaluatePipelineHealth({
+      now,
+      events: [sevenDaysAgoActivity],
+      hasParticipants: true,
+      hasWeekOldParticipant: true,
+    });
+    expect(result.status).toBe("alert");
+    expect(result.reason).toBe("flatline_vs_7_days_ago");
+    expect(result.compareCount).toBe(1);
+  });
+
+  it("현재 0건이지만 7일 전 같은 시간대도 원래 조용했으면 정상으로 간주한다(오탐 방지)", () => {
+    const now = 10 * DAY;
+    const result = evaluatePipelineHealth({
+      now,
+      events: [], // 비교 구간에도 이벤트 없음
+      hasParticipants: true,
+      hasWeekOldParticipant: true, // 비교할 참여자 히스토리는 있음
+    });
+    expect(result.status).toBe("ok");
+    expect(result.consecutiveZero).toBe(0);
+  });
+
+  it("비교할 만큼 오래된 참여자가 없을 때(연구 시작 초반) 1회 침묵은 warn_pending일 뿐 알리지 않는다", () => {
+    const now = 1 * DAY; // 아직 7일이 안 지난 이른 시점
+    const result = evaluatePipelineHealth({
+      now,
+      events: [],
+      hasParticipants: true,
+      hasWeekOldParticipant: false,
+      consecutiveZero: 0,
+    });
+    expect(result.status).toBe("warn_pending");
+    expect(result.consecutiveZero).toBe(1);
+  });
+
+  it("비교할 만큼 오래된 참여자가 없을 때 연속 2회(12시간) 침묵이면 alert다", () => {
+    const now = 1 * DAY;
+    const result = evaluatePipelineHealth({
+      now,
+      events: [],
+      hasParticipants: true,
+      hasWeekOldParticipant: false,
+      consecutiveZero: 1, // 직전 실행에서 이미 1회 침묵
+    });
+    expect(result.status).toBe("alert");
+    expect(result.reason).toBe("flatline_consecutive_windows");
+    expect(result.consecutiveZero).toBe(2);
+  });
+
+  it("침묵 이후 활동이 재개되면 consecutiveZero가 0으로 리셋된다", () => {
+    const now = 1 * DAY;
+    const result = evaluatePipelineHealth({
+      now,
+      events: [now - HOUR],
+      hasParticipants: true,
+      hasWeekOldParticipant: false,
+      consecutiveZero: 1,
+    });
+    expect(result.status).toBe("ok");
+    expect(result.consecutiveZero).toBe(0);
+  });
+});
+
+// collectRecentActivity는 실제 SQL(datetime() 정규화 포함)이 올바르게 동작하는지가
+// 핵심이라, db.test.js/sessions.wiring.test.js와 동일하게 실제 better-sqlite3 인스턴스로
+// 검증한다(가짜 DB 객체로는 SQL 문법 오류나 포맷 불일치를 잡아낼 수 없음).
+describe("collectRecentActivity — 실제 DB 배선", () => {
+  const require = createRequire(import.meta.url);
+  const TEST_DB_PATH = path.join(
+    os.tmpdir(),
+    `viewlens-pipeline-monitor-${process.pid}.db`,
+  );
+  fs.rmSync(TEST_DB_PATH, { force: true });
+  process.env.DB_ENCRYPTION_KEY = "vitest-in-memory-only";
+  process.env.DB_PATH = TEST_DB_PATH;
+
+  const { db, initializeDB } = require("../../db.js");
+  initializeDB();
+  const { collectRecentActivity } = require("../../monitoring/research-pipeline-monitor.js");
+
+  afterAll(() => {
+    db.close();
+    fs.rmSync(TEST_DB_PATH, { force: true });
+  });
+
+  beforeEach(() => {
+    db.exec("DELETE FROM participants");
+    db.exec("DELETE FROM video_events");
+    db.exec("DELETE FROM sessions");
+  });
+
+  function toSqliteDatetime(ms) {
+    return new Date(ms).toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
+  }
+
+  it("참여자가 없으면 hasParticipants=false다", () => {
+    const { hasParticipants } = collectRecentActivity(db, Date.now(), 7 * DAY);
+    expect(hasParticipants).toBe(false);
+  });
+
+  it("모든 참여자가 설치한 지 7일이 안 됐으면 hasWeekOldParticipant=false다", () => {
+    const now = Date.parse("2026-08-30T12:00:00Z");
+    db.prepare(
+      "INSERT INTO participants (anonymousId, group_code, installDate) VALUES (?, ?, ?)",
+    ).run("p1", "EXP", new Date(now - 3 * DAY).toISOString());
+
+    const { hasParticipants, hasWeekOldParticipant } = collectRecentActivity(
+      db,
+      now,
+      7 * DAY + 6 * HOUR,
+    );
+
+    expect(hasParticipants).toBe(true);
+    expect(hasWeekOldParticipant).toBe(false);
+  });
+
+  it("설치한 지 7일 이상 된 참여자가 있으면 hasWeekOldParticipant=true다", () => {
+    const now = Date.parse("2026-08-30T12:00:00Z");
+    db.prepare(
+      "INSERT INTO participants (anonymousId, group_code, installDate) VALUES (?, ?, ?)",
+    ).run("p1", "EXP", new Date(now - 8 * DAY).toISOString());
+
+    const { hasWeekOldParticipant } = collectRecentActivity(
+      db,
+      now,
+      7 * DAY + 6 * HOUR,
+    );
+
+    expect(hasWeekOldParticipant).toBe(true);
+  });
+
+  it("video_events(ISO 문자열)와 sessions(SQLite datetime 문자열)를 모두 epoch ms로 모은다", () => {
+    db.prepare(
+      "INSERT INTO participants (anonymousId, group_code, installDate) VALUES (?, ?, ?)",
+    ).run("p1", "EXP", "2026-01-01T00:00:00Z");
+
+    const now = Date.parse("2026-08-30T12:00:00Z");
+    const withinWindowIso = new Date(now - 2 * HOUR).toISOString();
+    const outsideLookbackIso = new Date(now - 10 * DAY).toISOString();
+
+    db.prepare(
+      "INSERT INTO video_events (anonymousId, videoId, watchedAt) VALUES (?, ?, ?)",
+    ).run("p1", "v1", withinWindowIso);
+    db.prepare(
+      "INSERT INTO video_events (anonymousId, videoId, watchedAt) VALUES (?, ?, ?)",
+    ).run("p1", "v2", outsideLookbackIso);
+
+    db.prepare(
+      `INSERT INTO sessions (anonymousId, sessionId, startTime, endTime, createdAt)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      "p1",
+      "s1",
+      withinWindowIso,
+      withinWindowIso,
+      toSqliteDatetime(now - 3 * HOUR),
+    );
+
+    const lookbackMs = 7 * DAY + 6 * HOUR;
+    const { hasParticipants, events } = collectRecentActivity(
+      db,
+      now,
+      lookbackMs,
+    );
+
+    expect(hasParticipants).toBe(true);
+    // 윈도우 안의 video_events 1건 + sessions 1건만 포함되고, 10일 전 video_events는 제외된다.
+    expect(events).toHaveLength(2);
+    expect(events.every((ts) => ts >= now - lookbackMs)).toBe(true);
+  });
+});

--- a/server/test/monitoring/research-pipeline-monitor.test.js
+++ b/server/test/monitoring/research-pipeline-monitor.test.js
@@ -5,7 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { evaluatePipelineHealth } from "../../monitoring/research-pipeline-monitor.js";
 
-const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
 describe("evaluatePipelineHealth — 순수 판정 로직", () => {
@@ -19,6 +20,7 @@ describe("evaluatePipelineHealth — 순수 판정 로직", () => {
       status: "skipped",
       reason: "no_participants",
       consecutiveZero: 0,
+      lastEvaluatedAt: 1000,
     });
   });
 
@@ -73,7 +75,7 @@ describe("evaluatePipelineHealth — 순수 판정 로직", () => {
     expect(result.consecutiveZero).toBe(1);
   });
 
-  it("비교할 만큼 오래된 참여자가 없을 때 연속 2회(12시간) 침묵이면 alert다", () => {
+  it("비교할 만큼 오래된 참여자가 없을 때, 직전 평가로부터 충분히(윈도우 절반 이상) 지난 연속 2회째 침묵이면 alert다", () => {
     const now = 1 * DAY;
     const result = evaluatePipelineHealth({
       now,
@@ -81,10 +83,39 @@ describe("evaluatePipelineHealth — 순수 판정 로직", () => {
       hasParticipants: true,
       hasWeekOldParticipant: false,
       consecutiveZero: 1, // 직전 실행에서 이미 1회 침묵
+      lastEvaluatedAt: now - 6 * HOUR, // 정상적인 6시간 간격 재실행
     });
     expect(result.status).toBe("alert");
     expect(result.reason).toBe("flatline_consecutive_windows");
     expect(result.consecutiveZero).toBe(2);
+  });
+
+  it("직전 평가로부터 너무 짧은 간격(예: 수동 재실행)으로 다시 실행되면 카운터를 증가시키지 않는다(허위 경보 방지)", () => {
+    const now = 1 * DAY;
+    const result = evaluatePipelineHealth({
+      now,
+      events: [],
+      hasParticipants: true,
+      hasWeekOldParticipant: false,
+      consecutiveZero: 1, // 직전 실행에서 이미 1회 침묵로 카운트됨
+      lastEvaluatedAt: now - 5 * MINUTE, // 몇 분 전에 막 실행됐음(같은 창 안 재실행)
+    });
+    expect(result.status).toBe("warn_pending");
+    expect(result.consecutiveZero).toBe(1); // 증가하지 않고 그대로
+  });
+
+  it("직전 평가 시각이 없으면(최초 실행) 첫 침묵을 정상적으로 1로 센다", () => {
+    const now = 1 * DAY;
+    const result = evaluatePipelineHealth({
+      now,
+      events: [],
+      hasParticipants: true,
+      hasWeekOldParticipant: false,
+      consecutiveZero: 0,
+      lastEvaluatedAt: null,
+    });
+    expect(result.status).toBe("warn_pending");
+    expect(result.consecutiveZero).toBe(1);
   });
 
   it("침묵 이후 활동이 재개되면 consecutiveZero가 0으로 리셋된다", () => {

--- a/server/test/monitoring/server-health-check.test.js
+++ b/server/test/monitoring/server-health-check.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { checkHealth } from "../../monitoring/server-health-check.js";
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+describe("checkHealth", () => {
+  it("db:ok 응답이면 정상으로 판정한다", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { data: { db: "ok" } }));
+
+    const result = await checkHealth({
+      healthUrl: "https://example.test/health",
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("HTTP 상태가 실패면 이유와 함께 실패로 판정한다", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(500, {}));
+
+    const result = await checkHealth({
+      healthUrl: "https://example.test/health",
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("HTTP 500");
+  });
+
+  it("HTTP는 200이지만 db가 fail이면 실패로 판정한다", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { data: { db: "fail" } }));
+
+    const result = await checkHealth({
+      healthUrl: "https://example.test/health",
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("db=fail");
+  });
+
+  it("네트워크 오류가 나도 예외를 던지지 않고 실패 사유를 반환한다", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const result = await checkHealth({
+      healthUrl: "https://example.test/health",
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "ECONNREFUSED" });
+  });
+
+  it("응답 본문에 data가 없어도 크래시하지 않는다", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+
+    const result = await checkHealth({
+      healthUrl: "https://example.test/health",
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("db=unknown");
+  });
+});

--- a/server/test/monitoring/state.test.js
+++ b/server/test/monitoring/state.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { statePath, readState, writeState } from "../../monitoring/state.js";
+
+describe("state — 모니터링 상태 파일 저장소", () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "viewlens-monitor-state-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("statePath는 dir 아래 <name>.json 경로를 만든다", () => {
+    expect(statePath("error-monitor", dir)).toBe(
+      path.join(dir, "error-monitor.json"),
+    );
+  });
+
+  it("파일이 없으면(최초 실행) fallback을 반환한다", () => {
+    const result = readState("error-monitor", { offset: 0 }, dir);
+    expect(result).toEqual({ offset: 0 });
+  });
+
+  it("writeState로 저장한 값을 readState로 그대로 읽는다", () => {
+    const data = { offset: 42, fingerprints: { abc123: { count: 3 } } };
+    writeState("error-monitor", data, dir);
+
+    expect(readState("error-monitor", {}, dir)).toEqual(data);
+  });
+
+  it("디렉터리가 아직 없어도 writeState가 생성한다", () => {
+    const nested = path.join(dir, "nested", "sub");
+    writeState("cursor", { offset: 1 }, nested);
+
+    expect(readState("cursor", {}, nested)).toEqual({ offset: 1 });
+  });
+
+  it("쓰기 후 임시 파일(.tmp-*)이 남지 않는다(원자적 교체)", () => {
+    writeState("error-monitor", { offset: 1 }, dir);
+
+    const files = fs.readdirSync(dir);
+    expect(files).toEqual(["error-monitor.json"]);
+  });
+
+  it("JSON이 손상돼도 예외를 던지지 않고 fallback을 반환한다", () => {
+    const file = statePath("broken", dir);
+    fs.writeFileSync(file, "{ not valid json");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = readState("broken", { safe: true }, dir);
+
+    expect(result).toEqual({ safe: true });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("다시 쓰면 이전 값을 덮어쓴다", () => {
+    writeState("error-monitor", { offset: 1 }, dir);
+    writeState("error-monitor", { offset: 2 }, dir);
+
+    expect(readState("error-monitor", {}, dir)).toEqual({ offset: 2 });
+  });
+});

--- a/server/test/routes/health.test.js
+++ b/server/test/routes/health.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { buildHealthPayload } from "../../routes/health.js";
+
+describe("buildHealthPayload", () => {
+  it("DB 접근이 정상이면 healthy/ok를 반환한다", () => {
+    const db = { prepare: () => ({ get: () => ({ 1: 1 }) }) };
+
+    const result = buildHealthPayload(db, () => 123);
+
+    expect(result).toEqual({ status: "healthy", db: "ok", timestamp: 123 });
+  });
+
+  it("DB 접근이 실패하면 예외를 던지지 않고 degraded/fail을 반환한다", () => {
+    const db = {
+      prepare: () => {
+        throw new Error("database is locked");
+      },
+    };
+
+    expect(() => buildHealthPayload(db)).not.toThrow();
+    const result = buildHealthPayload(db, () => 456);
+    expect(result).toEqual({ status: "degraded", db: "fail", timestamp: 456 });
+  });
+
+  it("prepare는 성공하지만 get()이 실패해도 degraded/fail을 반환한다", () => {
+    const db = {
+      prepare: () => ({
+        get: () => {
+          throw new Error("disk I/O error");
+        },
+      }),
+    };
+
+    const result = buildHealthPayload(db, () => 789);
+    expect(result).toEqual({ status: "degraded", db: "fail", timestamp: 789 });
+  });
+});


### PR DESCRIPTION
## 개요

6주 연구 기간 동안 서버 다운·DB 실패·크론 중단·심각한 에러·연구 데이터 수집 파이프라인 중단을 관리자가 매일 서버에 접속하지 않아도 놓치지 않도록, Healthchecks.io 기반 최소 관제 체계를 구축한다. 기존에 서버 로컬 파일로만 존재하던 크론 데드맨스위치 3개(백업×2, period-reviews×1)를 저장소 코드로 편입하고, 서버/DB 헬스체크·에러 로그 무음 실패 감시·연구 데이터 파이프라인 침묵 장애 감시를 새로 추가한다.

## 변경 사항

- `server/monitoring/healthchecks-ping.js`, `server/monitoring/state.js`: 모니터링 스크립트 공유 인프라  
- `server/routes/health.js`, `server/app.js`: `/health`에 DB `SELECT 1` 확인 추가, 서버 다운과 DB 장애를 구분해 응답  
- `server/monitoring/server-health-check.js`: `/health`를 외부에서 주기적으로 확인하는 모니터  
- `server/monitoring/error-monitor.js`: PM2 에러 로그를 커서 기반으로 감시, 지문(fingerprint)+쿨다운으로 중복 알림 방지  
- `server/monitoring/research-pipeline-monitor.js`: 전체 참여자 시청 활동을 7일 전 동일 시간대(히스토리 없으면 연속 2회 규칙)와 비교해 파이프라인 전체 침묵을 감지. 참여자 규모(2차 테스트 ~20명 → 본조사 80명) 변화에 영향받지 않도록 절대 임계값 대신 상대 비교로 설계
- `server/scripts/period-reviews-checked.sh`, `server/scripts/backup-checked.sh`: 기존 서버 로컬 크론 래퍼(`~/bin/*.sh`)를 저장소 코드로 재현  
- `.github/workflows/deploy-server.yml`: 배포 시 `server/.env`가 통째로 재생성되며 신규 모니터링 환경변수가 매번 초기화되던 문제 수정  
- `.github/workflows/ci.yml`: 신규 파일 구문 검증 추가(`node --check` 5개, `bash -n` 2개)  
- `server/.env.example`: 신규 환경변수 키 이름 추가  

## 관련 이슈

- closes #172 

## 테스트 확인

- [x] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인  
- [x] 콘솔 에러 없음 
- [x] `pnpm test` 전체 스위트(549개) 통과, 단계별 커밋마다 회귀 없음 확인
- [x] 신규 셸 스크립트 2개 `bash -n` 구문 검증 통과 + 실제 실행(성공/실패/ping URL 누락 3개 경로) 스모크 테스트
- [ ] 서버 배포 후 실제 crontab 등록 + Healthchecks.io 대시보드에서 6개 체크 Up 확인 
  
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 데이터베이스 상태를 포함한 서버 헬스체크 정보를 제공합니다.
  * 서버 장애, 오류 로그, 연구 데이터 수집 중단을 감지하고 외부 모니터링 서비스에 성공·실패 알림을 전송합니다.
  * 백업 및 정기 리뷰 작업 결과를 모니터링할 수 있습니다.
  * 로그 순환과 중복 알림을 처리하며 모니터링 상태를 안전하게 저장합니다.
* **개선 사항**
  * 배포 환경의 모니터링 설정과 서버·셸 스크립트 문법 검증을 강화했습니다.
* **테스트**
  * 헬스체크 및 모니터링 동작에 대한 검증을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->