### PR TITLE
feat: 세션·영상 이벤트 서버 전송 실패 시 로컬 재시도 큐로 데이터 유실 방지

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -96,8 +96,11 @@ chrome.storage.local.set({ serverUrl: SERVER_URL });
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name !== ALARM_NAME) return;
-  // 이번 세션 종료 감지보다 먼저 돌려야, 방금 끝난 세션이 아직 syncedToServer 필드조차
-  // 없는 상태로 이 틱에서 중복 시도되지 않는다(다음 틱부터 재시도 대상이 됨).
+  // 셋 다 await 없이 실행하므로 서로 순서가 보장되지 않는다 — 예를 들어
+  // checkSessionTimeout이 세션을 막 끝낸 직후 같은 세션을 retryUnsyncedSessions가
+  // 이 틱에서 곧바로 다시 집어도(혹은 그 반대여도) 안전하다: 서버가 세션은 409(중복
+  // 세션), 영상은 eventId 기반 OR IGNORE로 멱등 처리하므로 중복 전송이 일어나도
+  // 여분의 요청 하나로 끝나고 데이터가 중복 저장되거나 알림이 두 번 뜨지 않는다.
   retryUnsyncedSessions();
   retryUnsentVideoEvents();
   checkSessionTimeout();
@@ -290,6 +293,8 @@ async function postVideoEventToServer(anonymousId, event) {
         title: event.title ?? null,
         watchedAt: event.watchedAt,
         sessionId: event.sessionId,
+        // 같은 eventId로 재전송되면 서버가 INSERT OR IGNORE로 걸러내 이미 성공했던 전송을 다시 보내도 중복 행이 남지 않는다.
+        eventId: event.eventId,
       }),
     });
     if (!response.ok) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -97,6 +97,9 @@ chrome.storage.local.set({ serverUrl: SERVER_URL });
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name !== ALARM_NAME) return;
+  // 이번 세션 종료 감지보다 먼저 돌려야, 방금 끝난 세션이 아직 syncedToServer 필드조차
+  // 없는 상태로 이 틱에서 중복 시도되지 않는다(다음 틱부터 재시도 대상이 됨).
+  retryUnsyncedSessions();
   checkSessionTimeout();
 });
 
@@ -170,13 +173,29 @@ export async function analyzeSession(session) {
   const entropy = calculateEntropy(categoryDistribution);
   const videoCount = session.videos.length;
 
+  // syncedToServer를 false로 명시해둬야, 곧이어 서버 전송이 오프라인/오류로 실패했을 때
+  // retryUnsyncedSessions()가 이 세션을 재시도 대상으로 찾아낼 수 있다(이 필드가 아예
+  // 없는 - 이 기능이 생기기 전에 이미 분석됐던 - 세션과 구분하기 위한 값이다).
   await saveAnalysis(session.sessionId, {
     categoryDistribution,
     entropy,
     videoCount,
+    syncedToServer: false,
   });
   console.log("[background] 분석 완료:", { entropy, categoryDistribution });
 
+  const totalMs = Date.now() - t0;
+  await syncSessionToServer(
+    { ...session, categoryDistribution, entropy, videoCount },
+    { totalMs, youtubeMs },
+  );
+}
+
+// 세션 분석 결과를 서버로 보내고, 응답에 따라 오늘 리뷰 반영·알림까지 처리한다.
+// analyzeSession(최초 전송)과 retryUnsyncedSessions(재시도)가 이 함수를 공유한다 —
+// 최초 시도가 오프라인/서버 오류로 실패해도 syncedToServer가 false로 남기 때문에,
+// pendingPopupEvents 큐(팝업 이벤트용)와 같은 취지로 다음 1분 알람 틱마다 다시 시도된다.
+async function syncSessionToServer(session, metrics = {}) {
   // 알림 자격은 리뷰 생성 결과와 무관하게(그룹·베이스라인만으로) 미리 정해진다.
   // 이 값을 그대로 서버에 함께 보내 sessions.feedbackNotifiedAt에 기록한다.
   const onboarding = await getOnboarding();
@@ -188,15 +207,25 @@ export async function analyzeSession(session) {
     ? new Date().toISOString()
     : null;
 
-  const totalMs = Date.now() - t0;
   const postResult = await postSessionToServer(
     session,
-    categoryDistribution,
-    entropy,
-    videoCount,
+    session.categoryDistribution,
+    session.entropy,
+    session.videoCount,
     onboarding,
-    { totalMs, youtubeMs, feedbackNotifiedAt },
+    { ...metrics, feedbackNotifiedAt },
   );
+
+  // 이전 시도가 서버엔 이미 저장됐지만(중복 세션 오류) 그 응답만 못 받아 실패로 남았던
+  // 경우다 — 다시 보낼 필요는 없으니 재시도 대상에서만 제외한다.
+  if (postResult === "DUPLICATE") {
+    await saveAnalysis(session.sessionId, { syncedToServer: true });
+    return;
+  }
+  // 이번에도 실패 — syncedToServer는 false로 남아 다음 알람 틱에서 다시 시도된다.
+  if (postResult === null) return;
+
+  await saveAnalysis(session.sessionId, { syncedToServer: true });
 
   const todayReview = postResult?.todayReview ?? null;
   if (todayReview) {
@@ -214,6 +243,21 @@ export async function analyzeSession(session) {
   // 보이는 불일치가 생기기 때문이다.
   if (eligibleForNotification && todayReview) {
     showFeedbackNotification(session);
+  }
+}
+
+// 1분마다 도는 알람에서 checkSessionTimeout과 함께 호출된다. 세션 종료 시점에
+// 오프라인/서버 오류로 서버 전송이 실패해 syncedToServer가 false로 남은 세션을 다시
+// 보낸다 — 서버 장애·일시적 오프라인으로 인한 연구 데이터 유실을 막는 유일한 재시도
+// 경로다(연구 무결성 점검 항목 "서버 장애 대비 로컬 큐잉/재시도" 후속 조치).
+export async function retryUnsyncedSessions() {
+  const sessions = await getAllSessions();
+  const unsynced = sessions.filter(
+    (s) => s.categoryDistribution && s.syncedToServer === false,
+  );
+  for (const session of unsynced) {
+    // 재시도라 최초 지연시간(totalMs/youtubeMs)은 더 이상 의미가 없어 보내지 않는다.
+    await syncSessionToServer(session);
   }
 }
 
@@ -295,7 +339,9 @@ async function postSessionToServer(
     if (!response.ok) {
       const body = await response.text();
       console.warn("[background] 서버 전송 실패:", response.status, body);
-      return null;
+      // 409(중복 세션) — 이전 시도가 서버엔 이미 반영됐지만 응답만 못 받았던 경우다.
+      // 호출부(syncSessionToServer)가 재전송 없이 재시도 목록에서만 빼도록 구분해 알려준다.
+      return response.status === 409 ? "DUPLICATE" : null;
     }
 
     console.log("[background] 서버 전송 완료:", session.sessionId);

--- a/extension/background.js
+++ b/extension/background.js
@@ -5,6 +5,8 @@ import {
   getAllSessions,
   saveAnalysis,
   getOnboarding,
+  getUnsentVideoEvents,
+  markVideoEventSent,
 } from "./storage.js";
 import { fetchVideoCategories } from "./pipeline/youtube.js";
 import {
@@ -17,11 +19,8 @@ import { SERVER_URL } from "./config.js";
 const ALARM_NAME = "SESSION_TIMEOUT_CHECK";
 const TIMEOUT_MS = 10 * 60 * 1000;
 
-// 분석 완료 알림 대상 판정 (10-8). EXP 그룹이면서 베이스라인 기간(설치 후 14일)이
-// 끝난 경우에만 알림·배지를 노출한다 — 판정 로직을 이 한 곳에 모아둬 알림·배지·서버
-// 코드는 건드릴 필요가 없게 한다.
-// extension/popup/viewlens-data.js의 GROUPS 중 feedback:true인 그룹(EXP/TEST-EXP)과
-// 반드시 동일하게 유지해야 한다 — background.js는 popup 쪽 데이터 파일을 import할 수 없어(모듈 경계) 중복 정의한다.
+// 분석 완료 알림 대상 판정. EXP 그룹이면서 베이스라인 기간(설치 후 14일)이
+// 끝난 경우에만 알림·배지를 노출한다.
 const FEEDBACK_ELIGIBLE_GROUPS = new Set(["EXP", "TEST-EXP"]);
 
 // TEST-EXP(연구자 모드)는 "모든 화면을 미리 볼 수 있다"는 설계 의도(GROUPS 주석 참고)가 있어,
@@ -100,6 +99,7 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   // 이번 세션 종료 감지보다 먼저 돌려야, 방금 끝난 세션이 아직 syncedToServer 필드조차
   // 없는 상태로 이 틱에서 중복 시도되지 않는다(다음 틱부터 재시도 대상이 됨).
   retryUnsyncedSessions();
+  retryUnsentVideoEvents();
   checkSessionTimeout();
 });
 
@@ -258,6 +258,47 @@ export async function retryUnsyncedSessions() {
   for (const session of unsynced) {
     // 재시도라 최초 지연시간(totalMs/youtubeMs)은 더 이상 의미가 없어 보내지 않는다.
     await syncSessionToServer(session);
+  }
+}
+
+// content.js가 영상 한 편을 볼 때마다 즉시 시도하는 /api/video-events 전송은 실패하면
+// 그 자리에서 조용히 버려졌다(연구 무결성 점검: fire-and-forget이라 재시도가 전혀 없었음).
+// 1분마다 도는 알람에서 checkSessionTimeout·retryUnsyncedSessions와 함께 호출돼,
+// 아직 sent:true가 안 된 영상 이벤트를 찾아 다시 보낸다.
+export async function retryUnsentVideoEvents() {
+  const onboarding = await getOnboarding();
+  if (!onboarding?.anonymousId) return;
+
+  const events = await getUnsentVideoEvents();
+  for (const event of events) {
+    const ok = await postVideoEventToServer(onboarding.anonymousId, event);
+    if (ok) await markVideoEventSent(event);
+  }
+}
+
+async function postVideoEventToServer(anonymousId, event) {
+  if (!SERVER_URL || SERVER_URL.startsWith("YOUR_")) return false;
+
+  const cleanUrl = SERVER_URL.replace(/\/$/, "");
+  try {
+    const response = await fetch(`${cleanUrl}/api/video-events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        anonymousId,
+        videoId: event.videoId,
+        title: event.title ?? null,
+        watchedAt: event.watchedAt,
+        sessionId: event.sessionId,
+      }),
+    });
+    if (!response.ok) {
+      console.warn("[background] 영상 이벤트 재전송 실패:", response.status);
+    }
+    return response.ok;
+  } catch (error) {
+    console.warn("[background] 영상 이벤트 재전송 오류:", error);
+    return false;
   }
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -88,7 +88,9 @@ function recordVideo(videoId, title) {
         return;
       }
 
-      const videoKey = `video__${session.sessionId}__${crypto.randomUUID()}`;
+      // uuid를 videoKey와 eventId 양쪽에 재사용한다.
+      const eventId = crypto.randomUUID();
+      const videoKey = `video__${session.sessionId}__${eventId}`;
       // sent:false로 시작
       // 아래 전송이 실패하면 이 값이 그대로 남아, background.js의
       // 1분 재시도 큐(retryUnsentVideoEvents)가 나중에 다시 보낼 대상을 찾아낼 수 있다.
@@ -101,7 +103,7 @@ function recordVideo(videoId, title) {
           videoCount: (session.videoCount ?? 0) + 1,
         },
         lastRecordedVideo: { videoId, sessionId: session.sessionId },
-        [videoKey]: { videoId, title, watchedAt: now, sent: false },
+        [videoKey]: { videoId, title, watchedAt: now, sent: false, eventId },
       });
       console.log("[content] recorded:", { videoId, title });
 
@@ -117,12 +119,19 @@ function recordVideo(videoId, title) {
             title: title ?? null,
             watchedAt: now,
             sessionId: session.sessionId,
+            eventId,
           }),
         })
           .then((response) => {
             if (response.ok && chrome.runtime?.id) {
               chrome.storage.local.set({
-                [videoKey]: { videoId, title, watchedAt: now, sent: true },
+                [videoKey]: {
+                  videoId,
+                  title,
+                  watchedAt: now,
+                  sent: true,
+                  eventId,
+                },
               });
             }
           })

--- a/extension/content.js
+++ b/extension/content.js
@@ -89,6 +89,9 @@ function recordVideo(videoId, title) {
       }
 
       const videoKey = `video__${session.sessionId}__${crypto.randomUUID()}`;
+      // sent:false로 시작
+      // 아래 전송이 실패하면 이 값이 그대로 남아, background.js의
+      // 1분 재시도 큐(retryUnsentVideoEvents)가 나중에 다시 보낼 대상을 찾아낼 수 있다.
       await chrome.storage.local.set({
         lastWatchedAt: now,
         currentSession: {
@@ -98,11 +101,12 @@ function recordVideo(videoId, title) {
           videoCount: (session.videoCount ?? 0) + 1,
         },
         lastRecordedVideo: { videoId, sessionId: session.sessionId },
-        [videoKey]: { videoId, title, watchedAt: now },
+        [videoKey]: { videoId, title, watchedAt: now, sent: false },
       });
       console.log("[content] recorded:", { videoId, title });
 
       // 서버에 즉시 전송
+      // 성공(200)했을 때만 sent:true로 갱신한다. 실패해도 여기서 다시 시도하지 않는다.
       if (anonymousId && serverUrl && !serverUrl.startsWith("YOUR_")) {
         fetch(`${serverUrl.replace(/\/$/, "")}/api/video-events`, {
           method: "POST",
@@ -114,7 +118,15 @@ function recordVideo(videoId, title) {
             watchedAt: now,
             sessionId: session.sessionId,
           }),
-        }).catch(() => {});
+        })
+          .then((response) => {
+            if (response.ok && chrome.runtime?.id) {
+              chrome.storage.local.set({
+                [videoKey]: { videoId, title, watchedAt: now, sent: true },
+              });
+            }
+          })
+          .catch(() => {});
       }
     } catch (error) {
       // 컨텍스트가 호출 도중 무효화된 경우 등 — 조용히 삼키지 않고 원인을 남긴다.

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -68,10 +68,14 @@ function buildClosedSession(sessionId, videos, startTime, endTime) {
     sessionId,
     startTime: startTime ?? deduped[0].watchedAt,
     endTime,
-    videos: deduped.map(({ videoId, title, watchedAt }) => ({
+    // sent(서버 /api/video-events 전송 성공 여부)를 그대로 들고 간다.
+    // 세션이 끝나면 video__ 키 자체가 사라지므로, 아직 전송 못 한 영상의 재시도 대상 여부를
+    // getUnsentVideoEvents()가 sessions[].videos에서도 판단할 수 있어야 한다.
+    videos: deduped.map(({ videoId, title, watchedAt, sent }) => ({
       videoId,
       title,
       watchedAt,
+      sent,
     })),
   };
 }
@@ -145,6 +149,72 @@ async function _endSession() {
 export async function getLastWatchedAt() {
   const { lastWatchedAt } = await chrome.storage.local.get("lastWatchedAt");
   return lastWatchedAt ?? null;
+}
+
+// content.js의 즉시 전송(/api/video-events)이 실패해도 조용히 버리지 않도록, 세션 종료
+// 전(video__ 키)이든 후(sessions[].videos)든 아직 sent:true가 안 된 영상을 전부 모은다.
+// background.js의 재시도 큐(연구 무결성 점검: 서버 장애 대비 로컬 큐잉/재시도)가 사용한다.
+export async function getUnsentVideoEvents() {
+  const all = await chrome.storage.local.get(null);
+
+  const fromLive = Object.entries(all)
+    .filter(([key, v]) => key.startsWith("video__") && v?.sent !== true)
+    .map(([key, v]) => ({
+      location: "live",
+      key,
+      sessionId: sessionIdOf(key),
+      videoId: v.videoId,
+      title: v.title,
+      watchedAt: v.watchedAt,
+    }));
+
+  const fromSessions = (all.sessions ?? []).flatMap((session) =>
+    (session.videos ?? [])
+      .filter((v) => v.sent !== true)
+      .map((v) => ({
+        location: "session",
+        sessionId: session.sessionId,
+        videoId: v.videoId,
+        title: v.title,
+        watchedAt: v.watchedAt,
+      })),
+  );
+
+  return [...fromLive, ...fromSessions];
+}
+
+// getUnsentVideoEvents()가 돌려준 항목 하나를 서버 전송 성공 후 sent:true로 표시한다.
+// sessions 배열 갱신은 saveAnalysis/endSession과 마찬가지로 queue를 거쳐 직렬화한다.
+export function markVideoEventSent(event) {
+  queue = queue.then(() => _markVideoEventSent(event));
+  return queue;
+}
+
+async function _markVideoEventSent(event) {
+  if (event.location === "live") {
+    const { [event.key]: existing } = await chrome.storage.local.get(event.key);
+    // 이미 세션 종료로 sessions[]로 옮겨졌거나(키 삭제) 다른 재시도가 먼저 표시한 경우.
+    if (!existing) return;
+    await chrome.storage.local.set({
+      [event.key]: { ...existing, sent: true },
+    });
+    return;
+  }
+
+  const { sessions } = await chrome.storage.local.get("sessions");
+  if (!sessions) return;
+  const updatedSessions = sessions.map((session) => {
+    if (session.sessionId !== event.sessionId) return session;
+    return {
+      ...session,
+      videos: (session.videos ?? []).map((v) =>
+        v.videoId === event.videoId && v.watchedAt === event.watchedAt
+          ? { ...v, sent: true }
+          : v,
+      ),
+    };
+  });
+  await chrome.storage.local.set({ sessions: updatedSessions });
 }
 
 // --- 온보딩 ---

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -153,14 +153,12 @@ export async function getLastWatchedAt() {
   return lastWatchedAt ?? null;
 }
 
-// content.js의 즉시 전송(/api/video-events)이 실패해도 조용히 버리지 않도록, 세션 종료
-// 전(video__ 키)이든 후(sessions[].videos)든 아직 sent:true가 안 된 영상을 전부 모은다.
-// background.js의 재시도 큐(연구 무결성 점검: 서버 장애 대비 로컬 큐잉/재시도)가 사용한다.
+// content.js의 즉시 전송(/api/video-events)이 실패해도 조용히 버리지 않도록, sent:false로 명시된 영상만 모은다.
 export async function getUnsentVideoEvents() {
   const all = await chrome.storage.local.get(null);
 
   const fromLive = Object.entries(all)
-    .filter(([key, v]) => key.startsWith("video__") && v?.sent !== true)
+    .filter(([key, v]) => key.startsWith("video__") && v?.sent === false)
     .map(([key, v]) => ({
       location: "live",
       key,
@@ -168,14 +166,12 @@ export async function getUnsentVideoEvents() {
       videoId: v.videoId,
       title: v.title,
       watchedAt: v.watchedAt,
-      // 이 기능 이전에 기록된 항목엔 eventId가 없다(undefined) — 그대로 서버에 보내면
-      // 멱등 dedup만 생략되고 나머지 동작은 그대로다(하위호환).
       eventId: v.eventId,
     }));
 
   const fromSessions = (all.sessions ?? []).flatMap((session) =>
     (session.videos ?? [])
-      .filter((v) => v.sent !== true)
+      .filter((v) => v.sent === false)
       .map((v) => ({
         location: "session",
         sessionId: session.sessionId,

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -68,14 +68,16 @@ function buildClosedSession(sessionId, videos, startTime, endTime) {
     sessionId,
     startTime: startTime ?? deduped[0].watchedAt,
     endTime,
-    // sent(서버 /api/video-events 전송 성공 여부)를 그대로 들고 간다.
-    // 세션이 끝나면 video__ 키 자체가 사라지므로, 아직 전송 못 한 영상의 재시도 대상 여부를
-    // getUnsentVideoEvents()가 sessions[].videos에서도 판단할 수 있어야 한다.
-    videos: deduped.map(({ videoId, title, watchedAt, sent }) => ({
+    // sent(서버 /api/video-events 전송 성공 여부)와 eventId(서버 멱등 키)를 그대로
+    // 들고 간다. 세션이 끝나면 video__ 키 자체가 사라지므로, 아직 전송 못 한 영상의
+    // 재시도 대상 여부를 getUnsentVideoEvents()가 sessions[].videos에서도 판단할 수
+    // 있어야 하고, 재시도 시에도 같은 eventId를 다시 보내야 서버가 중복을 걸러낸다.
+    videos: deduped.map(({ videoId, title, watchedAt, sent, eventId }) => ({
       videoId,
       title,
       watchedAt,
       sent,
+      eventId,
     })),
   };
 }
@@ -166,6 +168,9 @@ export async function getUnsentVideoEvents() {
       videoId: v.videoId,
       title: v.title,
       watchedAt: v.watchedAt,
+      // 이 기능 이전에 기록된 항목엔 eventId가 없다(undefined) — 그대로 서버에 보내면
+      // 멱등 dedup만 생략되고 나머지 동작은 그대로다(하위호환).
+      eventId: v.eventId,
     }));
 
   const fromSessions = (all.sessions ?? []).flatMap((session) =>
@@ -177,6 +182,7 @@ export async function getUnsentVideoEvents() {
         videoId: v.videoId,
         title: v.title,
         watchedAt: v.watchedAt,
+        eventId: v.eventId,
       })),
   );
 

--- a/extension/test/background.e2e.test.js
+++ b/extension/test/background.e2e.test.js
@@ -461,3 +461,154 @@ describe("retryUnsyncedSessions — 서버 장애 대비 로컬 재시도 큐", 
     expect(calls.sessions).toHaveLength(0);
   });
 });
+
+// 연구 무결성 점검: content.js의 /api/video-events 즉시 전송은 fire-and-forget이라
+// 실패해도 그 자리에서 조용히 버려졌다. retryUnsentVideoEvents(1분 알람에서
+// checkSessionTimeout·retryUnsyncedSessions와 함께 호출됨)가 sent:true가 안 된 영상
+// 이벤트를 세션 종료 전(video__ 키)·후(sessions[].videos) 가리지 않고 찾아 재전송한다.
+describe("retryUnsentVideoEvents — 영상 이벤트 서버 장애 대비 재시도 큐", () => {
+  it("세션 종료 전(video__ 키)에 남은 미전송 영상을 재전송하고 sent:true로 표시한다", async () => {
+    global.chrome = createChromeMock();
+    const calls = { videoEvents: [] };
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const href = String(url);
+      if (href.endsWith("/api/video-events")) {
+        calls.videoEvents.push(JSON.parse(options.body));
+        return { ok: true, json: async () => ({ success: true }) };
+      }
+      throw new Error(`예상치 못한 fetch 호출: ${href}`);
+    });
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      currentSession: { sessionId: "s1", startTime: "2026-01-10T11:00:00Z" },
+      "video__s1__uuid1": {
+        videoId: "v1",
+        title: "노래 모음",
+        watchedAt: "2026-01-10T11:00:00Z",
+        sent: false, // 최초 즉시 전송(content.js)이 실패해 남은 상태
+      },
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    await mod.retryUnsentVideoEvents();
+
+    expect(calls.videoEvents).toHaveLength(1);
+    expect(calls.videoEvents[0]).toMatchObject({
+      anonymousId: "a1",
+      videoId: "v1",
+      sessionId: "s1",
+    });
+
+    const all = await global.chrome.storage.local.get(null);
+    expect(all["video__s1__uuid1"].sent).toBe(true);
+  });
+
+  it("세션 종료 후(sessions[].videos)에 남은 미전송 영상도 재전송하고 sent:true로 표시한다", async () => {
+    global.chrome = createChromeMock();
+    const calls = { videoEvents: [] };
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const href = String(url);
+      if (href.endsWith("/api/video-events")) {
+        calls.videoEvents.push(JSON.parse(options.body));
+        return { ok: true, json: async () => ({ success: true }) };
+      }
+      throw new Error(`예상치 못한 fetch 호출: ${href}`);
+    });
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      sessions: [
+        {
+          sessionId: "s1",
+          startTime: "2026-01-10T11:00:00Z",
+          endTime: "2026-01-10T11:20:00Z",
+          videos: [
+            {
+              videoId: "v1",
+              title: "노래 모음",
+              watchedAt: "2026-01-10T11:00:00Z",
+              sent: true, // 이미 성공 — 건드리면 안 됨
+            },
+            {
+              videoId: "v2",
+              title: "게임 하이라이트",
+              watchedAt: "2026-01-10T11:10:00Z",
+              sent: false, // 세션이 끝날 때까지 전송이 안 됐던 영상
+            },
+          ],
+        },
+      ],
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    await mod.retryUnsentVideoEvents();
+
+    // 이미 sent:true인 v1은 다시 보내지 않는다.
+    expect(calls.videoEvents).toHaveLength(1);
+    expect(calls.videoEvents[0]).toMatchObject({
+      anonymousId: "a1",
+      videoId: "v2",
+      sessionId: "s1",
+    });
+
+    const { sessions } = await global.chrome.storage.local.get("sessions");
+    const videos = sessions[0].videos;
+    expect(videos.find((v) => v.videoId === "v1").sent).toBe(true);
+    expect(videos.find((v) => v.videoId === "v2").sent).toBe(true);
+  });
+
+  it("재전송도 실패하면 sent:false로 남겨 다음 알람 틱에서 다시 시도할 수 있게 한다", async () => {
+    global.chrome = createChromeMock();
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("network down"));
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      "video__s1__uuid1": {
+        videoId: "v1",
+        title: "노래 모음",
+        watchedAt: "2026-01-10T11:00:00Z",
+        sent: false,
+      },
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    await mod.retryUnsentVideoEvents();
+
+    const all = await global.chrome.storage.local.get(null);
+    expect(all["video__s1__uuid1"].sent).toBe(false);
+  });
+
+  it("anonymousId가 없으면(온보딩 전) 아무것도 시도하지 않는다", async () => {
+    global.chrome = createChromeMock();
+    const calls = [];
+    global.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      return { ok: true, json: async () => ({ success: true }) };
+    });
+
+    await global.chrome.storage.local.set({
+      "video__s1__uuid1": {
+        videoId: "v1",
+        title: "노래 모음",
+        watchedAt: "2026-01-10T11:00:00Z",
+        sent: false,
+      },
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    await mod.retryUnsentVideoEvents();
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/extension/test/background.e2e.test.js
+++ b/extension/test/background.e2e.test.js
@@ -686,4 +686,41 @@ describe("retryUnsentVideoEvents — 영상 이벤트 서버 장애 대비 재�
 
     expect(calls).toHaveLength(0);
   });
+
+  it("sent 필드 자체가 없는 레거시 영상은 재전송하지 않는다(확장 업데이트 직후 대량 중복 방지)", async () => {
+    global.chrome = createChromeMock();
+    const calls = [];
+    global.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      return { ok: true, json: async () => ({ success: true }) };
+    });
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      // 이 재시도 큐가 생기기 전(구버전 content.js)에 기록된 영상 — sent 필드가 없다.
+      // 대부분 이미 서버 전송에 성공한 상태라, 이걸 재전송하면 eventId도 없어
+      // video_events에 영구 중복 행이 쌓인다.
+      "video__s1__legacy": {
+        videoId: "v1",
+        title: "노래 모음",
+        watchedAt: "2026-01-10T11:00:00Z",
+      },
+      sessions: [
+        {
+          sessionId: "s2",
+          videos: [
+            { videoId: "v2", title: "게임", watchedAt: "2026-01-10T12:00:00Z" },
+          ],
+        },
+      ],
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    await mod.retryUnsentVideoEvents();
+
+    expect(calls).toHaveLength(0);
+  });
 });

--- a/extension/test/background.e2e.test.js
+++ b/extension/test/background.e2e.test.js
@@ -270,10 +270,194 @@ describe("analyzeSession — 시청 감지 이후 전체 파이프라인 E2E", (
     const saved = sessions.find((s) => s.sessionId === "s1");
     expect(saved.categoryDistribution).toBeDefined();
     expect(saved.review).toBeUndefined();
+    // 재시도 큐(retryUnsyncedSessions)가 이 세션을 찾아낼 수 있어야 하므로 false로
+    // 명시돼 있어야 한다(필드 자체가 없는 것과는 구분).
+    expect(saved.syncedToServer).toBe(false);
 
     // 알림 대상(EXP, 베이스라인 아님)이라도 서버 전송이 실패해 오늘 리뷰를 받지 못했다면
     // 알림을 띄우지 않는다 — 그렇지 않으면 "피드백이 업데이트됐어요" 알림만 뜨고
     // 팝업엔 실제 리뷰 없이 "생성 중" 상태만 보이는 불일치가 생긴다.
     expect(global.chrome.notifications.create).not.toHaveBeenCalled();
+  });
+});
+
+// 서버 장애 대비 로컬 큐잉/재시도 로직 (데이터 유실 방지).
+// analyzeSession의 최초 전송이 실패해도 세션은 syncedToServer:false로 로컬에 남고,
+// retryUnsyncedSessions(1분 알람에서 checkSessionTimeout과 함께 호출됨)가 이를 찾아 재전송
+describe("retryUnsyncedSessions — 서버 장애 대비 로컬 재시도 큐", () => {
+  it("최초 서버 전송이 실패해도, 재시도에서 성공하면 리뷰 반영과 알림까지 완료된다", async () => {
+    global.chrome = createChromeMock();
+    const calls = { sessions: [] };
+    let sessionAttempt = 0;
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const href = String(url);
+      if (href.includes("googleapis.com/youtube/v3/videos")) {
+        const idsParam = new URL(href).searchParams.get("id");
+        const ids = idsParam ? idsParam.split(",") : [];
+        return {
+          ok: true,
+          json: async () => ({
+            items: ids.map((id) => ({ id, snippet: { categoryId: "10" } })),
+          }),
+        };
+      }
+      if (href.endsWith("/api/sessions")) {
+        calls.sessions.push(JSON.parse(options.body));
+        sessionAttempt++;
+        if (sessionAttempt === 1) {
+          throw new TypeError("network down"); // 최초 시도: 오프라인
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              todayReview: {
+                reviewDate: "2026-01-10",
+                review: "오늘은 음악 영상 위주로 보셨네요.",
+                reviewTopic: "음악",
+                source: "llm",
+                promptVersion: "viewlens-today-mirror-v1.0",
+              },
+            },
+          }),
+        };
+      }
+      throw new Error(`예상치 못한 fetch 호출: ${href}`);
+    });
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      sessions: [
+        {
+          sessionId: "s1",
+          startTime: new Date(2026, 0, 10, 11, 50).toISOString(),
+          endTime: FIXED_NOW.toISOString(),
+          videos: [{ videoId: "v1", title: "노래 모음" }],
+        },
+      ],
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+
+    await mod.analyzeSession({
+      sessionId: "s1",
+      videos: [{ videoId: "v1", title: "노래 모음" }],
+    });
+
+    // 최초 시도는 오프라인으로 실패 — 아직 미동기화 상태, 알림도 없다.
+    let { sessions } = await global.chrome.storage.local.get("sessions");
+    let saved = sessions.find((s) => s.sessionId === "s1");
+    expect(saved.syncedToServer).toBe(false);
+    expect(saved.review).toBeUndefined();
+    expect(global.chrome.notifications.create).not.toHaveBeenCalled();
+
+    // 1분 알람 틱마다 도는 재시도 — 이번엔 서버가 정상 응답한다.
+    await mod.retryUnsyncedSessions();
+
+    ({ sessions } = await global.chrome.storage.local.get("sessions"));
+    saved = sessions.find((s) => s.sessionId === "s1");
+    expect(saved.syncedToServer).toBe(true);
+    expect(saved.review).toBe("오늘은 음악 영상 위주로 보셨네요.");
+
+    const { todayReviewsCache } =
+      await global.chrome.storage.local.get("todayReviewsCache");
+    expect(todayReviewsCache.reviews).toEqual([
+      expect.objectContaining({ reviewDate: "2026-01-10" }),
+    ]);
+
+    expect(global.chrome.notifications.create).toHaveBeenCalledTimes(1);
+    // 재시도는 유튜브 카테고리 조회를 다시 하지 않는다 — /api/sessions만 두 번 호출된다.
+    expect(calls.sessions).toHaveLength(2);
+  });
+
+  it("재시도 중 서버가 409(중복 세션)를 반환하면 재전송 없이 동기화 완료로 처리한다", async () => {
+    global.chrome = createChromeMock();
+    const calls = { sessions: [] };
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const href = String(url);
+      if (href.endsWith("/api/sessions")) {
+        calls.sessions.push(JSON.parse(options.body));
+        return { ok: false, status: 409, text: async () => "duplicate" };
+      }
+      throw new Error(`예상치 못한 fetch 호출: ${href}`);
+    });
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      sessions: [
+        {
+          sessionId: "s1",
+          startTime: new Date(2026, 0, 10, 11, 50).toISOString(),
+          endTime: FIXED_NOW.toISOString(),
+          videos: [{ videoId: "v1", title: "노래 모음" }],
+          categoryDistribution: { 음악: 1 },
+          entropy: 0,
+          videoCount: 1,
+          syncedToServer: false,
+        },
+      ],
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    await mod.retryUnsyncedSessions();
+
+    const { sessions } = await global.chrome.storage.local.get("sessions");
+    const saved = sessions.find((s) => s.sessionId === "s1");
+    // 서버엔 이미 반영돼 있던 것(중복 오류)이므로, 다시 보내지 않고 동기화 완료로 처리한다.
+    expect(saved.syncedToServer).toBe(true);
+    expect(saved.review).toBeUndefined();
+    expect(calls.sessions).toHaveLength(1);
+  });
+
+  it("이미 동기화됐거나(true) 이 기능 이전에 만들어져 필드 자체가 없는 세션은 건드리지 않는다", async () => {
+    global.chrome = createChromeMock();
+    const calls = { sessions: [] };
+    global.fetch = vi.fn(async (url) => {
+      calls.sessions.push(String(url));
+      return {
+        ok: true,
+        json: async () => ({ success: true, data: { todayReview: null } }),
+      };
+    });
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      sessions: [
+        {
+          sessionId: "s-already-synced",
+          categoryDistribution: { 음악: 1 },
+          entropy: 0,
+          videoCount: 1,
+          syncedToServer: true,
+        },
+        {
+          // syncedToServer 필드 자체가 없음 — 이 재시도 기능이 생기기 전에 이미
+          // 분석·전송됐던(혹은 실패했던) 레거시 세션. 일괄 재전송 대상이 아니다.
+          sessionId: "s-legacy",
+          categoryDistribution: { 음악: 1 },
+          entropy: 0,
+          videoCount: 1,
+        },
+        {
+          // 아직 분석 자체가 끝나지 않은 세션(categoryDistribution 없음).
+          sessionId: "s-not-analyzed-yet",
+        },
+      ],
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    await mod.retryUnsyncedSessions();
+
+    expect(calls.sessions).toHaveLength(0);
   });
 });

--- a/extension/test/background.e2e.test.js
+++ b/extension/test/background.e2e.test.js
@@ -460,6 +460,78 @@ describe("retryUnsyncedSessions — 서버 장애 대비 로컬 재시도 큐", 
 
     expect(calls.sessions).toHaveLength(0);
   });
+
+  // 알람 리스너는 retryUnsyncedSessions/retryUnsentVideoEvents/checkSessionTimeout을
+  // await 없이 나란히 호출한다 — 즉 같은 세션을 두 경로가 "동시에" 다시 시도할 수 있다
+  // (예: checkSessionTimeout이 막 끝낸 세션을, 같은 틱의 retryUnsyncedSessions가 곧바로
+  // 집는 경우). 이 테스트는 그 경합을 재현해, 서버의 409(중복 세션) 응답 덕분에 알림이
+  // 두 번 뜨거나 오늘 리뷰 캐시가 잘못 반영되지 않음을 확인한다.
+  it("같은 세션을 두 경로가 동시에 재시도해도(경합) 알림은 한 번만 뜬다", async () => {
+    global.chrome = createChromeMock();
+    const calls = { sessions: [] };
+    let sessionAttempt = 0;
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const href = String(url);
+      if (href.endsWith("/api/sessions")) {
+        calls.sessions.push(JSON.parse(options.body));
+        sessionAttempt++;
+        // 첫 요청이 서버에 실제로 먼저 도착해 저장을 마쳤다고 가정 — 두 번째는 UNIQUE
+        // 제약(sessionId)에 걸려 409를 받는다(실제 동시 요청에서 서버가 보이는 동작).
+        if (sessionAttempt === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              success: true,
+              data: {
+                todayReview: {
+                  reviewDate: "2026-01-10",
+                  review: "오늘은 음악 영상 위주로 보셨네요.",
+                  reviewTopic: "음악",
+                  source: "llm",
+                  promptVersion: "viewlens-today-mirror-v1.0",
+                },
+              },
+            }),
+          };
+        }
+        return { ok: false, status: 409, text: async () => "duplicate" };
+      }
+      throw new Error(`예상치 못한 fetch 호출: ${href}`);
+    });
+
+    await global.chrome.storage.local.set({
+      anonymousId: "a1",
+      group: "EXP",
+      installDate: new Date(2025, 0, 1).toISOString(),
+      sessions: [
+        {
+          sessionId: "s1",
+          startTime: new Date(2026, 0, 10, 11, 50).toISOString(),
+          endTime: FIXED_NOW.toISOString(),
+          videos: [{ videoId: "v1", title: "노래 모음" }],
+          categoryDistribution: { 음악: 1 },
+          entropy: 0,
+          videoCount: 1,
+          syncedToServer: false,
+        },
+      ],
+    });
+
+    vi.resetModules();
+    const mod = await import("../background.js");
+    // 알람 리스너와 동일하게 await 없이 나란히 호출해 실제 경합 타이밍을 재현한다.
+    await Promise.all([mod.retryUnsyncedSessions(), mod.retryUnsyncedSessions()]);
+
+    expect(calls.sessions).toHaveLength(2);
+    // 승자(200)든 패자(409)든 최종적으로 동기화 완료 상태로 수렴한다.
+    const { sessions } = await global.chrome.storage.local.get("sessions");
+    expect(sessions.find((s) => s.sessionId === "s1").syncedToServer).toBe(
+      true,
+    );
+    // 알림은 승자 쪽 한 번만 뜬다 — 패자는 "DUPLICATE"를 보고 즉시 반환하므로
+    // showFeedbackNotification을 다시 호출하지 않는다.
+    expect(global.chrome.notifications.create).toHaveBeenCalledTimes(1);
+  });
 });
 
 // 연구 무결성 점검: content.js의 /api/video-events 즉시 전송은 fire-and-forget이라
@@ -489,6 +561,7 @@ describe("retryUnsentVideoEvents — 영상 이벤트 서버 장애 대비 재�
         title: "노래 모음",
         watchedAt: "2026-01-10T11:00:00Z",
         sent: false, // 최초 즉시 전송(content.js)이 실패해 남은 상태
+        eventId: "uuid1", // content.js가 최초 시도 때 발급해둔 멱등 키
       },
     });
 
@@ -501,6 +574,8 @@ describe("retryUnsentVideoEvents — 영상 이벤트 서버 장애 대비 재�
       anonymousId: "a1",
       videoId: "v1",
       sessionId: "s1",
+      // 최초 시도와 같은 eventId를 재전송해야 서버가 OR IGNORE로 중복을 걸러낸다.
+      eventId: "uuid1",
     });
 
     const all = await global.chrome.storage.local.get(null);

--- a/extension/test/content.test.js
+++ b/extension/test/content.test.js
@@ -379,4 +379,25 @@ describe("content.js recordVideo — /api/video-events 전송 결과를 sent 플
     expect(videos).toHaveLength(1);
     expect(videos[0].sent).toBe(false);
   });
+
+  it("서버가 멱등 처리(OR IGNORE)할 수 있도록, 로컬에 저장한 eventId와 서버로 보낸 eventId가 같다", async () => {
+    const storage = createSharedStorage({
+      currentSession: { sessionId: "s1", startTime: "t0" },
+      anonymousId: "a1",
+      serverUrl: "http://localhost:3000",
+    });
+    let sentBody = null;
+    const recordVideo = makeTabWithFetch(storage, (_url, options) => {
+      sentBody = JSON.parse(options.body);
+      return Promise.resolve({ ok: true });
+    });
+
+    await recordVideo("v1", "영상1");
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const videos = collectVideos(storage.dump(), "s1");
+    expect(videos[0].eventId).toEqual(expect.any(String));
+    expect(sentBody.eventId).toBe(videos[0].eventId);
+  });
 });

--- a/extension/test/content.test.js
+++ b/extension/test/content.test.js
@@ -303,3 +303,80 @@ describe("content.js recordVideo — 다중 탭 경합(연구 무결성 점검 �
     expect(storage.dump().currentSession.videoCount).toBe(1);
   });
 });
+
+// 연구 무결성 점검: /api/video-events 즉시 전송이 fire-and-forget이라 실패해도 조용히
+// 버려지던 문제. 이제 성공 여부를 sent 플래그로 남겨, background.js의 재시도 큐
+// (retryUnsentVideoEvents)가 실패분을 찾아낼 수 있게 한다.
+describe("content.js recordVideo — /api/video-events 전송 결과를 sent 플래그로 남긴다", () => {
+  let recordVideoFactory;
+
+  beforeAll(() => {
+    recordVideoFactory = loadRecordVideoFactory();
+  });
+
+  function makeTabWithFetch(sharedStorage, fetchMock) {
+    const chromeMock = {
+      runtime: { id: "fake-extension-id" },
+      storage: { local: sharedStorage },
+    };
+    const consoleMock = { log: () => {}, warn: () => {} };
+    return recordVideoFactory(chromeMock, fetchMock, consoleMock);
+  }
+
+  it("서버가 200을 반환하면 해당 영상 키를 sent:true로 갱신한다", async () => {
+    const storage = createSharedStorage({
+      currentSession: { sessionId: "s1", startTime: "t0" },
+      anonymousId: "a1",
+      serverUrl: "http://localhost:3000",
+    });
+    const recordVideo = makeTabWithFetch(storage, () =>
+      Promise.resolve({ ok: true }),
+    );
+
+    await recordVideo("v1", "영상1");
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const videos = collectVideos(storage.dump(), "s1");
+    expect(videos).toHaveLength(1);
+    expect(videos[0].sent).toBe(true);
+  });
+
+  it("서버가 오류 응답을 반환하면 sent:false로 남아 재시도 큐의 대상이 된다", async () => {
+    const storage = createSharedStorage({
+      currentSession: { sessionId: "s1", startTime: "t0" },
+      anonymousId: "a1",
+      serverUrl: "http://localhost:3000",
+    });
+    const recordVideo = makeTabWithFetch(storage, () =>
+      Promise.resolve({ ok: false, status: 500 }),
+    );
+
+    await recordVideo("v1", "영상1");
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const videos = collectVideos(storage.dump(), "s1");
+    expect(videos).toHaveLength(1);
+    expect(videos[0].sent).toBe(false);
+  });
+
+  it("네트워크 오류로 fetch 자체가 실패해도 예외 없이 sent:false로 남는다", async () => {
+    const storage = createSharedStorage({
+      currentSession: { sessionId: "s1", startTime: "t0" },
+      anonymousId: "a1",
+      serverUrl: "http://localhost:3000",
+    });
+    const recordVideo = makeTabWithFetch(storage, () =>
+      Promise.reject(new TypeError("network down")),
+    );
+
+    await recordVideo("v1", "영상1");
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const videos = collectVideos(storage.dump(), "s1");
+    expect(videos).toHaveLength(1);
+    expect(videos[0].sent).toBe(false);
+  });
+});

--- a/extension/test/storage.test.js
+++ b/extension/test/storage.test.js
@@ -329,13 +329,14 @@ describe("getOnboarding", () => {
 // 연구 무결성 점검: content.js의 /api/video-events 즉시 전송이 실패하면 sent:false로
 // 남는다. background.js의 재시도 큐가 이 두 함수로 그 상태를 읽고 갱신한다.
 describe("getUnsentVideoEvents / markVideoEventSent", () => {
-  it("세션 종료 전(video__ 키)의 미전송 영상을 찾아낸다", async () => {
+  it("세션 종료 전(video__ 키)의 미전송 영상을 찾아낸다(eventId 포함)", async () => {
     await global.chrome.storage.local.set({
       "video__s1__v1-1": {
         videoId: "v1",
         title: "제목-v1",
         watchedAt: "2026-01-01T00:00:00Z",
         sent: false,
+        eventId: "v1-1",
       },
     });
 
@@ -345,6 +346,8 @@ describe("getUnsentVideoEvents / markVideoEventSent", () => {
       location: "live",
       sessionId: "s1",
       videoId: "v1",
+      // 재전송 시 서버의 OR IGNORE 멱등 처리를 타려면 같은 eventId를 그대로 들고 있어야 한다.
+      eventId: "v1-1",
     });
   });
 
@@ -423,7 +426,7 @@ describe("getUnsentVideoEvents / markVideoEventSent", () => {
   });
 });
 
-describe("endSession — sent 플래그를 세션 종료 이후에도 보존한다", () => {
+describe("endSession — sent·eventId를 세션 종료 이후에도 보존한다", () => {
   it("전송 성공/실패 여부(sent)를 videos 배열로 그대로 옮긴다", async () => {
     await global.chrome.storage.local.set({
       currentSession: { sessionId: "s1", startTime: "2026-01-01T00:00:00Z" },
@@ -448,5 +451,24 @@ describe("endSession — sent 플래그를 세션 종료 이후에도 보존한�
     const videos = sessions[0].videos;
     expect(videos.find((v) => v.videoId === "v1").sent).toBe(true);
     expect(videos.find((v) => v.videoId === "v2").sent).toBe(false);
+  });
+
+  it("eventId(서버 멱등 키)도 그대로 옮긴다 — 세션 종료 후 재시도해도 같은 eventId로 나가야 한다", async () => {
+    await global.chrome.storage.local.set({
+      currentSession: { sessionId: "s1", startTime: "2026-01-01T00:00:00Z" },
+    });
+    await global.chrome.storage.local.set({
+      video__s1__v1: {
+        videoId: "v1",
+        title: "제목-v1",
+        watchedAt: "2026-01-01T00:00:00Z",
+        sent: false,
+        eventId: "evt-v1",
+      },
+    });
+    await endSession();
+
+    const sessions = await getAllSessions();
+    expect(sessions[0].videos[0].eventId).toBe("evt-v1");
   });
 });

--- a/extension/test/storage.test.js
+++ b/extension/test/storage.test.js
@@ -364,6 +364,22 @@ describe("getUnsentVideoEvents / markVideoEventSent", () => {
     expect(await getUnsentVideoEvents()).toEqual([]);
   });
 
+  it("sent 필드 자체가 없는(이 기능 이전에 기록된) 레거시 영상(video__ 키)은 재전송 대상에서 제외한다", async () => {
+    // 구버전 content.js는 sent를 아예 기록하지 않았고, fire-and-forget이라 대부분
+    // 이미 서버 전송에 성공한 상태다. !== true로 판정하면 이런 레거시 항목까지
+    // "미전송"으로 오판해 eventId도 없이 재전송 → video_events에 영구 중복이 쌓인다.
+    await global.chrome.storage.local.set({
+      "video__s1__legacy": {
+        videoId: "v1",
+        title: "제목-v1",
+        watchedAt: "2026-01-01T00:00:00Z",
+        // sent 필드 없음
+      },
+    });
+
+    expect(await getUnsentVideoEvents()).toEqual([]);
+  });
+
   it("세션 종료 후(sessions[].videos)의 미전송 영상도 찾아낸다", async () => {
     await global.chrome.storage.local.set({
       sessions: [
@@ -372,6 +388,8 @@ describe("getUnsentVideoEvents / markVideoEventSent", () => {
           videos: [
             { videoId: "v1", title: "제목-v1", watchedAt: "t1", sent: true },
             { videoId: "v2", title: "제목-v2", watchedAt: "t2", sent: false },
+            // sent 필드 자체가 없는 레거시 영상 — 재전송 대상이 아니다.
+            { videoId: "v3", title: "제목-v3", watchedAt: "t3" },
           ],
         },
       ],

--- a/extension/test/storage.test.js
+++ b/extension/test/storage.test.js
@@ -5,6 +5,8 @@ import {
   getAllSessions,
   getOnboarding,
   saveAnalysis,
+  getUnsentVideoEvents,
+  markVideoEventSent,
 } from "../storage.js";
 
 // 프로젝트에 chrome.storage.local 목이 없어 이번에 처음 만든다.
@@ -321,5 +323,130 @@ describe("getOnboarding", () => {
       group: "EXP",
       installDate: "2026-01-01T00:00:00Z",
     });
+  });
+});
+
+// 연구 무결성 점검: content.js의 /api/video-events 즉시 전송이 실패하면 sent:false로
+// 남는다. background.js의 재시도 큐가 이 두 함수로 그 상태를 읽고 갱신한다.
+describe("getUnsentVideoEvents / markVideoEventSent", () => {
+  it("세션 종료 전(video__ 키)의 미전송 영상을 찾아낸다", async () => {
+    await global.chrome.storage.local.set({
+      "video__s1__v1-1": {
+        videoId: "v1",
+        title: "제목-v1",
+        watchedAt: "2026-01-01T00:00:00Z",
+        sent: false,
+      },
+    });
+
+    const events = await getUnsentVideoEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      location: "live",
+      sessionId: "s1",
+      videoId: "v1",
+    });
+  });
+
+  it("sent:true인 영상(세션 종료 전)은 대상에서 제외한다", async () => {
+    await global.chrome.storage.local.set({
+      "video__s1__v1-1": {
+        videoId: "v1",
+        title: "제목-v1",
+        watchedAt: "2026-01-01T00:00:00Z",
+        sent: true,
+      },
+    });
+
+    expect(await getUnsentVideoEvents()).toEqual([]);
+  });
+
+  it("세션 종료 후(sessions[].videos)의 미전송 영상도 찾아낸다", async () => {
+    await global.chrome.storage.local.set({
+      sessions: [
+        {
+          sessionId: "s1",
+          videos: [
+            { videoId: "v1", title: "제목-v1", watchedAt: "t1", sent: true },
+            { videoId: "v2", title: "제목-v2", watchedAt: "t2", sent: false },
+          ],
+        },
+      ],
+    });
+
+    const events = await getUnsentVideoEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      location: "session",
+      sessionId: "s1",
+      videoId: "v2",
+    });
+  });
+
+  it("markVideoEventSent(live)는 video__ 키를 sent:true로 갱신한다", async () => {
+    await global.chrome.storage.local.set({
+      "video__s1__v1-1": {
+        videoId: "v1",
+        title: "제목-v1",
+        watchedAt: "2026-01-01T00:00:00Z",
+        sent: false,
+      },
+    });
+    const [event] = await getUnsentVideoEvents();
+
+    await markVideoEventSent(event);
+
+    const all = await global.chrome.storage.local.get(null);
+    expect(all["video__s1__v1-1"].sent).toBe(true);
+  });
+
+  it("markVideoEventSent(session)는 sessions[].videos 안의 해당 영상만 sent:true로 갱신한다", async () => {
+    await global.chrome.storage.local.set({
+      sessions: [
+        {
+          sessionId: "s1",
+          videos: [
+            { videoId: "v1", title: "제목-v1", watchedAt: "t1", sent: true },
+            { videoId: "v2", title: "제목-v2", watchedAt: "t2", sent: false },
+          ],
+        },
+      ],
+    });
+    const [event] = await getUnsentVideoEvents();
+
+    await markVideoEventSent(event);
+
+    const { sessions } = await global.chrome.storage.local.get("sessions");
+    const videos = sessions[0].videos;
+    expect(videos.find((v) => v.videoId === "v1").sent).toBe(true);
+    expect(videos.find((v) => v.videoId === "v2").sent).toBe(true);
+  });
+});
+
+describe("endSession — sent 플래그를 세션 종료 이후에도 보존한다", () => {
+  it("전송 성공/실패 여부(sent)를 videos 배열로 그대로 옮긴다", async () => {
+    await global.chrome.storage.local.set({
+      currentSession: { sessionId: "s1", startTime: "2026-01-01T00:00:00Z" },
+    });
+    await global.chrome.storage.local.set({
+      video__s1__v1: {
+        videoId: "v1",
+        title: "제목-v1",
+        watchedAt: "2026-01-01T00:00:00Z",
+        sent: true,
+      },
+      video__s1__v2: {
+        videoId: "v2",
+        title: "제목-v2",
+        watchedAt: "2026-01-01T00:01:00Z",
+        sent: false,
+      },
+    });
+    await endSession();
+
+    const sessions = await getAllSessions();
+    const videos = sessions[0].videos;
+    expect(videos.find((v) => v.videoId === "v1").sent).toBe(true);
+    expect(videos.find((v) => v.videoId === "v2").sent).toBe(false);
   });
 });

--- a/server/db.js
+++ b/server/db.js
@@ -85,11 +85,12 @@ function initializeDB() {
 
     CREATE TABLE IF NOT EXISTS video_events (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      eventId     TEXT,     -- 영상 기록 1건당 1회 발급하는 멱등 키 (재전송 중복 방지). UNIQUE는 별도 인덱스로 아래에서 건다
       anonymousId TEXT    NOT NULL,
       videoId     TEXT    NOT NULL,
       title       TEXT,
       watchedAt   TEXT    NOT NULL,
-      -- 이 영상이 속한 세션의 sessions.sessionId 
+      -- 이 영상이 속한 세션의 sessions.sessionId
       sessionId   TEXT,
       createdAt   TEXT    DEFAULT (datetime('now'))
     );
@@ -190,6 +191,13 @@ function initializeDB() {
   addColumn("popup_events", "eventId", "TEXT");
   db.exec(
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_popup_events_eventId ON popup_events(eventId)",
+  );
+
+  // video_events.eventId
+  // 확장 프로그램의 재시도 큐 같은 영상 기록을 다시 보낼 수 있어 popup_events와 동일한 멱등 키 패턴을 적용한다.
+  addColumn("video_events", "eventId", "TEXT");
+  db.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_video_events_eventId ON video_events(eventId)",
   );
 }
 

--- a/server/routes/video-events-validate.js
+++ b/server/routes/video-events-validate.js
@@ -29,6 +29,19 @@ function validateVideoEvent(body) {
     return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "sessionId" };
   }
 
+  // 재시도 큐(background.js)가 같은 영상을 다시 보낼 때 서버가 OR IGNORE로 걸러낼 수
+  // 있게 하는 멱등 키 — sessionId와 마찬가지로 구버전 확장 하위호환으로 미전송(null)은
+  // 허용한다. 문자열이 아닌 값(boolean·object 등)을 그대로 better-sqlite3에 바인딩하면
+  // TypeError가 나 500으로 새므로 여기서 미리 걸러낸다.
+  const { eventId } = body;
+  if (
+    eventId !== undefined &&
+    eventId !== null &&
+    (typeof eventId !== "string" || eventId.trim() === "")
+  ) {
+    return { code: ERROR_CODES.INVALID_FIELD_VALUE, field: "eventId" };
+  }
+
   return null;
 }
 

--- a/server/routes/video-events.js
+++ b/server/routes/video-events.js
@@ -6,8 +6,8 @@ const { validateVideoEvent } = require("./video-events-validate");
 const router = express.Router();
 
 const insertEvent = db.prepare(`
-  INSERT INTO video_events (anonymousId, videoId, title, watchedAt, sessionId)
-  VALUES (@anonymousId, @videoId, @title, @watchedAt, @sessionId)
+  INSERT OR IGNORE INTO video_events (eventId, anonymousId, videoId, title, watchedAt, sessionId)
+  VALUES (@eventId, @anonymousId, @videoId, @title, @watchedAt, @sessionId)
 `);
 
 router.post("/", (req, res, next) => {
@@ -22,10 +22,12 @@ router.post("/", (req, res, next) => {
     );
   }
 
-  const { anonymousId, videoId, watchedAt, title, sessionId } = req.body;
+  const { anonymousId, videoId, watchedAt, title, sessionId, eventId } =
+    req.body;
 
   try {
     insertEvent.run({
+      eventId: eventId ?? null,
       anonymousId,
       videoId,
       title: title ?? null,

--- a/server/test/routes/video-events-validate.test.js
+++ b/server/test/routes/video-events-validate.test.js
@@ -117,6 +117,39 @@ describe("validateVideoEvent — sessionId (옵션 필드, 하위호환)", () =>
   });
 });
 
+describe("validateVideoEvent — eventId (옵션 필드, 멱등 키·하위호환)", () => {
+  it.each([undefined, null])("%s이면 통과한다(구버전 확장 하위호환)", (value) => {
+    expect(validateVideoEvent(basePayload({ eventId: value }))).toBeNull();
+  });
+
+  it("빈 문자열이면 거부한다", () => {
+    expect(validateVideoEvent(basePayload({ eventId: "" }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "eventId",
+    });
+  });
+
+  it("문자열이 아니면(boolean) 거부한다 — better-sqlite3에 그대로 바인딩하면 TypeError로 500이 난다", () => {
+    expect(validateVideoEvent(basePayload({ eventId: true }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "eventId",
+    });
+  });
+
+  it("문자열이 아니면(object) 거부한다", () => {
+    expect(validateVideoEvent(basePayload({ eventId: { x: 1 } }))).toEqual({
+      code: ERROR_CODES.INVALID_FIELD_VALUE,
+      field: "eventId",
+    });
+  });
+
+  it("유효한 문자열이면 통과한다", () => {
+    expect(
+      validateVideoEvent(basePayload({ eventId: "evt-abc" })),
+    ).toBeNull();
+  });
+});
+
 describe("validateVideoEvent — title (옵션, 검증 대상 아님)", () => {
   it("title이 없어도 통과한다", () => {
     const payload = basePayload();

--- a/server/test/routes/video-events.wiring.test.js
+++ b/server/test/routes/video-events.wiring.test.js
@@ -108,4 +108,33 @@ describe("실제 server/routes/video-events.js 라우터 배선", () => {
     );
     expect(res.status).toBe(404);
   });
+
+  it("같은 eventId로 재전송해도 한 행만 남는다(OR IGNORE 멱등성) — 확장의 재시도 큐가 이미 성공한 전송을 다시 보내는 상황", async () => {
+    await request(app)
+      .post("/api/video-events")
+      .send(basePayload({ eventId: "wiring-evt-1" }));
+    const res = await request(app)
+      .post("/api/video-events")
+      .send(basePayload({ eventId: "wiring-evt-1", title: "다른 제목" }));
+
+    expect(res.status).toBe(200);
+    const rows = db
+      .prepare("SELECT * FROM video_events WHERE eventId = ?")
+      .all("wiring-evt-1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe("테스트 영상"); // 재전송 값이 아니라 최초 값 유지
+  });
+
+  it("eventId 없는 구버전 요청은 dedup 없이 매번 새 행으로 저장된다", async () => {
+    const payload = basePayload();
+    delete payload.eventId;
+
+    await request(app).post("/api/video-events").send(payload);
+    await request(app).post("/api/video-events").send(payload);
+
+    const rows = db
+      .prepare("SELECT * FROM video_events WHERE anonymousId = ?")
+      .all("wiring-user");
+    expect(rows).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## 개요

연구 무결성 점검 중, 참여자 시청 데이터를 서버로 보내는 두 경로(세션 요약 전송, 영상 개별 이벤트 전송) 모두 실패 시 재시도 로직이 없는 걸 발견해 로컬 재시도 큐로 고쳤다. 오프라인·서버 오류 순간에 세션이 끝나거나 영상이 기록되면, 그 데이터가 참여자 로컬에는 남아도 서버 DB에는 영구히 누락될 수 있었다.

## 변경 사항

- `POST /api/sessions` 전송 실패 시 세션에 `syncedToServer:false`를 남기고, 기존 1분  알람(`retryUnsyncedSessions`)이 매분 미전송 세션을 다시 시도하도록 함
- `POST /api/video-events`(영상 한 편마다 즉시 전송, 기존엔 fire-and-forget으로 실패를 그냥 버림) 도 동일하게 `sent:false` 플래그 + 재시도 큐(`retryUnsentVideoEvents`) 적용
  - 세션 종료 전(`video__` 키)·종료 후(`sessions[].videos`) 어느 시점에 실패했든 재시도 대상에서 빠지지 않도록 `storage.js`에 `getUnsentVideoEvents`/`markVideoEventSent` 추가
- `video_events` 테이블에 `eventId` 멱등 키(`INSERT OR IGNORE` + 유니크 인덱스) 추가  
  - 기존 `popup_events`와 동일한 패턴. 응답만 못 받고 서버엔 이미 저장된 전송을 재시도해도 중복 행이 남지 않음  
- 서버 응답이 409(중복 세션)면 재전송 없이 동기화 완료로 처리(무한 재전송 방지)  
- `eventId` 필드에 타입 검증 추가(`sessionId`와 동일한 패턴). 문자열이 아닌 값이 들어와 DB 바인딩에서 500으로 새던 지점을 400으로 정리  
- 두 재시도 함수가 `checkSessionTimeout`과 await 없이 나란히 도는 구조라, 같은 세션을 동시에 두 경로가 재시도해도(경합) 서버의 409/OR IGNORE 멱등 처리로 알림 중복·데이터 중복 없이 수렴함을 회귀 테스트로 확인  


## 테스트 확인

- [ ] 로컬에서 확장 프로그램 리로드 후 정상 동작 확인  
- [ ] 콘솔 에러 없음 
- [x] `npx vitest run 
- [x] 세션/영상 이벤트 재시도 큐, eventId 멱등성, 동시 재시도 경합 시나리오에 대한
      신규 단위·통합 테스트 추가 및 통과

 

## 참고 사항

- `video_events.eventId` 마이그레이션(`server/db.js`의 `addColumn` + `CREATE UNIQUE INDEX`)은 기존 `popup_events.eventId`와 동일한 패턴이라 운영 DB에도 안전하게 적용된다.
- 재시도에 횟수·기간 상한을 두지 않았다. 서버 URL이 영구히 잘못 설정된 극단적 경우에도 계속 재시도되지만, "데이터 유실 방지"가 목적이라 의도적으로 이렇게 뒀다.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 세션 및 영상 이벤트 전송 실패 시 자동 재시도 기능을 추가했습니다.
  * 전송 상태를 저장해 세션 종료 전후의 미전송 이벤트를 다시 보낼 수 있습니다.
  * 영상 이벤트에 고유 식별자를 적용해 재전송 중복 저장을 방지합니다.

* **버그 수정**
  * 네트워크·서버 오류 후에도 데이터 유실을 방지합니다.
  * 중복 세션 응답을 정상 동기화로 처리합니다.

* **테스트**
  * 전송 성공·실패·재시도·중복 처리 시나리오를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->